### PR TITLE
Implements count functionality to queries

### DIFF
--- a/Sources/Fluent/Memory/MemoryDriver.swift
+++ b/Sources/Fluent/Memory/MemoryDriver.swift
@@ -31,6 +31,10 @@ public final class MemoryDriver: Driver {
             let results = group.fetch(query.filters, query.sorts)
 
             return Node.array(results)
+        case .count:
+            let count = group.fetch(query.filters, query.sorts).count
+            
+            return Node.number(.int(count))
         case .modify:
             guard let data = query.data else {
                 throw Error.dataRequired

--- a/Sources/Fluent/Query/Action.swift
+++ b/Sources/Fluent/Query/Action.swift
@@ -5,6 +5,7 @@
 */
 public enum Action {
     case fetch
+    case count
     case delete
     case create
     case modify

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -151,6 +151,15 @@ extension QueryRepresentable {
 
         return m
     }
+    
+    /**
+        Returns the number of results for the query.
+    */
+    public func count() throws -> Int {
+        let query = try makeQuery()
+        query.action = .count
+        return try query.raw().int ?? 0
+    }
 
     //MARK: Create
 

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -68,6 +68,27 @@ open class GeneralSQLSerializer: SQLSerializer {
                 sql(statement),
                 values
             )
+        case .count(let table, let filters, let unions):
+            var statement: [String] = []
+            var values: [Node] = []
+
+            statement += "SELECT COUNT(*) FROM"
+            statement += sql(table)
+
+            if !unions.isEmpty {
+                statement += sql(unions)
+            }
+
+            if !filters.isEmpty {
+                let (filtersClause, filtersValues) = sql(filters)
+                statement += filtersClause
+                values += filtersValues
+            }
+
+            return (
+                sql(statement),
+                values
+            )
         case .delete(let table, let filters, let limit):
             var statement: [String] = []
             var values: [Node] = []

--- a/Sources/Fluent/SQL/SQL+Query.swift
+++ b/Sources/Fluent/SQL/SQL+Query.swift
@@ -9,6 +9,12 @@ extension SQL {
                 orders: query.sorts,
                 limit: query.limit
             )
+        case .count:
+            self = .count(
+                table: query.entity,
+                filters: query.filters,
+                joins: query.unions
+            )
         case .create:
             self = .insert(
                 table: query.entity,

--- a/Sources/Fluent/SQL/SQL.swift
+++ b/Sources/Fluent/SQL/SQL.swift
@@ -12,6 +12,7 @@ public enum SQL {
     
     case insert(table: String, data: Node?)
     case select(table: String, filters: [Filter], joins: [Union], orders: [Sort], limit: Limit?)
+    case count(table: String, filters: [Filter], joins: [Union])
     case update(table: String, filters: [Filter], data: Node?)
     case delete(table: String, filters: [Filter], limit: Limit?)
     case table(action: TableAction, table: String)

--- a/Tests/FluentTests/MemoryTests.swift
+++ b/Tests/FluentTests/MemoryTests.swift
@@ -90,7 +90,7 @@ class MemoryTests: XCTestCase {
     }
     
     func testCount() throws {
-        let (driver, database) = makeTestModels()
+        let (_, database) = makeTestModels()
         
         var new1 = User(id: nil, name: "Vapor", email: "test1@email.com")
         var new2 = User(id: nil, name: "Vapor", email: "test2@email.com")

--- a/Tests/FluentTests/MemoryTests.swift
+++ b/Tests/FluentTests/MemoryTests.swift
@@ -88,4 +88,23 @@ class MemoryTests: XCTestCase {
             return u1.name < u2.name
         }))
     }
+    
+    func testCount() throws {
+        let (driver, database) = makeTestModels()
+        
+        var new1 = User(id: nil, name: "Vapor", email: "test1@email.com")
+        var new2 = User(id: nil, name: "Vapor", email: "test2@email.com")
+        let store = Query<User>(database)
+        try store.save(&new1)
+        try store.save(&new2)
+
+        let count1 = try Query<User>(database).filter("name", "Vapor").count()
+        XCTAssertEqual(count1, 2)
+        
+        let count2 = try Query<User>(database).filter("email", "test1@email.com").count()
+        XCTAssertEqual(count2, 1)
+        
+        let count3 = try Query<User>(database).filter("name", "Test").count()
+        XCTAssertEqual(count3, 0)
+    }
 }

--- a/Tests/FluentTests/QueryFiltersTests.swift
+++ b/Tests/FluentTests/QueryFiltersTests.swift
@@ -6,6 +6,8 @@ class QueryFiltersTests: XCTestCase {
         ("testBasalQuery", testBasalQuery),
         ("testBasicQuery", testBasicQuery),
         ("testLikeQuery", testLikeQuery),
+        ("testCountQuery", testCountQuery),
+        ("testDeleteQuery", testDeleteQuery),
     ]
 
     override func setUp() {
@@ -24,7 +26,6 @@ class QueryFiltersTests: XCTestCase {
         XCTAssert(query.limit == nil, "Limit should be empty")
         XCTAssert(query.entity == DummyModel.entity, "Entity should match")
     }
-
 
     func testBasicQuery() throws {
         let query = try DummyModel.query().filter("name", "Vapor")
@@ -64,17 +65,17 @@ class QueryFiltersTests: XCTestCase {
         XCTAssert(comparison == .hasPrefix, "Position should be start")
         XCTAssert(value.string == "Vap", "Value should be Vap")
     }
-    
+ 
     func testCountQuery() throws {
         let query = try DummyModel.query().filter("id", 5)
-        
+
         do {
             let numberOfResults = try query.count()
             XCTAssertEqual(numberOfResults, 0)
         } catch {
             XCTFail("Count should not have failed")
         }
-        
+
         XCTAssert(query.action == .count)
     }
 

--- a/Tests/FluentTests/QueryFiltersTests.swift
+++ b/Tests/FluentTests/QueryFiltersTests.swift
@@ -64,6 +64,19 @@ class QueryFiltersTests: XCTestCase {
         XCTAssert(comparison == .hasPrefix, "Position should be start")
         XCTAssert(value.string == "Vap", "Value should be Vap")
     }
+    
+    func testCountQuery() throws {
+        let query = try DummyModel.query().filter("id", 5)
+        
+        do {
+            let numberOfResults = try query.count()
+            XCTAssertEqual(numberOfResults, 0)
+        } catch {
+            XCTFail("Count should not have failed")
+        }
+        
+        XCTAssert(query.action == .count)
+    }
 
     func testDeleteQuery() throws {
         let query = try DummyModel.query().filter("id", 5)

--- a/Tests/FluentTests/SQLSerializerTests.swift
+++ b/Tests/FluentTests/SQLSerializerTests.swift
@@ -60,6 +60,46 @@ class SQLSerializerTests: XCTestCase {
         XCTAssertEqual(values.first?.string, "duc%")
         XCTAssertEqual(values.count, 1)
     }
+    
+    func testBasicCount() {
+        let sql = SQL.count(table: "users", filters: [], joins: [])
+        let (statement, values) = serialize(sql)
+
+        XCTAssertEqual(statement, "SELECT COUNT(*) FROM `users`")
+        XCTAssert(values.isEmpty)
+    }
+
+    func testRegularCount() {
+        let filter = Filter(User.self, .compare("age", .greaterThanOrEquals, 21))
+        let sql = SQL.count(table: "users", filters: [filter], joins: [])
+        let (statement, values) = serialize(sql)
+
+        XCTAssertEqual(statement, "SELECT COUNT(*) FROM `users` WHERE `users`.`age` >= ?")
+        XCTAssertEqual(values.first?.int, 21)
+        XCTAssertEqual(values.count, 1)
+    }
+
+    func testFilterCompareCount() {
+        let filter = Filter(User.self, .compare("name", .notEquals, "duck"))
+
+        let select = SQL.count(table: "friends", filters: [filter], joins: [])
+        let (statement, values) = serialize(select)
+
+        XCTAssertEqual(statement, "SELECT COUNT(*) FROM `friends` WHERE `users`.`name` != ?")
+        XCTAssertEqual(values.first?.string, "duck")
+        XCTAssertEqual(values.count, 1)
+    }
+
+    func testFilterLikeCount() {
+        let filter = Filter(User.self, .compare("name", .hasPrefix, "duc"))
+
+        let select = SQL.count(table: "friends", filters: [filter], joins: [])
+        let (statement, values) = serialize(select)
+
+        XCTAssertEqual(statement, "SELECT COUNT(*) FROM `friends` WHERE `users`.`name` LIKE ?")
+        XCTAssertEqual(values.first?.string, "duc%")
+        XCTAssertEqual(values.count, 1)
+    }
 
     func testFilterCompareUpdate() {
         let filter = Filter(User.self, .compare("name", .equals, "duck"))

--- a/Tests/FluentTests/SQLSerializerTests.swift
+++ b/Tests/FluentTests/SQLSerializerTests.swift
@@ -8,6 +8,10 @@ class SQLSerializerTests: XCTestCase {
         ("testOffsetSelect", testOffsetSelect),
         ("testFilterCompareSelect", testFilterCompareSelect),
         ("testFilterLikeSelect", testFilterLikeSelect),
+        ("testBasicCount", testBasicCount),
+        ("testRegularCount", testRegularCount),
+        ("testFilterCompareCount", testFilterCompareCount),
+        ("testFilterLikeCount", testFilterLikeCount),
         ("testFilterCompareUpdate", testFilterCompareUpdate),
         ("testFilterCompareDelete", testFilterCompareDelete),
         ("testFilterGroup", testFilterGroup)


### PR DESCRIPTION
This is part of a series of pull requests to implement the count functionality for queries in Fluent. This addition allows to quickly determine the number of results of a query, without retrieving and parsing any data from the database. The exception here is the `MemoryDriver` where all data items are obviously already in memory.

There are also pull requests for mongo-driver (vapor/mongo-driver#17), postgresql-driver (vapor/postgresql-driver#11), mysql-driver (vapor/mysql-driver#17) and sqlite-driver (vapor/sqlite-driver#13).