### PR TITLE
Added test for pivot database setting

### DIFF
--- a/Tests/FluentTests/RelationTests.swift
+++ b/Tests/FluentTests/RelationTests.swift
@@ -5,6 +5,8 @@ class RelationTests: XCTestCase {
     static let allTests = [
         ("testHasMany", testHasMany),
         ("testBelongsToMany", testBelongsToMany),
+        ("testCustomForeignKey", testCustomForeignKey),
+        ("testPivotDatabase", testPivotDatabase),
     ]
 
     var database: Database!
@@ -50,5 +52,11 @@ class RelationTests: XCTestCase {
         } catch {
             print(error)
         }
+    }
+    
+    func testPivotDatabase() throws {
+        Pivot<Atom, Nucleus>.database = database
+        XCTAssertTrue(Pivot<Atom, Nucleus>.database === database)
+        XCTAssertTrue(Pivot<Nucleus, Atom>.database === database)
     }
 }


### PR DESCRIPTION
This test shows that setting the database on the Pivot entity and swapping the generic entities, does not result in the same database.