### PR TITLE
Allow custom naming relations

### DIFF
--- a/Sources/Fluent/Schema/Schema+Creator.swift
+++ b/Sources/Fluent/Schema/Schema+Creator.swift
@@ -127,13 +127,14 @@ extension Schema {
         // MARK: Relations
 
         public func parent<E: Entity>(
-            _ entity: E.Type = E.self,
+            _ name: String? = nil,
+            entity: E.Type = E.self,
             optional: Bool = false,
             unique: Bool = false,
             default: NodeRepresentable? = nil
         ) {
             fields += Field(
-                name: "\(entity.name)_id",
+                name: name == nil ? "\(entity.name)_id" : name!,
                 type: .int,
                 optional: optional,
                 unique: unique,


### PR DESCRIPTION
Allows for custom named relations.

So in the prepare(_ database: Database):

```swift
static func prepare(_ database: Database) throws {
        try database.create("bar") { bar in
            bar.id()
            bar.parent("foo1ID", entity: Foo.self)
            bar.parent("foo2ID", entity: Foo.self)
        }
    }
```

Allows multiple relations to the same table in databases. Also lets developers choose the key name instead of having to use entity.name_id

I'm currently using this code in my own vapor server