### PR TITLE
connection pool

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -1,0 +1,30 @@
+{
+  "autoPin": true,
+  "pins": [
+    {
+      "package": "Core",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/core.git",
+      "version": "1.0.0"
+    },
+    {
+      "package": "Node",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/node.git",
+      "version": "1.0.1"
+    },
+    {
+      "package": "PathIndexable",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/path-indexable.git",
+      "version": "1.0.0"
+    },
+    {
+      "package": "Polymorphic",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/polymorphic.git",
+      "version": "1.0.1"
+    }
+  ],
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,9 @@ let package = Package(
     ],
     dependencies: [
         // Data structure for converting between multiple representations
-        .Package(url: "https://github.com/vapor/node.git", majorVersion: 1)
+        .Package(url: "https://github.com/vapor/node.git", majorVersion: 1),
+
+        // Core Components
+        .Package(url: "https://github.com/vapor/core.git", majorVersion: 1),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -8,9 +8,9 @@ let package = Package(
     ],
     dependencies: [
         // Data structure for converting between multiple representations
-        .Package(url: "https://github.com/vapor/node.git", majorVersion: 1),
+        .Package(url: "https://github.com/vapor/node.git", Version(2,0,0, prereleaseIdentifiers: ["alpha.1"])),
 
         // Core Components
-        .Package(url: "https://github.com/vapor/core.git", majorVersion: 1),
+        .Package(url: "https://github.com/vapor/core.git", Version(2,0,0, prereleaseIdentifiers: ["alpha.1"])),
     ]
 )

--- a/Sources/Fluent/Database/Connection.swift
+++ b/Sources/Fluent/Database/Connection.swift
@@ -1,0 +1,8 @@
+/**
+    The lowest level executor. All
+    calls to higher level executors
+    eventually end up here.
+*/
+public protocol Connection: Executor {
+    var closed: Bool { get }
+}

--- a/Sources/Fluent/Database/Connection.swift
+++ b/Sources/Fluent/Database/Connection.swift
@@ -4,5 +4,7 @@
     eventually end up here.
 */
 public protocol Connection: Executor {
+    /// Indicates whether the connection has
+    /// closed permanently and should be discarded.
     var closed: Bool { get }
 }

--- a/Sources/Fluent/Database/Database.swift
+++ b/Sources/Fluent/Database/Database.swift
@@ -16,7 +16,7 @@ public class Database: Executor {
     public init(_ driver: Driver) {
         threadConnectionPool = ThreadConnectionPool(
             makeConnection: driver.makeConnection,
-            maxConnections: 5
+            maxConnections: 128 // some number larger than the max threads
         )
         self.driver = driver
     }

--- a/Sources/Fluent/Database/Database.swift
+++ b/Sources/Fluent/Database/Database.swift
@@ -3,6 +3,19 @@
     Statically maps `Model`s to `Database`s.
 */
 public class Database: Executor {
+    /**
+         Maps `Model` names to their respective
+         `Database`. This allows multiple models
+         in the same application to use different
+         methods of data persistence.
+    */
+    public static var map: [String: Database] = [:]
+
+    /**
+         The default database for all `Model` types.
+    */
+    public static var `default`: Database?
+
     /// The `Driver` powering this database.
     /// Responsible for executing queries.
     public let driver: Driver
@@ -20,19 +33,6 @@ public class Database: Executor {
         )
         self.driver = driver
     }
-
-    /**
-        Maps `Model` names to their respective 
-        `Database`. This allows multiple models 
-        in the same application to use different
-        methods of data persistence.
-    */
-    public static var map: [String: Database] = [:]
-
-    /**
-        The default database for all `Model` types.
-    */
-    public static var `default`: Database?
     
     // MARK: Executor
 

--- a/Sources/Fluent/Database/Driver.swift
+++ b/Sources/Fluent/Database/Driver.swift
@@ -4,7 +4,7 @@
     It is responsible for interfacing
     with the data store powering Fluent.
 */
-public protocol Driver {
+public protocol Driver: Executor {
     /**
         The string value for the 
         default identifier key.
@@ -14,36 +14,45 @@ public protocol Driver {
         by identifier methods are used.
     */
     var idKey: String { get }
-
+    
     /**
-        Executes a `Query` from and
-        returns an array of results fetched,
-        created, or updated by the action.
+        Creates a connection for executing 
+        queries. This method is used to 
+        automatically create a connection
+        if any Executor methods are called on 
+        the Driver.
     */
-    @discardableResult
-    func query<T: Entity>(_ query: Query<T>) throws -> Node
-
-    /**
-        Creates the `Schema` indicated
-        by the `Builder`.
-    */
-    func schema(_ schema: Schema) throws
-
-    /**
-        Drivers that support raw querying
-        accept string queries and parameterized values.
-
-        This allows Fluent extensions to be written that
-        can support custom querying behavior.
-    */
-    @discardableResult
-    func raw(_ raw: String, _ values: [Node]) throws -> Node
+    func makeConnection() throws -> Connection
 }
+
+// MARK: Executor
 
 extension Driver {
     @discardableResult
-    public func raw(_ raw: String, _ values: [NodeRepresentable] = []) throws -> Node {
-        let nodes = try values.map { try $0.makeNode() }
-        return try self.raw(raw, nodes)
+    public func query<T: Entity>(_ query: Query<T>) throws -> Node {
+        return try makeConnection().query(query)
+    }
+    
+    public func schema(_ schema: Schema) throws {
+        return try makeConnection().schema(schema)
+    }
+    
+    @discardableResult
+    public func raw(_ raw: String, _ values: [Node]) throws -> Node {
+        return try makeConnection().raw(raw, values)
     }
 }
+
+
+// MARK: Deprecated
+
+enum DriverError: Error {
+    case unimplemented(String)
+}
+
+extension Driver {
+    public func makeConnection() throws -> Connection {
+        throw DriverError.unimplemented("Please update your database driver package to one that is compatible with Fluent 1.4.")
+    }
+}
+

--- a/Sources/Fluent/Database/Driver.swift
+++ b/Sources/Fluent/Database/Driver.swift
@@ -47,12 +47,12 @@ extension Driver {
 // MARK: Deprecated
 
 enum DriverError: Error {
-    case unimplemented(String)
+    case connectionsNotSupported(String)
 }
 
 extension Driver {
     public func makeConnection() throws -> Connection {
-        throw DriverError.unimplemented("Please update your database driver package to one that is compatible with Fluent 1.4.")
+        throw DriverError.connectionsNotSupported("Please update your database driver package to be compatible with Fluent 1.4.")
     }
 }
 

--- a/Sources/Fluent/Database/Executor.swift
+++ b/Sources/Fluent/Database/Executor.swift
@@ -1,0 +1,49 @@
+/**
+    An Executor is any entity that can execute
+    the queries for retreiving/sending data and
+    building databases that Fluent relies on.
+ 
+    Executors may include varying layers of 
+    performance optimizations such as connection
+    and thread pooling.
+ 
+    The lowest level executor is usually a connection
+    while the highest level executor can have many
+    layers of abstraction on top of the connection
+    for performance and convenience.
+*/
+public protocol Executor {
+    /**
+        Executes a `Query` from and
+        returns an array of results fetched,
+        created, or updated by the action.
+    */
+    @discardableResult
+    func query<T: Entity>(_ query: Query<T>) throws -> Node
+    
+    /**
+        Creates the `Schema` indicated
+        by the `Builder`.
+    */
+    func schema(_ schema: Schema) throws
+    
+    /**
+        Drivers that support raw querying
+        accept string queries and parameterized values.
+
+        This allows Fluent extensions to be written that
+        can support custom querying behavior.
+    */
+    @discardableResult
+    func raw(_ raw: String, _ values: [Node]) throws -> Node
+}
+
+// MARK: Convenience
+
+extension Executor {
+    @discardableResult
+    public func raw(_ raw: String, _ values: [NodeRepresentable] = []) throws -> Node {
+        let nodes = try values.map { try $0.makeNode() }
+        return try self.raw(raw, nodes)
+    }
+}

--- a/Sources/Fluent/Database/ThreadConnectionPool.swift
+++ b/Sources/Fluent/Database/ThreadConnectionPool.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/**
+    Responsible for maintaing of pool
+    of connections, one for each thread.
+ 
+    Uses a Driver to make new connections.
+*/
+public final class ThreadConnectionPool {
+    var makeConnection: ConnectionFactory
+    var storage: [pthread_t: (conn: Connection, time: Int)]
+    var maxConnections: Int
+    var time: Int
+    
+    public typealias ConnectionFactory = () throws -> Connection
+    
+    init(makeConnection: @escaping ConnectionFactory, maxConnections: Int) {
+        self.makeConnection = makeConnection
+        self.maxConnections = maxConnections
+        storage = [:]
+        time = 0
+    }
+    
+    static var threadId: pthread_t {
+        return pthread_self()
+    }
+    
+    func connection() throws -> Connection {
+        if let threadConnection = storage[ThreadConnectionPool.threadId] {
+            return threadConnection.conn
+        } else {
+            let connection: Connection
+            
+            if storage.keys.count >= maxConnections {
+                // remove any closed connections
+                for (pthread, conn) in storage {
+                    if conn.conn.closed {
+                        storage.removeValue(forKey: pthread)
+                    }
+                }
+                
+                // find and re-use the oldest connection
+                var lowestTime: Int = Int.max
+                var oldestPthread: pthread_t?
+                var oldestConn: Connection?
+                
+                for (pthread, conn) in storage {
+                    if conn.time < lowestTime {
+                        oldestPthread = pthread
+                        oldestConn = conn.conn
+                        lowestTime = conn.time
+                    }
+                }
+                
+                if
+                    let p = oldestPthread,
+                    let c = oldestConn
+                {
+                    storage.removeValue(forKey: p)
+                    connection = c
+                } else {
+                    connection = try makeConnection()
+                }
+            } else {
+                connection = try makeConnection()
+            }
+            
+            time += 1
+            
+            storage[ThreadConnectionPool.threadId] = (connection, time)
+            
+            return connection
+        }
+    }
+}

--- a/Sources/Fluent/Database/ThreadConnectionPool.swift
+++ b/Sources/Fluent/Database/ThreadConnectionPool.swift
@@ -2,87 +2,138 @@ import Foundation
 import Core
 
 /**
-    Responsible for maintaing of pool
+    Responsible for maintaing a pool
     of connections, one for each thread.
- 
-    Uses a Driver to make new connections.
 */
 public final class ThreadConnectionPool {
-    var makeConnection: ConnectionFactory
-    var storage: [pthread_t: (conn: Connection, time: Int)]
-    var maxConnections: Int
-    var time: Int
-    var storageLock: Lock
-    
-    public typealias ConnectionFactory = () throws -> Connection
-    
-    init(makeConnection: @escaping ConnectionFactory, maxConnections: Int) {
-        self.makeConnection = makeConnection
-        self.maxConnections = maxConnections
-        storage = [:]
-        time = 0
-        storageLock = Lock()
+
+    /**
+        Thread Pool Errors
+    */
+    public enum Error: Swift.Error {
+        /**
+            Something in our internal lock mechanism has unexpectedly failed 
+            ... should never see this except for more widespread system 
+            dispatch errors
+        */
+        case lockFailure
+
+        /**
+            The maximum number of active connections has been reached and the pool
+            is no longer capable of creating new ones.
+        */
+        case maxConnectionsReached(max: Int)
+
+        /**
+            This is here to allow extensibility w/o breaking apis, it is not currently
+            used, but should be accounted for by end user if they are handling the 
+            error
+        */
+        case unspecified(Swift.Error)
     }
-    
-    static var threadId: pthread_t {
+
+    /**
+        The constructor used by the factory to create new connections
+    */
+    public typealias ConnectionFactory = () throws -> Connection
+
+
+    private static var threadId: pthread_t {
+        // must run every time, do not assign
         return pthread_self()
     }
-    
-    public enum Error: Swift.Error {
-        case lockFailure
+
+    /**
+        The maximum amount of connections permitted in the pool
+    */
+    public var maxConnections: Int
+
+    /**
+        When the maximum amount of connections has been reached and all connections
+        are in use at time of request, how long should the system wait
+        until it gives up and throws an error.
+     
+        default is 10 seconds.
+    */
+    public var connectionPendingTimeoutSeconds: Int = 10
+
+    private var connections: [pthread_t: Connection]
+    private let connectionsLock: NSLock
+    private let makeConnection: ConnectionFactory
+
+    /**
+        Initializes a thread pool with a connectionFactory intended to construct
+        new connections when appropriate and an Integer defining the maximum 
+        number of connections the pool is allowed to make
+    */
+    public init(makeConnection: @escaping ConnectionFactory, maxConnections: Int) {
+        self.makeConnection = makeConnection
+        self.maxConnections = maxConnections
+        connections = [:]
+        connectionsLock = NSLock()
     }
     
-    public func connection() throws -> Connection {
-        if let threadConnection = storage[ThreadConnectionPool.threadId] {
-            return threadConnection.conn
-        } else {
-            var connection: Connection?
-            
-            try storageLock.locked {
-                if storage.keys.count >= maxConnections {
-                    // remove any closed connections
-                    for (pthread, conn) in storage {
-                        if conn.conn.closed {
-                            storage.removeValue(forKey: pthread)
-                        }
-                    }
-                    
-                    // find and re-use the oldest connection
-                    var lowestTime: Int = Int.max
-                    var oldestPthread: pthread_t?
-                    var oldestConn: Connection?
-                    
-                    for (pthread, conn) in storage {
-                        if conn.time < lowestTime {
-                            oldestPthread = pthread
-                            oldestConn = conn.conn
-                            lowestTime = conn.time
-                        }
-                    }
-                    
-                    if
-                        let p = oldestPthread,
-                        let c = oldestConn
-                    {
-                        storage.removeValue(forKey: p)
-                        connection = c
-                    } else {
-                        connection = try makeConnection()
-                    }
-                } else {
-                    connection = try makeConnection()
-                }
+    internal func connection() throws -> Connection {
+        /**
+            Because we might wait inside of the makeNewConnection function, 
+            do NOT attempt to wrap this within connectionLock or it may
+            be blocked from other threads
+         
+            In the makeConnection call, there will be a threadsafe check to prevent
+            creating duplicates.
+         
+            It shouldn't happen that two calls come on same thread anyways, but
+            in the interest of 'just in case'
+        */
+        guard let existing = connections[ThreadConnectionPool.threadId] else { return try makeNewConnection() }
+        return existing
+    }
+
+    private func makeNewConnection() throws -> Connection {
+        // MUST capture threadID OUTSIDE of lock to ensure appropriate thread id is received
+        let threadId = ThreadConnectionPool.threadId
+
+        var connection: Connection?
+        try connectionsLock.locked {
+            /**
+                Just in case our first attempt to access failed in a non thread safe manner
+                to prevent duplicates, we do a quick check here.
+             
+                Likely redundant, but beneficial for safety.
+            */
+            if let existing = connections[threadId] {
+                connection = existing
+                return
             }
-            
-            guard let c = connection else {
-                throw Error.lockFailure
-            }
-            
-            time += 1
-            
-            storage[ThreadConnectionPool.threadId] = (c, time)
-            
-            return c
+
+            // Attempt to make space if possible
+            if connections.keys.count >= maxConnections { clearClosedConnections() }
+            // If space hasn't been created, attempt to wait for space
+            if connections.keys.count >= maxConnections { waitForSpace() }
+            // the maximum number of connections has been created, even after attempting to clear out closed connections
+            if connections.keys.count >= maxConnections { throw Error.maxConnectionsReached(max: maxConnections) }
+            let c = try makeConnection()
+            connections[threadId] = c
+            connection = c
+        }
+
+        guard let c = connection else { throw Error.lockFailure }
+        return c
+    }
+
+    private func waitForSpace() {
+        var waited = 0
+        while waited < connectionPendingTimeoutSeconds, connections.keys.count >= maxConnections {
+            sleep(1)
+            clearClosedConnections()
+            waited += 1
+        }
+    }
+
+    private func clearClosedConnections() {
+        connections.forEach { thread, connection in
+            guard connection.closed else { return }
+            connections[thread] = nil
         }
     }
 }

--- a/Sources/Fluent/Memory/Memory+Filters.swift
+++ b/Sources/Fluent/Memory/Memory+Filters.swift
@@ -148,6 +148,10 @@ extension Node {
             case .or:
                 return passesOne(filters)
             }
+        case .raw(command: let command, values: let values):
+            // TODO: Throw error, memory DB doesn't support raw?
+            print("not handling \(command) values \(values)")
+            return true
         }
         return false
 

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -83,7 +83,7 @@ public class Query<T: Entity>: QueryRepresentable {
     */
     @discardableResult
     public func raw() throws -> Node {
-        return try database.driver.query(self)
+        return try database.query(self)
     }
 
     /**

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -236,6 +236,9 @@ open class GeneralSQLSerializer: SQLSerializer {
             let (clause, subvals) = sql(filters, relation: relation)
             statement += "(\(clause))"
             values += subvals
+        case .raw(command: let command, values: let subvalues):
+            statement += command
+            values += subvalues
         }
 
         return (

--- a/Sources/Fluent/Schema/Database+Schema.swift
+++ b/Sources/Fluent/Schema/Database+Schema.swift
@@ -6,7 +6,7 @@ extension Database {
     public func modify(_ entity: String, closure: (Schema.Modifier) throws -> ()) throws {
         let modifier = Schema.Modifier(entity)
         try closure(modifier)
-        _ = try driver.schema(modifier.schema)
+        _ = try schema(modifier.schema)
     }
 
     /**
@@ -16,7 +16,7 @@ extension Database {
     public func create(_ entity: String, closure: (Schema.Creator) throws -> ()) throws {
         let creator = Schema.Creator(entity)
         try closure(creator)
-        _ = try driver.schema(creator.schema)
+        _ = try schema(creator.schema)
     }
 
     /**
@@ -25,6 +25,6 @@ extension Database {
     */
     public func delete(_ entity: String) throws {
         let schema = Schema.delete(entity: entity)
-        _ = try driver.schema(schema)
+        _ = try self.schema(schema)
     }
 }

--- a/Tests/FluentTests/MemoryTests.swift
+++ b/Tests/FluentTests/MemoryTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import Fluent
+import Dispatch
 
 class MemoryTests: XCTestCase {
     static var allTests = [
@@ -24,6 +25,7 @@ class MemoryTests: XCTestCase {
         var user = User(id: nil, name: "Vapor", email: "test@email.com")
         let query = Query<User>(database)
         try query.save(&user)
+        
         XCTAssertEqual(user.id?.int, 1)
         XCTAssertEqual(driver.store["users"]?.data.count, 1)
     }

--- a/Tests/FluentTests/ModelFindTests.swift
+++ b/Tests/FluentTests/ModelFindTests.swift
@@ -34,22 +34,36 @@ class ModelFindTests: XCTestCase {
         enum Error: Swift.Error {
             case broken
         }
-
+        
+        func makeConnection() throws -> Connection {
+            return DummyConnection(driver: self)
+        }
+    }
+    
+    class DummyConnection: Connection {
+        public var closed: Bool = false
+        
+        var driver: DummyDriver
+        
+        init(driver: DummyDriver) {
+            self.driver = driver
+        }
+        
         func query<T: Entity>(_ query: Query<T>) throws -> Node {
             if
                 let filter = query.filters.first,
                 case .compare(let key, let comparison, let value) = filter.method,
                 query.action == .fetch &&
                     query.filters.count == 1 &&
-                    key == idKey &&
+                    key == driver.idKey &&
                     comparison == .equals
             {
                 if value.int == 42 {
                     return .array([
-                        .object([idKey: 42])
+                        .object([driver.idKey: 42])
                     ])
                 } else if value.int == 500 {
-                    throw Error.broken
+                    throw DummyDriver.Error.broken
                 }
             }
             

--- a/Tests/FluentTests/PreparationTests.swift
+++ b/Tests/FluentTests/PreparationTests.swift
@@ -153,16 +153,31 @@ class TestPreparation: Preparation {
 class TestSchemaDriver: Driver {
     var idKey: String = "id"
 
-    @discardableResult
-    func query<T: Entity>(_ query: Query<T>) throws -> Node { return .null }
-
     var testClosure: (Schema) -> ()
     init(testClosure: @escaping (Schema) -> ()) {
         self.testClosure = testClosure
     }
+    
+    func makeConnection() throws -> Connection {
+        return TestSchemaConnection(driver: self)
+    }
+}
+
+struct TestSchemaConnection: Connection {
+    public var closed: Bool = false
+    
+    var driver: TestSchemaDriver
+    
+    init(driver: TestSchemaDriver) {
+        self.driver = driver
+    }
+    
+    @discardableResult
+    func query<T: Entity>(_ query: Query<T>) throws -> Node { return .null }
+
 
     func schema(_ schema: Schema) throws {
-        testClosure(schema)
+        driver.testClosure(schema)
     }
 
 

--- a/Tests/FluentTests/Utilities/Dummy.swift
+++ b/Tests/FluentTests/Utilities/Dummy.swift
@@ -28,6 +28,14 @@ class DummyDriver: Driver {
     enum Error: Swift.Error {
         case broken
     }
+    
+    func makeConnection() throws -> Connection {
+        return DummyConnection()
+    }
+}
+
+class DummyConnection: Connection {
+    public var closed: Bool = false
 
     func query<T: Entity>(_ query: Query<T>) throws -> Node {
         if query.action == .count {

--- a/Tests/FluentTests/Utilities/LastQueryDriver.swift
+++ b/Tests/FluentTests/Utilities/LastQueryDriver.swift
@@ -6,21 +6,35 @@ class LastQueryDriver: Driver {
     var lastQuery: SQL?
     var lastSchema: Schema?
     var lastRaw: (String, [Node])?
+    
+    func makeConnection() throws -> Connection {
+        return LastQueryConnection(driver: self)
+    }
+}
 
+struct LastQueryConnection: Connection {
+    public var closed: Bool = false
+    
+    var driver: LastQueryDriver
+    
+    init(driver: LastQueryDriver) {
+        self.driver = driver
+    }
+    
     @discardableResult
     func query<T: Entity>(_ query: Query<T>) throws -> Node {
         let sql = query.sql
-        lastQuery = sql
+        driver.lastQuery = sql
         print("[LQD] \(sql)")
-        return Node.object([idKey: 5])
+        return Node.object([driver.idKey: 5])
     }
 
     func schema(_ schema: Schema) throws {
-        lastSchema = schema
+        driver.lastSchema = schema
     }
 
     func raw(_ raw: String, _ values: [Node]) throws -> Node {
-        lastRaw = (raw, values)
+        driver.lastRaw = (raw, values)
         return .null
     }
 }


### PR DESCRIPTION
This pull request solves bugs and performance issues related to Fluent's query protocols:
- Inability to perform transactions in MySQL and Postgres
- Unnecessary connection creation overhead for multiple queries ran at once

A new `Connection` protocol is added that will allow Fluent to create pools of re-usable connections. 

This will:

- Speed up multiple Fluent queries that happen during one Vapor request/response cycle.
- Allow things like transactions that require multiple queries to go over the same connection.

This thread-based approach is simple to implement, but may have some underwater rocks. The only other approach I can think of is to include a pointer to the current connection in `Request`. This pointer would then need to be passed to all queries that should happen on that connection. Obviously a lot clunkier and a bigger change to the API.

Related to https://github.com/vapor/mysql-driver/pull/28

TODO:
- [ ] Fully comment
- [ ] allow manual connection in query init and Model make query init
- [ ] Method for passing max connections to Fluent (probably a `fluent.json` file)

https://github.com/nodes-vapor/readme/issues/15