### PR TITLE
Adding fetch action for all() and first() methods

### DIFF
--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -128,6 +128,7 @@ extension QueryRepresentable {
     */
     public func first() throws -> T? {
         let query = try makeQuery()
+        query.action = .fetch
         query.limit = Limit(count: 1)
 
         var model = try query.run().first
@@ -142,6 +143,8 @@ extension QueryRepresentable {
     */
     public func all() throws -> [T] {
         let query = try makeQuery()
+        
+        query.action = .fetch
 
         let models = try query.run()
         models.forEach { model in


### PR DESCRIPTION
This is a fix for an issue I am having for an special case.

I have a custom query with filters and I need to perform a count() before the all() method, but when I do that, the all() method is peformed with .count as action, so at the end the model is trying to initialize _fluent_count

My solution is to add query.action = .fetch to both all() and first()