### PR TITLE
Added case sensitive/insensitive comparisons and find model by 'ids'

### DIFF
--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -73,6 +73,17 @@ extension Entity {
     }
 
     /**
+        Finds the entities with the given `ids`.
+    */
+    public static func find(_ ids: [NodeRepresentable]) throws -> [Self] {
+        guard let idKey = database?.driver.idKey else {
+            return []
+        }
+
+        return try Self.query().filter(idKey, .in, ids).all()
+    }
+
+    /**
         Creates a `Query` instance for this `Model`.
     */
     public static func query() throws -> Query<Self> {

--- a/Sources/Fluent/Query/Comparison.swift
+++ b/Sources/Fluent/Query/Comparison.swift
@@ -3,16 +3,92 @@ extension Filter {
         Describes the various operators for
         comparing values.
     */
-    public enum Comparison {
+    public enum Comparison : Equatable {
         case equals
         case greaterThan
         case lessThan
         case greaterThanOrEquals
         case lessThanOrEquals
         case notEquals
-        case hasSuffix
-        case hasPrefix
-        case contains
+        case hasSuffix(caseSensitive: Bool)
+        case hasPrefix(caseSensitive: Bool)
+        case contains(caseSensitive: Bool)
     }
     
+}
+
+public func ==(lhs: Filter.Comparison, rhs: Filter.Comparison) -> Bool {
+    switch lhs {
+    case .equals:
+        switch rhs {
+        case .equals:
+            return true
+        default:
+            return false
+        }
+
+    case .greaterThan:
+        switch rhs {
+        case .greaterThan:
+            return true
+        default:
+            return false
+        }
+
+    case .lessThan:
+        switch rhs {
+        case .lessThan:
+            return true
+        default:
+            return false
+        }
+
+    case .greaterThanOrEquals:
+        switch rhs {
+        case .greaterThanOrEquals:
+            return true
+        default:
+            return false
+        }
+
+    case .lessThanOrEquals:
+        switch rhs {
+        case .lessThanOrEquals:
+            return true
+        default:
+            return false
+        }
+
+    case .notEquals:
+        switch rhs {
+        case .notEquals:
+            return true
+        default:
+            return false
+        }
+
+    case .hasPrefix(let leftSensitivity):
+        switch rhs {
+        case .hasPrefix(let rightSensitivity):
+            return leftSensitivity == rightSensitivity
+        default:
+            return false
+        }
+
+    case .hasSuffix(let leftSensitivity):
+        switch rhs {
+        case .hasSuffix(let rightSensitivity):
+            return leftSensitivity == rightSensitivity
+        default:
+            return false
+        }
+
+    case .contains(let leftSensitivity):
+        switch rhs {
+        case .contains(let rightSensitivity):
+            return leftSensitivity == rightSensitivity
+        default:
+            return false
+        }
+    }
 }

--- a/Sources/Fluent/Query/Filter.swift
+++ b/Sources/Fluent/Query/Filter.swift
@@ -119,6 +119,6 @@ extension QueryRepresentable {
         _ field: String,
         contains value: NodeRepresentable
     ) throws -> Query<Self.T> {
-        return try filter(T.self, field, .contains, value)
+        return try filter(T.self, field, .contains(caseSensitive: false), value)
     }
 }

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -157,12 +157,15 @@ public class GeneralSQLSerializer: SQLSerializer {
                 processing of `value`
              */
             switch comparison {
-            case .hasPrefix:
+            case .hasPrefix(let caseSensitive):
                 values += sql(hasPrefix: value)
-            case .hasSuffix:
+                statement += sql(caseSensitive)
+            case .hasSuffix(let caseSensitive):
                 values += sql(hasSuffix: value)
-            case .contains:
+                statement += sql(caseSensitive)
+            case .contains(let caseSensitive):
                 values += sql(contains: value)
+                statement += sql(caseSensitive)
             default:
                 values += value
             }
@@ -224,6 +227,14 @@ public class GeneralSQLSerializer: SQLSerializer {
         }
 
         return .string("%\(string)%")
+    }
+
+    public func sql(_ caseSensitive: Bool) -> String {
+        if caseSensitive {
+            return "COLLATE utf8_bin"
+        } else {
+            return "COLLATE utf8_general_ci"
+        }
     }
 
     public func sql(_ scope: Filter.Scope) -> String {

--- a/Tests/Fluent/ModelFindTests.swift
+++ b/Tests/Fluent/ModelFindTests.swift
@@ -49,6 +49,30 @@ class ModelFindTests: XCTestCase {
                 } else if value.int == 500 {
                     throw Error.broken
                 }
+            } else 
+            if 
+                let filter = query.filters.first,
+                case .subset(let key, let scope, let values) = filter.method,
+                query.action == .fetch &&
+                    query.filters.count == 1 &&
+                    key == idKey &&
+                    scope == .in
+            {
+                if 
+                    values.count == 3 &&
+                    values[0] == 22 &&
+                    values[1] == 24 &&
+                    values[2] == 12
+                {
+                    return .array([
+                        .object([idKey: 12]),
+                        .object([idKey: 22]),
+                        .object([idKey: 24])
+                    ])
+                } else
+                {
+                    throw Error.broken
+                }
             }
             
             return .array([])
@@ -66,6 +90,7 @@ class ModelFindTests: XCTestCase {
     static let allTests = [
         ("testFindFailing", testFindFailing),
         ("testFindSucceeding", testFindSucceeding),
+        ("testFindMultipleSucceeding", testFindMultipleSucceeding),
         ("testFindErroring", testFindErroring),
     ]
 
@@ -89,6 +114,18 @@ class ModelFindTests: XCTestCase {
         do {
             let result = try DummyModel.find(42)
             XCTAssert(result?.id?.int == 42, "Result should have matching id")
+        } catch {
+            XCTFail("Find should not have failed")
+        }
+    }
+
+    func testFindMultipleSucceeding() {
+        do {
+            let result = try DummyModel.find([22,24,12])
+            XCTAssert(result.count == 3, "Count should have been 3")
+            XCTAssert(result[0].id?.int == 12, "[0] should have matching id")
+            XCTAssert(result[1].id?.int == 22, "[1] should have matching id")
+            XCTAssert(result[2].id?.int == 24, "[2] should have matching id")
         } catch {
             XCTFail("Find should not have failed")
         }

--- a/Tests/Fluent/QueryFiltersTests.swift
+++ b/Tests/Fluent/QueryFiltersTests.swift
@@ -88,7 +88,7 @@ class QueryFiltersTests: XCTestCase {
     }
 
     func testLikeQuery() throws {
-        let query = try DummyModel.query().filter("name", .hasPrefix, "Vap")
+        let query = try DummyModel.query().filter("name", .hasPrefix(caseSensitive: false), "Vap")
 
         guard
             let filter = query.filters.first,
@@ -104,7 +104,7 @@ class QueryFiltersTests: XCTestCase {
         }
 
         XCTAssert(key == "name", "Key should be name")
-        XCTAssert(comparison == .hasPrefix, "Position should be start")
+        XCTAssert(comparison == .hasPrefix(caseSensitive: false), "Position should be start")
         XCTAssert(value.string == "Vap", "Value should be Vap")
     }
 

--- a/Tests/Fluent/SQLSerializerTests.swift
+++ b/Tests/Fluent/SQLSerializerTests.swift
@@ -36,12 +36,12 @@ class SQLSerializerTests: XCTestCase {
     }
 
     func testFilterLikeSelect() {
-        let filter = Filter(User.self, .compare("name", .hasPrefix, "duc"))
+        let filter = Filter(User.self, .compare("name", .hasPrefix(caseSensitive: false), "duc"))
 
         let select = SQL.select(table: "friends", filters: [filter], joins: [], limit: nil)
         let (statement, values) = serialize(select)
 
-        XCTAssertEqual(statement, "SELECT * FROM `friends` WHERE `users`.`name` LIKE ?")
+        XCTAssertEqual(statement, "SELECT * FROM `friends` WHERE `users`.`name` LIKE ? COLLATE utf8_general_ci")
         XCTAssertEqual(values.first?.string, "duc%")
         XCTAssertEqual(values.count, 1)
     }


### PR DESCRIPTION
# Case Sensitive Partial Comparisons
Updated `.hasPrefix`, `.hasSuffix` and `.contains` to be case sensitive or insensitive.

Had a discussion on the syntax with Logan and we thought of `.hasPrefix(caseSensitive: Bool)`. Any suggestions? Input?

# Find Model(s) with ID(s)
A macro for finding model(s) using a list of `ids` that gains performance over `map`ing an array and individually calling `Model.find` and also makes it more for authors to figure out how to get an array of `Model`s using an array of `ids`.

I'm not quite sure about the `idKey` `guard` and just returning an empty array as that's "silently" failing, but I tried to copy the implementation of `find(id)` closely and that method also fails "silently" (unless throwing). Any thoughts?