### PR TITLE
Fix for only retrieving a fields from the Model table in union SQL queries

### DIFF
--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -43,8 +43,9 @@ open class GeneralSQLSerializer: SQLSerializer {
             var statement: [String] = []
             var values: [Node] = []
 
-            statement += "SELECT * FROM"
-            statement += sql(table)
+            let tableSQL = sql(table)
+            statement += "SELECT \(tableSQL).* FROM"
+            statement += tableSQL
 
             if !unions.isEmpty {
                 statement += sql(unions)

--- a/Tests/FluentTests/SQLSerializerTests.swift
+++ b/Tests/FluentTests/SQLSerializerTests.swift
@@ -17,7 +17,7 @@ class SQLSerializerTests: XCTestCase {
         let sql = SQL.select(table: "users", filters: [], joins: [], orders: [], limit: nil)
         let (statement, values) = serialize(sql)
 
-        XCTAssertEqual(statement, "SELECT * FROM `users`")
+        XCTAssertEqual(statement, "SELECT `users`.* FROM `users`")
         XCTAssert(values.isEmpty)
     }
 
@@ -26,7 +26,7 @@ class SQLSerializerTests: XCTestCase {
         let sql = SQL.select(table: "users", filters: [filter], joins: [], orders: [], limit: Limit(count: 5))
         let (statement, values) = serialize(sql)
 
-        XCTAssertEqual(statement, "SELECT * FROM `users` WHERE `users`.`age` >= ? LIMIT 0, 5")
+        XCTAssertEqual(statement, "SELECT `users`.* FROM `users` WHERE `users`.`age` >= ? LIMIT 0, 5")
         XCTAssertEqual(values.first?.int, 21)
         XCTAssertEqual(values.count, 1)
     }
@@ -36,7 +36,7 @@ class SQLSerializerTests: XCTestCase {
         let sql = SQL.select(table: "users", filters: [filter], joins: [], orders: [], limit: Limit(count: 5, offset: 15))
         let (statement, _) = serialize(sql)
         
-        XCTAssertEqual(statement, "SELECT * FROM `users` WHERE `users`.`age` >= ? LIMIT 15, 5")
+        XCTAssertEqual(statement, "SELECT `users`.* FROM `users` WHERE `users`.`age` >= ? LIMIT 15, 5")
     }
 
     func testFilterCompareSelect() {
@@ -45,7 +45,7 @@ class SQLSerializerTests: XCTestCase {
         let select = SQL.select(table: "friends", filters: [filter], joins: [], orders: [], limit: nil)
         let (statement, values) = serialize(select)
 
-        XCTAssertEqual(statement, "SELECT * FROM `friends` WHERE `users`.`name` != ?")
+        XCTAssertEqual(statement, "SELECT `friends`.* FROM `friends` WHERE `users`.`name` != ?")
         XCTAssertEqual(values.first?.string, "duck")
         XCTAssertEqual(values.count, 1)
     }
@@ -56,7 +56,7 @@ class SQLSerializerTests: XCTestCase {
         let select = SQL.select(table: "friends", filters: [filter], joins: [], orders: [], limit: nil)
         let (statement, values) = serialize(select)
 
-        XCTAssertEqual(statement, "SELECT * FROM `friends` WHERE `users`.`name` LIKE ?")
+        XCTAssertEqual(statement, "SELECT `friends`.* FROM `friends` WHERE `users`.`name` LIKE ?")
         XCTAssertEqual(values.first?.string, "duc%")
         XCTAssertEqual(values.count, 1)
     }
@@ -93,7 +93,7 @@ class SQLSerializerTests: XCTestCase {
         let select = SQL.select(table: "users", filters: [one, group, four], joins: [], orders: [], limit: nil)
         let (statement, values) = serialize(select)
 
-        XCTAssertEqual(statement, "SELECT * FROM `users` WHERE `users`.`1` = ? AND (`users`.`2` = ? OR `users`.`3` = ?) AND `users`.`4` = ?")
+        XCTAssertEqual(statement, "SELECT `users`.* FROM `users` WHERE `users`.`1` = ? AND (`users`.`2` = ? OR `users`.`3` = ?) AND `users`.`4` = ?")
         XCTAssertEqual(values.count, 4)
     }
 
@@ -102,7 +102,7 @@ class SQLSerializerTests: XCTestCase {
         let name = Sort(User.self, "name", .ascending)
         let select = SQL.select(table: "users", filters: [adult], joins: [], orders: [name], limit: nil)
         let (statement, values) = serialize(select)
-        XCTAssertEqual(statement, "SELECT * FROM `users` WHERE `users`.`age` > ? ORDER BY `users`.`name` ASC")
+        XCTAssertEqual(statement, "SELECT `users`.* FROM `users` WHERE `users`.`age` > ? ORDER BY `users`.`name` ASC")
         XCTAssertEqual(values.count, 1)
     }
 
@@ -112,7 +112,7 @@ class SQLSerializerTests: XCTestCase {
         let email = Sort(User.self, "email", .descending)
         let select = SQL.select(table: "users", filters: [adult], joins: [], orders: [name, email], limit: nil)
         let (statement, values) = serialize(select)
-        XCTAssertEqual(statement, "SELECT * FROM `users` WHERE `users`.`age` > ? ORDER BY `users`.`name` ASC, `users`.`email` DESC")
+        XCTAssertEqual(statement, "SELECT `users`.* FROM `users` WHERE `users`.`age` > ? ORDER BY `users`.`name` ASC, `users`.`email` DESC")
         XCTAssertEqual(values.count, 1)
     }
 }

--- a/Tests/FluentTests/UnionTests.swift
+++ b/Tests/FluentTests/UnionTests.swift
@@ -84,7 +84,7 @@ class UnionTests: XCTestCase {
         if let sql = lqd.lastQuery {
             let serializer = GeneralSQLSerializer(sql: sql)
             let (statement, values) = serializer.serialize()
-            XCTAssertEqual(statement, "SELECT * FROM `atoms` JOIN `compounds` ON `atoms`.`#local_key` = `compounds`.`#foreign_key`")
+            XCTAssertEqual(statement, "SELECT `atoms`.* FROM `atoms` JOIN `compounds` ON `atoms`.`#local_key` = `compounds`.`#foreign_key`")
             XCTAssertEqual(values.count, 0)
         } else {
             XCTFail("No last query.")
@@ -106,7 +106,7 @@ class UnionTests: XCTestCase {
         if let sql = lqd.lastQuery {
             let serializer = GeneralSQLSerializer(sql: sql)
             let (statement, values) = serializer.serialize()
-            XCTAssertEqual(statement, "SELECT * FROM `atoms` JOIN `compounds` ON `atoms`.`#local_key` = `compounds`.`#foreign_key` WHERE `atoms`.`protons` > ? AND `compounds`.`atoms` < ?")
+            XCTAssertEqual(statement, "SELECT `atoms`.* FROM `atoms` JOIN `compounds` ON `atoms`.`#local_key` = `compounds`.`#foreign_key` WHERE `atoms`.`protons` > ? AND `compounds`.`atoms` < ?")
 
             if values.count == 2 {
                 XCTAssertEqual(values[0].int, 5)
@@ -135,7 +135,7 @@ class UnionTests: XCTestCase {
             let (statement, values) = serializer.serialize()
             XCTAssertEqual(
                 statement,
-                "SELECT * FROM `compounds` JOIN `atom_compound` ON `compounds`.`\(lqd.idKey)` = `atom_compound`.`compound_\(lqd.idKey)` WHERE `atom_compound`.`atom_\(lqd.idKey)` = ?"
+                "SELECT `compounds`.* FROM `compounds` JOIN `atom_compound` ON `compounds`.`\(lqd.idKey)` = `atom_compound`.`compound_\(lqd.idKey)` WHERE `atom_compound`.`atom_\(lqd.idKey)` = ?"
             )
             XCTAssertEqual(values.count, 1)
             XCTAssertEqual(values.first?.int, 42)


### PR DESCRIPTION
When retrieving `Model`'s using a query with `union`, all fields of the join are retrieved and combined into a `Node`. This results in problems when parsing the `Model`. This fix updates the query creation to specifically use ```SELECT `tableName`.*```, instead of `SELECT *`.