### PR TITLE
The entity preparation/callback functions are now throwable

### DIFF
--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -40,32 +40,32 @@ public protocol Entity: Preparation, NodeConvertible {
     /**
         Called before the entity will be created.
     */
-    func willCreate()
+    func willCreate() throws
 
     /**
         Called after the entity has been created.
     */
-    func didCreate()
+    func didCreate() throws
 
     /**
         Called before the entity will be updated.
     */
-    func willUpdate()
+    func willUpdate() throws
 
     /**
         Called after the entity has been updated.
     */
-    func didUpdate()
+    func didUpdate() throws
 
     /**
         Called before the entity will be deleted.
     */
-    func willDelete()
+    func willDelete() throws
 
     /**
         Called after the entity has been deleted.
     */
-    func didDelete()
+    func didDelete() throws
 }
 
 // MARK: Defaults
@@ -100,12 +100,12 @@ extension Entity {
 
 
 extension Entity {
-    public func willCreate() {}
-    public func didCreate() {}
-    public func willUpdate() {}
-    public func didUpdate() {}
-    public func willDelete() {}
-    public func didDelete() {}
+    public func willCreate() throws {}
+    public func didCreate() throws {}
+    public func willUpdate() throws {}
+    public func didUpdate() throws {}
+    public func willDelete() throws {}
+    public func didDelete() throws {}
 }
 
 //MARK: CRUD

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -200,13 +200,13 @@ extension QueryRepresentable {
         let data = try model.makeNode()
 
         if let _ = model.id, model.exists {
-            model.willUpdate()
+            try model.willUpdate()
             try modify(data)
-            model.didUpdate()
+            try model.didUpdate()
         } else {
-            model.willCreate()
+            try model.willCreate()
             model.id = try query.create(data)
-            model.didCreate()
+            try model.didCreate()
         }
         model.exists = true
     }
@@ -251,9 +251,9 @@ extension QueryRepresentable {
 
         query.filters.append(filter)
 
-        model.willDelete()
+        try model.willDelete()
         try query.run()
-        model.didDelete()
+        try model.didDelete()
 
         var model = model
         model.exists = false

--- a/Tests/FluentTests/Utilities/Atom.swift
+++ b/Tests/FluentTests/Utilities/Atom.swift
@@ -54,27 +54,27 @@ struct Atom: Entity {
 
     // MARK: Callbacks
 
-    func willCreate() {
+    func willCreate() throws {
         print("Atom will create.")
     }
 
-    func didCreate() {
+    func didCreate() throws {
         print("Atom did create.")
     }
 
-    func willUpdate() {
+    func willUpdate() throws {
         print("Atom will update.")
     }
 
-    func didUpdate() {
+    func didUpdate() throws {
         print("Atom did update.")
     }
 
-    func willDelete() {
+    func willDelete() throws {
         print("Atom will delete.")
     }
 
-    func didDelete() {
+    func didDelete() throws {
         print("Atom did delete.")
     }
 }


### PR DESCRIPTION
It is impossible to throw an exception in those functions, making error handling impossible. I wanted to be able to delete the children of a model in willDelete(), but I couldn't throw an error if one deletion query isn't successful. 