### PR TITLE
Fix for filtering on null in SQL

### DIFF
--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -179,23 +179,32 @@ open class GeneralSQLSerializer: SQLSerializer {
 
         switch filter.method {
         case .compare(let key, let comparison, let value):
-            statement += "\(sql(filter.entity.entity)).\(sql(key))"
-            statement += sql(comparison)
-            statement += "?"
-
-            /**
-                `.like` comparison operator requires additional
-                processing of `value`
-             */
-            switch comparison {
-            case .hasPrefix:
-                values += sql(hasPrefix: value)
-            case .hasSuffix:
-                values += sql(hasSuffix: value)
-            case .contains:
-                values += sql(contains: value)
-            default:
-                values += value
+            // `.null` needs special handling in the case of `.equals` or `.notEquals`.
+            if comparison == .equals && value == .null {
+                statement += "\(sql(filter.entity.entity)).\(sql(key)) IS NULL"
+            }
+            else if comparison == .notEquals && value == .null {
+                statement += "\(sql(filter.entity.entity)).\(sql(key)) IS NOT NULL"
+            }
+            else {
+                statement += "\(sql(filter.entity.entity)).\(sql(key))"
+                statement += sql(comparison)
+                statement += "?"
+    
+                /**
+                    `.like` comparison operator requires additional
+                    processing of `value`
+                 */
+                switch comparison {
+                case .hasPrefix:
+                    values += sql(hasPrefix: value)
+                case .hasSuffix:
+                    values += sql(hasSuffix: value)
+                case .contains:
+                    values += sql(contains: value)
+                default:
+                    values += value
+                }
             }
         case .subset(let key, let scope, let subValues):
             statement += "\(sql(filter.entity.entity)).\(sql(key))"

--- a/Tests/FluentTests/SQLSerializerTests.swift
+++ b/Tests/FluentTests/SQLSerializerTests.swift
@@ -8,9 +8,13 @@ class SQLSerializerTests: XCTestCase {
         ("testOffsetSelect", testOffsetSelect),
         ("testFilterCompareSelect", testFilterCompareSelect),
         ("testFilterLikeSelect", testFilterLikeSelect),
+        ("testFilterEqualsNullSelect", testFilterEqualsNullSelect),
+        ("testFilterNotEqualsNullSelect", testFilterNotEqualsNullSelect),
         ("testFilterCompareUpdate", testFilterCompareUpdate),
         ("testFilterCompareDelete", testFilterCompareDelete),
-        ("testFilterGroup", testFilterGroup)
+        ("testFilterGroup", testFilterGroup),
+        ("testSort", testSort),
+        ("testSortMultiple", testSortMultiple),
     ]
 
     func testBasicSelect() {
@@ -59,6 +63,26 @@ class SQLSerializerTests: XCTestCase {
         XCTAssertEqual(statement, "SELECT `friends`.* FROM `friends` WHERE `users`.`name` LIKE ?")
         XCTAssertEqual(values.first?.string, "duc%")
         XCTAssertEqual(values.count, 1)
+    }
+    
+    func testFilterEqualsNullSelect() {
+        let filter = Filter(User.self, .compare("name", .equals, Node.null))
+        
+        let select = SQL.select(table: "friends", filters: [filter], joins: [], orders: [], limit: nil)
+        let (statement, values) = serialize(select)
+
+        XCTAssertEqual(statement, "SELECT `friends`.* FROM `friends` WHERE `users`.`name` IS NULL")
+        XCTAssertEqual(values.count, 0)
+    }
+    
+    func testFilterNotEqualsNullSelect() {
+        let filter = Filter(User.self, .compare("name", .notEquals, Node.null))
+        
+        let select = SQL.select(table: "friends", filters: [filter], joins: [], orders: [], limit: nil)
+        let (statement, values) = serialize(select)
+
+        XCTAssertEqual(statement, "SELECT `friends`.* FROM `friends` WHERE `users`.`name` IS NOT NULL")
+        XCTAssertEqual(values.count, 0)
     }
 
     func testFilterCompareUpdate() {


### PR DESCRIPTION
When filtering on `Node.null`, the resulting SQL should use either be `IS NULL` or `IS NOT NULL` in order to work correctly.