### PR TITLE
limit func

### DIFF
--- a/Sources/Fluent/Query/Limit.swift
+++ b/Sources/Fluent/Query/Limit.swift
@@ -20,3 +20,16 @@ public struct Limit {
         self.offset = offset
     }
 }
+
+extension QueryRepresentable {
+
+    /**
+        Limits the count of results returned
+        by the `Query`.
+    */
+    public func limit(_ count: Int) throws -> Query<T> {
+        let query = try makeQuery()
+        query.limit = Limit(count: count)
+        return query
+    }
+}

--- a/Tests/FluentTests/QueryFiltersTests.swift
+++ b/Tests/FluentTests/QueryFiltersTests.swift
@@ -77,4 +77,9 @@ class QueryFiltersTests: XCTestCase {
         XCTAssert(query.action == .delete)
     }
 
+    func testLimitQuery() throws {
+        let query = try DummyModel.query().limit(5)
+        XCTAssertEqual(query.limit?.count, 5)
+    }
+
 }


### PR DESCRIPTION
Convenience method for adding a limit to a query.

```swift
let query = try MyModel.query().limit(5).all()
```