### PR TITLE
Separate LIMIT and OFFSET output

### DIFF
--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -118,8 +118,7 @@ open class GeneralSQLSerializer: SQLSerializer {
     open func sql(limit: Limit) -> String {
         var statement: [String] = []
 
-        statement += "LIMIT"
-        statement += "\(limit.offset), \(limit.count)"
+        statement += "LIMIT \(limit.count) OFFSET \(limit.offset)"
 
         return statement.joined(separator: " ")
     }

--- a/Tests/FluentTests/SQLSerializerTests.swift
+++ b/Tests/FluentTests/SQLSerializerTests.swift
@@ -26,17 +26,17 @@ class SQLSerializerTests: XCTestCase {
         let sql = SQL.select(table: "users", filters: [filter], joins: [], orders: [], limit: Limit(count: 5))
         let (statement, values) = serialize(sql)
 
-        XCTAssertEqual(statement, "SELECT * FROM `users` WHERE `users`.`age` >= ? LIMIT 0, 5")
+        XCTAssertEqual(statement, "SELECT * FROM `users` WHERE `users`.`age` >= ? LIMIT 5 OFFSET 0")
         XCTAssertEqual(values.first?.int, 21)
         XCTAssertEqual(values.count, 1)
     }
-    
+
     func testOffsetSelect() {
         let filter = Filter(User.self, .compare("age", .greaterThanOrEquals, 21))
         let sql = SQL.select(table: "users", filters: [filter], joins: [], orders: [], limit: Limit(count: 5, offset: 15))
         let (statement, _) = serialize(sql)
-        
-        XCTAssertEqual(statement, "SELECT * FROM `users` WHERE `users`.`age` >= ? LIMIT 15, 5")
+
+        XCTAssertEqual(statement, "SELECT * FROM `users` WHERE `users`.`age` >= ? LIMIT 5 OFFSET 15")
     }
 
     func testFilterCompareSelect() {


### PR DESCRIPTION
* This separation is needed for PostgreSQL compatibility. The `sql(limit)` function can't be overridden because `.count` is an internal method of `Limit`.