### PR TITLE
Add missing test from previous PR

### DIFF
--- a/Tests/FluentTests/MemoryTests.swift
+++ b/Tests/FluentTests/MemoryTests.swift
@@ -14,6 +14,7 @@ class MemoryTests: XCTestCase {
         ("testFetchWithLimitWithSizeGreaterThatContents", testFetchWithLimitWithSizeGreaterThatContents),
         ("testFetchWithLimitWithOffsetGreaterThanContents", testFetchWithLimitWithOffsetGreaterThanContents),
         ("testFetchWithLimitWithOffsetAndSizeGreaterThanContents", testFetchWithLimitWithOffsetAndSizeGreaterThanContents),
+        ("testFetchWithLimitWithOffsetInMiddleAndCountGreaterThanRemainingContents", testFetchWithLimitWithOffsetInMiddleAndCountGreaterThanRemainingContents),
     ]
 
     func makeTestModels() -> (MemoryDriver, Database) {


### PR DESCRIPTION
Only a minor change, just adds a missing test into the `all_tests` array that was added in #163 for completeness.