### PR TITLE
Retrieving direct relation in a single query.

### DIFF
--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -19,6 +19,20 @@ public protocol Entity: Preparation, NodeConvertible {
         like pivots.
     */
     static var name: String { get }
+    
+    
+    /**
+        Retrieves a list of all table field names for this entity.
+     
+        This array will be used when retrieving relations together
+        in one query.
+     
+        - parameter database: The database for which to retrieve
+        the field names.
+     
+        - returns: The list of all table field names.
+    */
+    static func fields(for database: Database) -> [String]
 
     /**
         The entity's primary identifier.
@@ -123,8 +137,8 @@ extension Entity {
         Deletes the entity from the data
         store if the `id` property is set.
     */
-    public func delete() throws {
-        try Self.query().delete(self)
+    public mutating func delete() throws {
+        try Self.query().delete(&self)
     }
 
     /**

--- a/Sources/Fluent/Preparation/Migration.swift
+++ b/Sources/Fluent/Preparation/Migration.swift
@@ -8,6 +8,10 @@ final class Migration: Entity {
     init(name: String) {
         self.name = name
     }
+    
+    static func fields(for database: Database) -> [String] {
+        return ["id", "name"]
+    }
 
     init(node: Node, in context: Context) throws {
         id = try node.extract("id")

--- a/Sources/Fluent/Query/Join.swift
+++ b/Sources/Fluent/Query/Join.swift
@@ -32,6 +32,15 @@ public final class Pivot<
     public static var name: String {
         return entity
     }
+    
+    public static func fields(for database: Database) -> [String] {
+        let idKey = database.driver.idKey
+        return [
+            idKey,
+            "\(left.name)_\(idKey)",
+            "\(right.name)_\(idKey)",
+        ]
+    }
 
     public static var left: Entity.Type {
         if First.entity < Second.entity {

--- a/Sources/Fluent/SQL/SQL+Query.swift
+++ b/Sources/Fluent/SQL/SQL+Query.swift
@@ -4,6 +4,8 @@ extension SQL {
         case .fetch:
             self = .select(
                 table: query.entity,
+                fields: query.fields,
+                relationFields: query.relationFields,
                 filters: query.filters,
                 joins: query.unions,
                 orders: query.sorts,

--- a/Sources/Fluent/SQL/SQL.swift
+++ b/Sources/Fluent/SQL/SQL.swift
@@ -11,7 +11,7 @@ public enum SQL {
     }
     
     case insert(table: String, data: Node?)
-    case select(table: String, filters: [Filter], joins: [Union], orders: [Sort], limit: Limit?)
+    case select(table: String, fields: [String], relationFields: [(table: String, fields: [String])], filters: [Filter], joins: [Union], orders: [Sort], limit: Limit?)
     case update(table: String, filters: [Filter], data: Node?)
     case delete(table: String, filters: [Filter], limit: Limit?)
     case table(action: TableAction, table: String)

--- a/Tests/FluentTests/ModelFindTests.swift
+++ b/Tests/FluentTests/ModelFindTests.swift
@@ -14,6 +14,10 @@ class ModelFindTests: XCTestCase {
         static func revert(_ database: Database) throws {}
 
         var id: Node?
+        
+        static func fields(for database: Database) -> [String] {
+            return []
+        }
 
         init(node: Node, in context: Context) throws {
 

--- a/Tests/FluentTests/PreparationTests.swift
+++ b/Tests/FluentTests/PreparationTests.swift
@@ -107,6 +107,14 @@ final class TestModel: Entity {
     var name: String
     var age: Int
     var exists: Bool = false
+    
+    static func fields(for database: Database) -> [String] {
+        return [
+            "id",
+            "name",
+            "age",
+        ]
+    }
 
     init(node: Node, in context: Context) throws {
         id = try node.extract("id")

--- a/Tests/FluentTests/QueryFiltersTests.swift
+++ b/Tests/FluentTests/QueryFiltersTests.swift
@@ -6,6 +6,7 @@ class QueryFiltersTests: XCTestCase {
         ("testBasalQuery", testBasalQuery),
         ("testBasicQuery", testBasicQuery),
         ("testLikeQuery", testLikeQuery),
+        ("testDeleteQuery", testDeleteQuery),
     ]
 
     override func setUp() {
@@ -76,5 +77,4 @@ class QueryFiltersTests: XCTestCase {
 
         XCTAssert(query.action == .delete)
     }
-
 }

--- a/Tests/FluentTests/RelationTests.swift
+++ b/Tests/FluentTests/RelationTests.swift
@@ -7,6 +7,8 @@ class RelationTests: XCTestCase {
         ("testBelongsToMany", testBelongsToMany),
         ("testCustomForeignKey", testCustomForeignKey),
         ("testPivotDatabase", testPivotDatabase),
+        ("testRetrieveRelationFirst", testRetrieveRelationFirst),
+        ("testRetrieveRelationAll", testRetrieveRelationAll),
     ]
 
     var memory: MemoryDriver!
@@ -76,5 +78,17 @@ class RelationTests: XCTestCase {
         Pivot<Atom, Nucleus>.database = database
         XCTAssertTrue(Pivot<Atom, Nucleus>.database === database)
         XCTAssertTrue(Pivot<Nucleus, Atom>.database === database)
+    }
+    
+    func testRetrieveRelationFirst() throws {
+        _ = try Atom.query()
+            .union(Group.self)
+            .first(including: Group.self)
+    }
+    
+    func testRetrieveRelationAll() throws {
+        _ = try Atom.query()
+            .union(Group.self)
+            .all(including: Group.self)
     }
 }

--- a/Tests/FluentTests/Utilities/Atom.swift
+++ b/Tests/FluentTests/Utilities/Atom.swift
@@ -10,6 +10,14 @@ struct Atom: Entity {
         self.id = id
         self.name = name
     }
+    
+    static func fields(for database: Database) -> [String] {
+        return [
+            "id",
+            "name",
+            "group_id",
+        ]
+    }
 
     init(node: Node, in context: Context) throws {
         id = try node.extract("id")

--- a/Tests/FluentTests/Utilities/Compound.swift
+++ b/Tests/FluentTests/Utilities/Compound.swift
@@ -4,6 +4,13 @@ final class Compound: Entity {
     var id: Node?
     var name: String
     var exists: Bool = false
+    
+    static func fields(for database: Database) -> [String] {
+        return [
+            "id",
+            "name",
+        ]
+    }
 
     init(node: Node, in context: Context) throws {
         id = try node.extract("id")

--- a/Tests/FluentTests/Utilities/Dummy.swift
+++ b/Tests/FluentTests/Utilities/Dummy.swift
@@ -10,6 +10,10 @@ final class DummyModel: Entity {
     static func revert(_ database: Database) throws {}
 
     var id: Node?
+    
+    static func fields(for database: Database) -> [String] {
+        return []
+    }
 
     init(node: Node, in context: Context) throws {
 

--- a/Tests/FluentTests/Utilities/Group.swift
+++ b/Tests/FluentTests/Utilities/Group.swift
@@ -3,9 +3,12 @@ import Fluent
 final class Group: Entity {
     var id: Node?
     var exists: Bool = false
+    
+    static func fields(for database: Database) -> [String] { return [] }
+    
     init(node: Node, in context: Context) throws {}
-
     func makeNode(context: Context = EmptyNode) -> Node { return .null }
+    
     static func prepare(_ database: Database) throws {}
     static func revert(_ database: Database) throws {}
 }

--- a/Tests/FluentTests/Utilities/Nucleus.swift
+++ b/Tests/FluentTests/Utilities/Nucleus.swift
@@ -4,9 +4,12 @@ final class Nucleus: Entity {
     var exists: Bool = false
     static var entity = "nuclei"
     var id: Node?
+    
+    static func fields(for database: Database) -> [String] { return [] }
+    
     init(node: Node, in context: Context) throws { }
-
     func makeNode(context: Context = EmptyNode) -> Node { return .null }
+    
     static func prepare(_ database: Database) throws {}
     static func revert(_ database: Database) throws {}
 }

--- a/Tests/FluentTests/Utilities/Proton.swift
+++ b/Tests/FluentTests/Utilities/Proton.swift
@@ -3,9 +3,12 @@ import Fluent
 final class Proton: Entity {
     var id: Node?
     var exists: Bool = false
+    
+    static func fields(for database: Database) -> [String] { return [] }
+    
     init(node: Node, in context: Context) throws {}
-
     func makeNode(context: Context = EmptyNode) -> Node { return .null }
+    
     static func prepare(_ database: Database) throws {}
     static func revert(_ database: Database) throws {}
 }

--- a/Tests/FluentTests/Utilities/User.swift
+++ b/Tests/FluentTests/Utilities/User.swift
@@ -23,6 +23,14 @@ final class User: Entity {
         self.name = name
         self.email = email
     }
+    
+    static func fields(for database: Database) -> [String] {
+        return [
+            "id",
+            "name",
+            "email",
+        ]
+    }
 
     init(node: Node, in context: Context) throws {
         id = try node.extract("id")


### PR DESCRIPTION
In order to keep database retrieval efficient, it can be useful to retrieve relations of a model together with the model directly in a single query.

I was thinking about how this could work in Fluent. I tried to implement this, without changing to much to the public API. The main problem here is, that in order to perform a proper SQL query, all field names for a model have to be known, because otherwise field names could cause conflicts. So for this to work I added the `fields` and `relationField` properties to the `Query<T>` class.

In order for this functionality to work, `.union` has to be called for the relation that you want to retrieve. Finally either `all(including: Entity.Type)` or `first(including: Entity.Type)` needs to be called to retrieve either an array of tuples or a single tuple of both the model and the relation.

Example:

``` swift
let (owner, pet) = try Owner.query()
    .union(Pet.self, localKey: "id", foreignKey: "owner_id")
    .filter(Pet.self, "type", .in, ["Dog", "Ferret"])
    .first(including: Pet.self)
```

I would love to get some feedback on this pull request, as I am myself not completely sure if this is the right way to go. For now at least it seems to work properly. I also added some unit tests.

Currently the `MemoryDriver` is not updated, but I noticed it was already not working correctly for unions.
