### PR TITLE
Support for Limit in Fluent InMemory Database

### DIFF
--- a/Sources/Fluent/Memory/Memory+Group.swift
+++ b/Sources/Fluent/Memory/Memory+Group.swift
@@ -22,8 +22,26 @@ extension MemoryDriver {
             data = data.fails(filters)
         }
 
-        func fetch(_ filters: [Filter], _ sorts: [Sort]) -> [Node] {
-            return data.passes(filters).sort(sorts)
+        func fetch(_ filters: [Filter], _ sorts: [Sort], _ limit: Limit? = nil) -> [Node] {
+            var dataToReturn = data.passes(filters).sort(sorts)
+            
+            if let limit = limit {
+                if dataToReturn.count > 0 {
+                    var count = limit.count + limit.offset - 1
+                    
+                    if limit.offset > dataToReturn.count {
+                        return []
+                    }
+                    
+                    if count > dataToReturn.count {
+                        count = dataToReturn.count - 1
+                    }
+                    
+                    dataToReturn = Array(dataToReturn[limit.offset...count])
+                }
+            }
+            
+            return dataToReturn
         }
 
         func modify(_ update: Node, filters: [Filter]) -> [Node] {

--- a/Sources/Fluent/Memory/MemoryDriver.swift
+++ b/Sources/Fluent/Memory/MemoryDriver.swift
@@ -31,7 +31,7 @@ public final class MemoryDriver: Driver {
                 group = prepare(union: union)
             }
             
-            let results = group.fetch(query.filters, query.sorts)
+            let results = group.fetch(query.filters, query.sorts, query.limit)
 
             return Node.array(results)
         case .count:

--- a/Tests/FluentTests/MemoryTests.swift
+++ b/Tests/FluentTests/MemoryTests.swift
@@ -205,4 +205,38 @@ class MemoryTests: XCTestCase {
         XCTAssertEqual(fetched.count, 0)
         XCTAssertEqual(driver.store["users"]?.data.count, 3)
     }
+    
+    func testFetchWithLimitWithOffsetInMiddleAndCountGreaterThanRemainingContents() throws {
+        let (driver, database) = makeTestModels()
+        
+        var new = User(id: nil, name: "Vapor", email: "test@email.com")
+        var new2 = User(id: nil, name: "Vapor2", email: "test2@email.com")
+        var new3 = User(id: nil, name: "Vapor3", email: "test3@email.com")
+        var new4 = User(id: nil, name: "Vapor4", email: "test4@email.com")
+        var new5 = User(id: nil, name: "Vapor5", email: "test5@email.com")
+        var new6 = User(id: nil, name: "Vapor6", email: "test6@email.com")
+        var new7 = User(id: nil, name: "Vapor7", email: "test7@email.com")
+        var new8 = User(id: nil, name: "Vapor8", email: "test8@email.com")
+        var new9 = User(id: nil, name: "Vapor9", email: "test9@email.com")
+        
+        let store = Query<User>(database)
+        try store.save(&new)
+        try store.save(&new2)
+        try store.save(&new3)
+        try store.save(&new4)
+        try store.save(&new5)
+        try store.save(&new6)
+        try store.save(&new7)
+        try store.save(&new8)
+        try store.save(&new9)
+        
+        let limit = Limit(count: 10, offset: 5)
+        let query = Query<User>(database)
+        query.limit = limit
+        
+        let fetched = try query.all()
+        XCTAssertEqual(fetched.count, 4)
+        XCTAssertEqual(driver.store["users"]?.data.count, 9)
+
+    }
 }

--- a/Tests/FluentTests/MemoryTests.swift
+++ b/Tests/FluentTests/MemoryTests.swift
@@ -9,6 +9,11 @@ class MemoryTests: XCTestCase {
         ("testModify", testModify),
         ("testSort", testSort),
         ("testCount", testCount),
+        ("testFetchWithLimit", testFetchWithLimit),
+        ("testFetchWithLimitAndOffset", testFetchWithLimitAndOffset),
+        ("testFetchWithLimitWithSizeGreaterThatContents", testFetchWithLimitWithSizeGreaterThatContents),
+        ("testFetchWithLimitWithOffsetGreaterThanContents", testFetchWithLimitWithOffsetGreaterThanContents),
+        ("testFetchWithLimitWithOffsetAndSizeGreaterThanContents", testFetchWithLimitWithOffsetAndSizeGreaterThanContents),
     ]
 
     func makeTestModels() -> (MemoryDriver, Database) {
@@ -109,5 +114,93 @@ class MemoryTests: XCTestCase {
         
         let count3 = try Query<User>(database).filter("name", "Test").count()
         XCTAssertEqual(count3, 0)
+    }
+    
+    func testFetchWithLimit() throws {
+        let (driver, database) = makeTestModels()
+        
+        var new = User(id: nil, name: "Vapor", email: "test@email.com")
+        var new2 = User(id: nil, name: "Vapor2", email: "test2@email.com")
+        let store = Query<User>(database)
+        try store.save(&new)
+        try store.save(&new2)
+        
+        let fetched = try Query<User>(database).limit(1).all()
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(driver.store["users"]?.data.count, 2)
+    }
+    
+    func testFetchWithLimitAndOffset() throws {
+        let (driver, database) = makeTestModels()
+        
+        var new = User(id: nil, name: "Vapor", email: "test@email.com")
+        var new2 = User(id: nil, name: "Vapor2", email: "test2@email.com")
+        var new3 = User(id: nil, name: "Vapor3", email: "test3@email.com")
+        let store = Query<User>(database)
+        try store.save(&new)
+        try store.save(&new2)
+        try store.save(&new3)
+        
+        let limit = Limit(count: 1, offset: 1)
+        let query = Query<User>(database)
+        query.limit = limit
+        
+        let fetched = try query.all()
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(driver.store["users"]?.data.count, 3)
+    }
+    
+    func testFetchWithLimitWithSizeGreaterThatContents() throws {
+        let (driver, database) = makeTestModels()
+        
+        var new = User(id: nil, name: "Vapor", email: "test@email.com")
+        var new2 = User(id: nil, name: "Vapor2", email: "test2@email.com")
+        let store = Query<User>(database)
+        try store.save(&new)
+        try store.save(&new2)
+        
+        let fetched = try Query<User>(database).limit(10).all()
+        XCTAssertEqual(fetched.count, 2)
+        XCTAssertEqual(driver.store["users"]?.data.count, 2)
+    }
+    
+    func testFetchWithLimitWithOffsetGreaterThanContents() throws {
+        let (driver, database) = makeTestModels()
+        
+        var new = User(id: nil, name: "Vapor", email: "test@email.com")
+        var new2 = User(id: nil, name: "Vapor2", email: "test2@email.com")
+        var new3 = User(id: nil, name: "Vapor3", email: "test3@email.com")
+        let store = Query<User>(database)
+        try store.save(&new)
+        try store.save(&new2)
+        try store.save(&new3)
+        
+        let limit = Limit(count: 1, offset: 5)
+        let query = Query<User>(database)
+        query.limit = limit
+        
+        let fetched = try query.all()
+        XCTAssertEqual(fetched.count, 0)
+        XCTAssertEqual(driver.store["users"]?.data.count, 3)
+    }
+    
+    func testFetchWithLimitWithOffsetAndSizeGreaterThanContents() throws {
+        let (driver, database) = makeTestModels()
+        
+        var new = User(id: nil, name: "Vapor", email: "test@email.com")
+        var new2 = User(id: nil, name: "Vapor2", email: "test2@email.com")
+        var new3 = User(id: nil, name: "Vapor3", email: "test3@email.com")
+        let store = Query<User>(database)
+        try store.save(&new)
+        try store.save(&new2)
+        try store.save(&new3)
+        
+        let limit = Limit(count: 10, offset: 5)
+        let query = Query<User>(database)
+        query.limit = limit
+        
+        let fetched = try query.all()
+        XCTAssertEqual(fetched.count, 0)
+        XCTAssertEqual(driver.store["users"]?.data.count, 3)
     }
 }

--- a/Tests/FluentTests/MemoryTests.swift
+++ b/Tests/FluentTests/MemoryTests.swift
@@ -127,6 +127,7 @@ class MemoryTests: XCTestCase {
         
         let fetched = try Query<User>(database).limit(1).all()
         XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.id, new.id)
         XCTAssertEqual(driver.store["users"]?.data.count, 2)
     }
     
@@ -147,6 +148,7 @@ class MemoryTests: XCTestCase {
         
         let fetched = try query.all()
         XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.id, new2.id)
         XCTAssertEqual(driver.store["users"]?.data.count, 3)
     }
     
@@ -163,7 +165,7 @@ class MemoryTests: XCTestCase {
         XCTAssertEqual(fetched.count, 2)
         XCTAssertEqual(driver.store["users"]?.data.count, 2)
     }
-    
+
     func testFetchWithLimitWithOffsetGreaterThanContents() throws {
         let (driver, database) = makeTestModels()
         
@@ -183,7 +185,7 @@ class MemoryTests: XCTestCase {
         XCTAssertEqual(fetched.count, 0)
         XCTAssertEqual(driver.store["users"]?.data.count, 3)
     }
-    
+
     func testFetchWithLimitWithOffsetAndSizeGreaterThanContents() throws {
         let (driver, database) = makeTestModels()
         


### PR DESCRIPTION
This PR addresses #162 and adds support for `Limit`s on a query on the InMemory database, with tests to support the new behaviour.

Happy to discuss the behaviour of what happens when the offset is greater than the number of rows in the database. Current behaviour is that if the offset is greater than the size of the database, an empty result is returned. If the offset + count is greater than the size of the database, then the remaining rows are returned from the offset. There are tests to describe this behaviour.