### PR TITLE
Add datetime support in Fluent and in Node

### DIFF
--- a/Sources/Fluent/Preparation/Database+Preparation.swift
+++ b/Sources/Fluent/Preparation/Database+Preparation.swift
@@ -11,6 +11,11 @@ extension Database {
         do {
             // check to see if this preparation has already run
             if let _ = try Migration.query().filter("name", preparation.name).first() {
+                
+                // set the current database on involved Models
+                if let model = preparation as? Entity.Type {
+                    model.database = self
+                }
                 return true
             }
         } catch {

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -363,6 +363,10 @@ open class GeneralSQLSerializer: SQLSerializer {
             return "BOOL"
         case .data:
             return "BLOB"
+        case .timestamp:
+            return "TIMESTAMP"
+        case .datetime:
+            return "DATETIME"
         }
     }
 

--- a/Sources/Fluent/Schema/Schema+Creator.swift
+++ b/Sources/Fluent/Schema/Schema+Creator.swift
@@ -56,9 +56,27 @@ extension Schema {
             fields += Field(name: name, type: .data, optional: optional)
         }
 
+        public func timestamp(
+            _ name: String,
+            optional: Bool = false
+            ) {
+            fields += Field(name: name, type: .timestamp, optional: optional)
+        }
+        
+        
+        public func datetime(
+            _ name: String,
+            optional: Bool = false
+            ) {
+            fields += Field(name: name, type: .datetime, optional: optional)
+        }
+
         public var schema: Schema {
             return .create(entity: entity, create: fields)
         }
+        
+        
+
 
         // MARK: Relations
 

--- a/Sources/Fluent/Schema/Schema+Field.swift
+++ b/Sources/Fluent/Schema/Schema+Field.swift
@@ -15,6 +15,8 @@ extension Schema {
             case double
             case bool
             case data
+            case timestamp
+            case datetime
         }
 
         public init(name: String, type: DataType, optional: Bool = false) {


### PR DESCRIPTION
I am submitting a series of pull requests to add Date as a class in Node and datetime and timestamp support in Fluent.  This allows for full support for time throughout Vapor.

Specifically, there are pull requests for Vapor, Fluent, Node, JSON, MySQL, Leaf, and FluentMySQL