### PR TITLE
Add .filter("field", .isNull) and .filter("field", .isNotNull) support 

### DIFF
--- a/Sources/Fluent/Memory/Memory+Filters.swift
+++ b/Sources/Fluent/Memory/Memory+Filters.swift
@@ -55,6 +55,13 @@ extension Node {
 
     func passes(_ filter: Filter) -> Bool {
         switch filter.method {
+        case .nullability(let key, let nullability):
+            switch(nullability) {
+            case .isNull:
+                return self[key] == nil
+            case .isNotNull:
+                return self[key] != nil
+            }
         case .compare(let key, let comparison, let val):
             switch comparison {
             case .equals:

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -179,12 +179,13 @@ open class GeneralSQLSerializer: SQLSerializer {
 
         switch filter.method {
         case .nullability(let key, let nullability):
-            // `.null` needs special handling in the case of `.equals` or `.notEquals`.
-            if nullability == .isNull {
-                statement += "\(sql(filter.entity.entity)).\(sql(key)) IS NULL"
-            }
-            else if nullability == .isNotNull {
-                statement += "\(sql(filter.entity.entity)).\(sql(key)) IS NOT NULL"
+            statement += "\(sql(filter.entity.entity)).\(sql(key)) IS "
+            
+            switch(nullability) {
+            case .isNull:
+                statement += "NULL"
+            case .isNotNull:
+                statement += "NOT NULL"
             }
         case .compare(let key, let comparison, let value):
             // `.null` needs special handling in the case of `.equals` or `.notEquals`.

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -178,6 +178,14 @@ open class GeneralSQLSerializer: SQLSerializer {
         var values: [Node] = []
 
         switch filter.method {
+        case .nullability(let key, let nullability):
+            // `.null` needs special handling in the case of `.equals` or `.notEquals`.
+            if nullability == .isNull {
+                statement += "\(sql(filter.entity.entity)).\(sql(key)) IS NULL"
+            }
+            else if nullability == .isNotNull {
+                statement += "\(sql(filter.entity.entity)).\(sql(key)) IS NOT NULL"
+            }
         case .compare(let key, let comparison, let value):
             // `.null` needs special handling in the case of `.equals` or `.notEquals`.
             if comparison == .equals && value == .null {

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -179,13 +179,11 @@ open class GeneralSQLSerializer: SQLSerializer {
 
         switch filter.method {
         case .nullability(let key, let nullability):
-            statement += "\(sql(filter.entity.entity)).\(sql(key)) IS "
-            
             switch(nullability) {
             case .isNull:
-                statement += "NULL"
+                statement += "\(sql(filter.entity.entity)).\(sql(key)) IS NULL"
             case .isNotNull:
-                statement += "NOT NULL"
+                statement += "\(sql(filter.entity.entity)).\(sql(key)) IS NOT NULL"
             }
         case .compare(let key, let comparison, let value):
             // `.null` needs special handling in the case of `.equals` or `.notEquals`.

--- a/Tests/FluentTests/QueryFiltersTests.swift
+++ b/Tests/FluentTests/QueryFiltersTests.swift
@@ -43,6 +43,23 @@ class QueryFiltersTests: XCTestCase {
         XCTAssert(comparison == .equals, "Comparison should be equals")
         XCTAssert(value.string == "Vapor", "Value should be vapor")
     }
+    
+    func testIsNullQuery() throws {
+        let query = try DummyModel.query().filter("name", .isNull)
+        
+        guard let filter = query.filters.first, query.filters.count == 1 else {
+            XCTFail("Should be one filter")
+            return
+        }
+        
+        guard case .nullability(let key, let null) = filter.method else {
+            XCTFail("Should be nullability filter")
+            return
+        }
+        
+        XCTAssert(key == "name", "Key should be name")
+        XCTAssert(null == .isNull, "Nullability check should be 'is null'")
+    }
 
     func testLikeQuery() throws {
         let query = try DummyModel.query().filter("name", .hasPrefix, "Vap")

--- a/Tests/FluentTests/QueryFiltersTests.swift
+++ b/Tests/FluentTests/QueryFiltersTests.swift
@@ -5,6 +5,7 @@ class QueryFiltersTests: XCTestCase {
     static var allTests = [
         ("testBasalQuery", testBasalQuery),
         ("testBasicQuery", testBasicQuery),
+        ("testIsNullQuery", testIsNullQuery),
         ("testLikeQuery", testLikeQuery),
     ]
 

--- a/Tests/FluentTests/SQLSerializerTests.swift
+++ b/Tests/FluentTests/SQLSerializerTests.swift
@@ -42,6 +42,24 @@ class SQLSerializerTests: XCTestCase {
         
         XCTAssertEqual(statement, "SELECT `users`.* FROM `users` WHERE `users`.`age` >= ? LIMIT 15, 5")
     }
+    
+    func testFilterIsNullSelect() {
+        let filter = Filter(User.self, .nullability("name", .isNull))
+        
+        let select = SQL.select(table: "friends", filters: [filter], joins: [], orders: [], limit: nil)
+        let (statement, _) = serialize(select)
+        
+        XCTAssertEqual(statement, "SELECT `friends`.* FROM `friends` WHERE `users`.`name` IS NULL")
+    }
+    
+    func testFilterIsNotNullSelect() {
+        let filter = Filter(User.self, .nullability("name", .isNotNull))
+        
+        let select = SQL.select(table: "friends", filters: [filter], joins: [], orders: [], limit: nil)
+        let (statement, _) = serialize(select)
+        
+        XCTAssertEqual(statement, "SELECT `friends`.* FROM `friends` WHERE `users`.`name` IS NOT NULL")
+    }
 
     func testFilterCompareSelect() {
         let filter = Filter(User.self, .compare("name", .notEquals, "duck"))


### PR DESCRIPTION
Currently, it's possible to null-check fields with `.filter("field", .equals/.notEquals, Node.null)` which has a special case handling in the General SQL serializer. This adds support for proper nullability checks with a new `Nullability` enum in the Filter struct, which then makes possible to express null checks in a more explicit manner using `.filter("field", .isNull)` and `.filter("field", .isNotNull)`.

Feedback would be appreciated!

Relevant issue: #143