### PR TITLE
Offset Query Limits

### DIFF
--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -73,6 +73,17 @@ extension Entity {
     }
 
     /**
+        Finds the entities with the given `ids`.
+    */
+    public static func find(_ ids: [NodeRepresentable]) throws -> [Self] {
+        guard let idKey = database?.driver.idKey else {
+            return []
+        }
+
+        return try Self.query().filter(idKey, .in, ids).all()
+    }
+
+    /**
         Creates a `Query` instance for this `Model`.
     */
     public static func query() throws -> Query<Self> {

--- a/Sources/Fluent/Query/Comparison.swift
+++ b/Sources/Fluent/Query/Comparison.swift
@@ -3,16 +3,92 @@ extension Filter {
         Describes the various operators for
         comparing values.
     */
-    public enum Comparison {
+    public enum Comparison : Equatable {
         case equals
         case greaterThan
         case lessThan
         case greaterThanOrEquals
         case lessThanOrEquals
         case notEquals
-        case hasSuffix
-        case hasPrefix
-        case contains
+        case hasSuffix(caseSensitive: Bool)
+        case hasPrefix(caseSensitive: Bool)
+        case contains(caseSensitive: Bool)
     }
     
+}
+
+public func ==(lhs: Filter.Comparison, rhs: Filter.Comparison) -> Bool {
+    switch lhs {
+    case .equals:
+        switch rhs {
+        case .equals:
+            return true
+        default:
+            return false
+        }
+
+    case .greaterThan:
+        switch rhs {
+        case .greaterThan:
+            return true
+        default:
+            return false
+        }
+
+    case .lessThan:
+        switch rhs {
+        case .lessThan:
+            return true
+        default:
+            return false
+        }
+
+    case .greaterThanOrEquals:
+        switch rhs {
+        case .greaterThanOrEquals:
+            return true
+        default:
+            return false
+        }
+
+    case .lessThanOrEquals:
+        switch rhs {
+        case .lessThanOrEquals:
+            return true
+        default:
+            return false
+        }
+
+    case .notEquals:
+        switch rhs {
+        case .notEquals:
+            return true
+        default:
+            return false
+        }
+
+    case .hasPrefix(let leftSensitivity):
+        switch rhs {
+        case .hasPrefix(let rightSensitivity):
+            return leftSensitivity == rightSensitivity
+        default:
+            return false
+        }
+
+    case .hasSuffix(let leftSensitivity):
+        switch rhs {
+        case .hasSuffix(let rightSensitivity):
+            return leftSensitivity == rightSensitivity
+        default:
+            return false
+        }
+
+    case .contains(let leftSensitivity):
+        switch rhs {
+        case .contains(let rightSensitivity):
+            return leftSensitivity == rightSensitivity
+        default:
+            return false
+        }
+    }
 }

--- a/Sources/Fluent/Query/Filter.swift
+++ b/Sources/Fluent/Query/Filter.swift
@@ -119,6 +119,6 @@ extension QueryRepresentable {
         _ field: String,
         contains value: NodeRepresentable
     ) throws -> Query<Self.T> {
-        return try filter(T.self, field, .contains, value)
+        return try filter(T.self, field, .contains(caseSensitive: false), value)
     }
 }

--- a/Sources/Fluent/Query/Limit.swift
+++ b/Sources/Fluent/Query/Limit.swift
@@ -10,4 +10,18 @@ public struct Limit {
     */
     var count: Int
     
+    /**
+    	The number of results to
+    	offset the query by.
+    */
+    var offset: Int
+
+    /**
+    	Default `offset` to 0
+    */
+    init(count: Int, offset: Int = 0)
+    {
+    	self.count = count
+    	self.offset = offset
+    }
 }

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -111,11 +111,11 @@ public class GeneralSQLSerializer: SQLSerializer {
         }
     }
 
-    public func sql(limit: Int) -> String {
+    public func sql(limit: Limit) -> String {
         var statement: [String] = []
 
         statement += "LIMIT"
-        statement += limit.description
+        statement += "\(limit.offset), \(limit.count)"
 
         return statement.joined(separator: " ")
     }

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -157,12 +157,15 @@ public class GeneralSQLSerializer: SQLSerializer {
                 processing of `value`
              */
             switch comparison {
-            case .hasPrefix:
+            case .hasPrefix(let caseSensitive):
                 values += sql(hasPrefix: value)
-            case .hasSuffix:
+                statement += sql(caseSensitive)
+            case .hasSuffix(let caseSensitive):
                 values += sql(hasSuffix: value)
-            case .contains:
+                statement += sql(caseSensitive)
+            case .contains(let caseSensitive):
                 values += sql(contains: value)
+                statement += sql(caseSensitive)
             default:
                 values += value
             }
@@ -224,6 +227,14 @@ public class GeneralSQLSerializer: SQLSerializer {
         }
 
         return .string("%\(string)%")
+    }
+
+    public func sql(_ caseSensitive: Bool) -> String {
+        if caseSensitive {
+            return "COLLATE utf8_bin"
+        } else {
+            return "COLLATE utf8_general_ci"
+        }
     }
 
     public func sql(_ scope: Filter.Scope) -> String {

--- a/Sources/Fluent/SQL/SQL+Query.swift
+++ b/Sources/Fluent/SQL/SQL+Query.swift
@@ -6,7 +6,7 @@ extension SQL {
                 table: query.entity,
                 filters: query.filters,
                 joins: query.unions,
-                limit: query.limit?.count
+                limit: query.limit
             )
         case .create:
             self = .insert(
@@ -17,7 +17,7 @@ extension SQL {
             self = .delete(
                 table: query.entity,
                 filters: query.filters,
-                limit: query.limit?.count
+                limit: query.limit
             )
         case .modify:
             self = .update(

--- a/Sources/Fluent/SQL/SQL.swift
+++ b/Sources/Fluent/SQL/SQL.swift
@@ -11,8 +11,8 @@ public enum SQL {
     }
     
     case insert(table: String, data: Node?)
-    case select(table: String, filters: [Filter], joins: [Union], limit: Int?)
+    case select(table: String, filters: [Filter], joins: [Union], limit: Limit?)
     case update(table: String, filters: [Filter], data: Node?)
-    case delete(table: String, filters: [Filter], limit: Int?)
+    case delete(table: String, filters: [Filter], limit: Limit?)
     case table(action: TableAction, table: String)
 }

--- a/Tests/Fluent/ModelFindTests.swift
+++ b/Tests/Fluent/ModelFindTests.swift
@@ -49,6 +49,30 @@ class ModelFindTests: XCTestCase {
                 } else if value.int == 500 {
                     throw Error.broken
                 }
+            } else 
+            if 
+                let filter = query.filters.first,
+                case .subset(let key, let scope, let values) = filter.method,
+                query.action == .fetch &&
+                    query.filters.count == 1 &&
+                    key == idKey &&
+                    scope == .in
+            {
+                if 
+                    values.count == 3 &&
+                    values[0] == 22 &&
+                    values[1] == 24 &&
+                    values[2] == 12
+                {
+                    return .array([
+                        .object([idKey: 12]),
+                        .object([idKey: 22]),
+                        .object([idKey: 24])
+                    ])
+                } else
+                {
+                    throw Error.broken
+                }
             }
             
             return .array([])
@@ -66,6 +90,7 @@ class ModelFindTests: XCTestCase {
     static let allTests = [
         ("testFindFailing", testFindFailing),
         ("testFindSucceeding", testFindSucceeding),
+        ("testFindMultipleSucceeding", testFindMultipleSucceeding),
         ("testFindErroring", testFindErroring),
     ]
 
@@ -89,6 +114,18 @@ class ModelFindTests: XCTestCase {
         do {
             let result = try DummyModel.find(42)
             XCTAssert(result?.id?.int == 42, "Result should have matching id")
+        } catch {
+            XCTFail("Find should not have failed")
+        }
+    }
+
+    func testFindMultipleSucceeding() {
+        do {
+            let result = try DummyModel.find([22,24,12])
+            XCTAssert(result.count == 3, "Count should have been 3")
+            XCTAssert(result[0].id?.int == 12, "[0] should have matching id")
+            XCTAssert(result[1].id?.int == 22, "[1] should have matching id")
+            XCTAssert(result[2].id?.int == 24, "[2] should have matching id")
         } catch {
             XCTFail("Find should not have failed")
         }

--- a/Tests/Fluent/QueryFiltersTests.swift
+++ b/Tests/Fluent/QueryFiltersTests.swift
@@ -88,7 +88,7 @@ class QueryFiltersTests: XCTestCase {
     }
 
     func testLikeQuery() throws {
-        let query = try DummyModel.query().filter("name", .hasPrefix, "Vap")
+        let query = try DummyModel.query().filter("name", .hasPrefix(caseSensitive: false), "Vap")
 
         guard
             let filter = query.filters.first,
@@ -104,7 +104,7 @@ class QueryFiltersTests: XCTestCase {
         }
 
         XCTAssert(key == "name", "Key should be name")
-        XCTAssert(comparison == .hasPrefix, "Position should be start")
+        XCTAssert(comparison == .hasPrefix(caseSensitive: false), "Position should be start")
         XCTAssert(value.string == "Vap", "Value should be Vap")
     }
 

--- a/Tests/Fluent/SQLSerializerTests.swift
+++ b/Tests/Fluent/SQLSerializerTests.swift
@@ -36,12 +36,12 @@ class SQLSerializerTests: XCTestCase {
     }
 
     func testFilterLikeSelect() {
-        let filter = Filter(User.self, .compare("name", .hasPrefix, "duc"))
+        let filter = Filter(User.self, .compare("name", .hasPrefix(caseSensitive: false), "duc"))
 
         let select = SQL.select(table: "friends", filters: [filter], joins: [], limit: nil)
         let (statement, values) = serialize(select)
 
-        XCTAssertEqual(statement, "SELECT * FROM `friends` WHERE `users`.`name` LIKE ?")
+        XCTAssertEqual(statement, "SELECT * FROM `friends` WHERE `users`.`name` LIKE ? COLLATE utf8_general_ci")
         XCTAssertEqual(values.first?.string, "duc%")
         XCTAssertEqual(values.count, 1)
     }

--- a/Tests/Fluent/SQLSerializerTests.swift
+++ b/Tests/Fluent/SQLSerializerTests.swift
@@ -16,10 +16,10 @@ class SQLSerializerTests: XCTestCase {
 
     func testRegularSelect() {
         let filter = Filter(User.self, .compare("age", .greaterThanOrEquals, 21))
-        let sql = SQL.select(table: "users", filters: [filter], joins: [], limit: 5)
+        let sql = SQL.select(table: "users", filters: [filter], joins: [], limit: Limit(count: 5))
         let (statement, values) = serialize(sql)
 
-        XCTAssertEqual(statement, "SELECT * FROM `users` WHERE `users`.`age` >= ? LIMIT 5")
+        XCTAssertEqual(statement, "SELECT * FROM `users` WHERE `users`.`age` >= ? LIMIT 0, 5")
         XCTAssertEqual(values.first?.int, 21)
         XCTAssertEqual(values.count, 1)
     }

--- a/Tests/Fluent/UnionTests.swift
+++ b/Tests/Fluent/UnionTests.swift
@@ -33,7 +33,7 @@ class UnionTests: XCTestCase {
                     XCTAssert(join.foreign == Compound.self)
                     XCTAssertEqual(join.foreignKey, lqd.idKey)
                 }
-                XCTAssertEqual(limit, nil)
+                XCTAssert(limit == nil)
             default:
                 XCTFail("Invalid SQL type.")
             }
@@ -62,7 +62,7 @@ class UnionTests: XCTestCase {
                     XCTAssert(join.foreign == Compound.self)
                     XCTAssertEqual(join.foreignKey, foreignKey)
                 }
-                XCTAssertEqual(limit, nil)
+                XCTAssert(limit == nil)
             default:
                 XCTFail("Invalid SQL type.")
             }


### PR DESCRIPTION
In order to add pagination to an API's endpoint, you need to be able to limit the number of results and you need to be able to offset them. Presently, we can limit the amount of results from the db, but we cannot offset them.

SQL supports two ways (that I know of) to do this. There's `select * from table limit 10 offset 5` or the shorthand `select * from table limit 5, 10`. For the implementation and tests I chose the shorthand method, but it can easily be changed to the more explicit one if need be.

Built off of #57 