### PR TITLE
Fix missing action on pre-existing tables during preparation

### DIFF
--- a/Sources/Fluent/Preparation/Database+Preparation.swift
+++ b/Sources/Fluent/Preparation/Database+Preparation.swift
@@ -11,6 +11,11 @@ extension Database {
         do {
             // check to see if this preparation has already run
             if let _ = try Migration.query().filter("name", preparation.name).first() {
+                
+                // set the current database on involved Models
+                if let model = preparation as? Entity.Type {
+                    model.database = self
+                }
                 return true
             }
         } catch {


### PR DESCRIPTION
When a table already exists (so prepare is not called), the model.database is not set.  This corrects that issue.  