### PR TITLE
Fixes

### DIFF
--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -18,9 +18,35 @@ public protocol Entity: Preparation, NodeConvertible {
     */
     var id: Node? { get set }
 
-    func onCreate()
-    func onUpdate()
-    func onDelete()
+    /**
+        Called before the entity will be created.
+    */
+    func willCreate()
+
+    /**
+        Called after the entity has been created.
+    */
+    func didCreate()
+
+    /**
+        Called before the entity will be updated.
+    */
+    func willUpdate()
+
+    /**
+        Called after the entity has been updated.
+    */
+    func didUpdate()
+
+    /**
+        Called before the entity will be deleted.
+    */
+    func willDelete()
+
+    /**
+        Called after the entity has been deleted.
+    */
+    func didDelete()
 }
 
 //MARK: Defaults
@@ -60,9 +86,12 @@ extension Entity {
 
 
 extension Entity {
-    public func onCreate() {}
-    public func onUpdate() {}
-    public func onDelete() {}
+    public func willCreate() {}
+    public func didCreate() {}
+    public func willUpdate() {}
+    public func didUpdate() {}
+    public func willDelete() {}
+    public func didDelete() {}
 }
 
 //MARK: CRUD

--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -17,9 +17,15 @@ public protocol Entity: Preparation, NodeConvertible {
         `find(:_)`.
     */
     var id: Node? { get set }
+
+    func onCreate()
+    func onUpdate()
+    func onDelete()
 }
 
 //MARK: Defaults
+
+var existanceStorage: [String: Bool] = [:]
 
 extension Entity {
     /**
@@ -33,6 +39,30 @@ extension Entity {
     public static var name: String {
         return String(describing: self).lowercased()
     }
+
+    private var address: String {
+        mutating get {
+            var id = ""
+            withUnsafePointer(to: &self) { id = "\($0)"}
+            return id
+        }
+    }
+
+    var exists: Bool {
+        mutating get {
+            return existanceStorage[address] ?? false
+        }
+        set {
+            existanceStorage[address] = newValue
+        }
+    }
+}
+
+
+extension Entity {
+    public func onCreate() {}
+    public func onUpdate() {}
+    public func onDelete() {}
 }
 
 //MARK: CRUD

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -183,11 +183,13 @@ extension QueryRepresentable {
                 .equals,
                 id
             )
+            model.willUpdate()
             try modify(data)
-            model.onUpdate()
+            model.didUpdate()
         } else {
+            model.willCreate()
             model.id = try query.create(data)
-            model.onCreate()
+            model.didCreate()
         }
         model.exists = true
     }
@@ -227,9 +229,9 @@ extension QueryRepresentable {
 
         query.filters.append(filter)
 
+        model.willDelete()
         try query.run()
-
-        model.onDelete()
+        model.didDelete()
 
         var model = model
         model.exists = false

--- a/Tests/FluentTests/ModelTests.swift
+++ b/Tests/FluentTests/ModelTests.swift
@@ -16,19 +16,19 @@ class ModelTests: XCTestCase {
 
     func testExamples() throws {
         Atom.database = db
-        var atom = Atom(name: "test")
+        var atom = Atom(name: "test", id: 5)
 
-        atom.id = 5
-        print(atom.exists)
+        XCTAssertFalse(atom.exists, "Model shouldn't exist yet.")
+
         try! atom.save()
+
+        XCTAssertTrue(atom.exists, "Model should exist after saving.")
 
         let (sql, _) = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
         print(sql)
 
         atom.name = "bob"
         try atom.save()
-
-        print(atom.exists)
 
         let (sql2, _) = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
         print(sql2)

--- a/Tests/FluentTests/ModelTests.swift
+++ b/Tests/FluentTests/ModelTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import Fluent
+
+class ModelTests: XCTestCase {
+    static let allTests = [
+        ("testManualPreparation", testManualPreparation),
+    ]
+
+    var lqd: LastQueryDriver!
+    var db: Database!
+
+    override func setUp() {
+        lqd = LastQueryDriver()
+        db = Database(lqd)
+    }
+
+    func testManualPreparation() throws {
+        Atom.database = db
+        var atom = Atom(name: "test")
+
+        atom.id = 5
+        print(atom.exists)
+        try! atom.save()
+
+        let (sql, _) = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
+        print(sql)
+
+        atom.name = "bob"
+        try atom.save()
+
+        print(atom.exists)
+
+        let (sql2, _) = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
+        print(sql2)
+
+        print(atom.id)
+
+        try atom.delete()
+    }
+}

--- a/Tests/FluentTests/ModelTests.swift
+++ b/Tests/FluentTests/ModelTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class ModelTests: XCTestCase {
     static let allTests = [
-        ("testManualPreparation", testManualPreparation),
+        ("testExamples", testExamples),
     ]
 
     var lqd: LastQueryDriver!
@@ -14,7 +14,7 @@ class ModelTests: XCTestCase {
         db = Database(lqd)
     }
 
-    func testManualPreparation() throws {
+    func testExamples() throws {
         Atom.database = db
         var atom = Atom(name: "test")
 

--- a/Tests/FluentTests/UnionTests.swift
+++ b/Tests/FluentTests/UnionTests.swift
@@ -123,7 +123,7 @@ class UnionTests: XCTestCase {
         Atom.database = db
         Compound.database = db
 
-        let atom = Atom(name: "Hydrogen")
+        var atom = Atom(name: "Hydrogen")
         atom.id = Node(42)
 
         do {

--- a/Tests/FluentTests/Utilities/Atom.swift
+++ b/Tests/FluentTests/Utilities/Atom.swift
@@ -1,6 +1,6 @@
 import Fluent
 
-final class Atom: Entity {
+struct Atom: Entity {
     var id: Node?
     var name: String
     var groupId: Node?
@@ -20,7 +20,7 @@ final class Atom: Entity {
         return try Node(node: [
             "id": id,
             "name": name,
-            "group": try group().get()
+            "group_id": groupId
         ])
     }
 
@@ -49,5 +49,17 @@ final class Atom: Entity {
     }
     static func revert(_ database: Fluent.Database) throws {
         try database.delete(entity)
+    }
+
+    func onCreate() {
+        print("Atom create.")
+    }
+
+    func onUpdate() {
+        print("Atom update.")
+    }
+
+    func onDelete() {
+        print("Atom delete.")
     }
 }

--- a/Tests/FluentTests/Utilities/Atom.swift
+++ b/Tests/FluentTests/Utilities/Atom.swift
@@ -5,8 +5,8 @@ struct Atom: Entity {
     var name: String
     var groupId: Node?
 
-    init(name: String) {
-        id = nil
+    init(name: String, id: Node? = nil) {
+        self.id = id
         self.name = name
     }
 
@@ -51,15 +51,29 @@ struct Atom: Entity {
         try database.delete(entity)
     }
 
-    func onCreate() {
-        print("Atom create.")
+    // MARK: Callbacks
+
+    func willCreate() {
+        print("Atom will create.")
     }
 
-    func onUpdate() {
-        print("Atom update.")
+    func didCreate() {
+        print("Atom did create.")
     }
 
-    func onDelete() {
-        print("Atom delete.")
+    func willUpdate() {
+        print("Atom will update.")
+    }
+
+    func didUpdate() {
+        print("Atom did update.")
+    }
+
+    func willDelete() {
+        print("Atom will delete.")
+    }
+
+    func didDelete() {
+        print("Atom did delete.")
     }
 }

--- a/Tests/FluentTests/Utilities/LastQueryDriver.swift
+++ b/Tests/FluentTests/Utilities/LastQueryDriver.swift
@@ -12,7 +12,7 @@ class LastQueryDriver: Driver {
         let sql = query.sql
         lastQuery = sql
         print("[LQD] \(sql)")
-        return .null
+        return Node.object([idKey: 5])
     }
 
     func schema(_ schema: Schema) throws {


### PR DESCRIPTION
This adds an internal `exists` property which will allow us to differentiate between saving a new item with a preset ID and updating an existing item.

It also adds 3 hooks: `onUpdate`, `onCreate`, and `onDelete` which will users to hook into the entity for things like timestamps until we provide more robust solutions.

Fixes #86 
Fixes #80 

Provides a solution for #82 

- [ ] Add all types of callbacks: creating, created, updating, updated, saving, saved, deleting, deleted
- [ ] Consider beforeValidate and afterValidate