### PR TITLE
Adding optional offset to limit() function

### DIFF
--- a/Sources/Fluent/Query/Limit.swift
+++ b/Sources/Fluent/Query/Limit.swift
@@ -27,9 +27,9 @@ extension QueryRepresentable {
         Limits the count of results returned
         by the `Query`.
     */
-    public func limit(_ count: Int) throws -> Query<T> {
+    public func limit(_ count: Int, withOffset offset: Int = 0) throws -> Query<T> {
         let query = try makeQuery()
-        query.limit = Limit(count: count)
+        query.limit = Limit(count: count, offset: offset)
         return query
     }
 }


### PR DESCRIPTION
This PR solve issue https://github.com/vapor/fluent/issues/135 adding offset as a new optional parameter, very handy for pagination.