### PR TITLE
Generalise the field type used for DataType.id from int

### DIFF
--- a/Sources/Fluent/Database/Driver.swift
+++ b/Sources/Fluent/Database/Driver.swift
@@ -14,6 +14,14 @@ public protocol Driver {
         by identifier methods are used.
     */
     var idKey: String { get }
+    
+    /**
+        The default type for values stored against the identifier key.
+     
+        The `idType` will be accessed by those Entity implementations
+        which do not themselves implement `Entity.idType`.
+    */
+    var idType: Schema.Field.KeyType { get }
 
     /**
         Executes a `Query` from and
@@ -45,5 +53,9 @@ extension Driver {
     public func raw(_ raw: String, _ values: [NodeRepresentable] = []) throws -> Node {
         let nodes = try values.map { try $0.makeNode() }
         return try self.raw(raw, nodes)
+    }
+    
+    public var idType: Schema.Field.KeyType {
+        return .int
     }
 }

--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -27,7 +27,7 @@ public protocol Entity: Preparation, NodeConvertible {
     */
     var id: Node? { get set }
     
-    static var idType: Schema.Field.KeyType? { get }
+    static var idType: Schema.Field.KeyType { get }
 
     /**
         Whether or not entity was retrieved from database.
@@ -85,8 +85,8 @@ extension Entity {
         return String(describing: self).lowercased()
     }
     
-    public static var idType: Schema.Field.KeyType? {
-        return nil
+    public static var idType: Schema.Field.KeyType {
+        return database?.driver.idType ?? .int
     }
 
     // FIXME: Remove in 2.0. Also, make exists optional.

--- a/Sources/Fluent/Preparation/Migration.swift
+++ b/Sources/Fluent/Preparation/Migration.swift
@@ -23,7 +23,7 @@ final class Migration: Entity {
 
     static func prepare(_ database: Database) throws {
         try database.create(entity) { builder in
-            builder.id()
+            builder.id(for: self)
             builder.string("name")
         }
     }

--- a/Sources/Fluent/Query/Join.swift
+++ b/Sources/Fluent/Query/Join.swift
@@ -90,7 +90,7 @@ public final class Pivot<
 
     public static func prepare(_ database: Database) throws {
         try database.create(entity) { builder in
-            builder.id()
+            builder.id(for: self)
             builder.pivotKeys(left: left, right: right, suffix: "_\(database.driver.idKey)")
         }
     }

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -403,9 +403,8 @@ open class GeneralSQLSerializer: SQLSerializer {
 
     open func sql(_ type: Schema.Field.DataType) -> String {
         switch type {
-        case .id(let type):
-            let keyType = type ?? Schema.Field.KeyType.int
-            switch keyType {
+        case .id(let keyType):
+            switch keyType ?? Schema.Field.KeyType.int {
             case .int:
                 return "INTEGER PRIMARY KEY"
                 

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -408,8 +408,8 @@ open class GeneralSQLSerializer: SQLSerializer {
             case .int:
                 return "INTEGER PRIMARY KEY"
                 
-            case .string(_):
-                return "STRING PRIMARY KEY"
+            case .string(let length):
+                return "VARCHAR(\(length ?? 128)) PRIMARY KEY"
                 
             case .custom(let type):
                 return "\(type) PRIMARY KEY"

--- a/Sources/Fluent/Schema/Schema+Creator.swift
+++ b/Sources/Fluent/Schema/Schema+Creator.swift
@@ -13,20 +13,9 @@ extension Schema {
             fields = []
         }
         
-        public func id(
-            _ name: String = "id",
-            type: Field.KeyType? = nil,
-            optional: Bool = false,
-            unique: Bool = false,
-            default: NodeRepresentable? = nil
-        ) {
-            fields += Field(
-                name: name,
-                type: .id(keyType: type),
-                optional: optional,
-                unique: unique,
-                default: `default`
-            )
+        public func id(for entityType: Entity.Type, name: String = "id")
+        {
+            fields += Field(name: name, type: .id(keyType: entityType.idType))
         }
 
         public func int(
@@ -135,7 +124,7 @@ extension Schema {
         ) {
             fields += Field(
                 name: "\(entity.name)_id",
-                type: E.idType?.fieldType ?? .int,
+                type: E.idType.fieldType,
                 optional: optional,
                 unique: unique,
                 default: `default`
@@ -147,8 +136,8 @@ extension Schema {
             right: Entity.Type,
             suffix: String
         ) {
-            let leftKeyType = left.idType ?? Schema.Field.KeyType.int
-            let rightKeyType = right.idType ?? Schema.Field.KeyType.int
+            let leftKeyType = left.idType
+            let rightKeyType = right.idType
             
             let leftName = "\(left.name)\(suffix)"
             let rightName = "\(right.name)\(suffix)"

--- a/Sources/Fluent/Schema/Schema+Creator.swift
+++ b/Sources/Fluent/Schema/Schema+Creator.swift
@@ -22,7 +22,7 @@ extension Schema {
         ) {
             fields += Field(
                 name: name,
-                type: .id(type: type),
+                type: .id(keyType: type),
                 optional: optional,
                 unique: unique,
                 default: `default`
@@ -135,7 +135,7 @@ extension Schema {
         ) {
             fields += Field(
                 name: "\(entity.name)_id",
-                type: E.idType?.dataType ?? .int,
+                type: E.idType?.fieldType ?? .int,
                 optional: optional,
                 unique: unique,
                 default: `default`
@@ -154,12 +154,12 @@ extension Schema {
             let rightName = "\(right.name)\(suffix)"
             
             fields += Field(name: leftName,
-                            type: leftKeyType.dataType,
+                            type: leftKeyType.fieldType,
                             optional: false,
                             unique: false)
             
             fields += Field(name: rightName,
-                            type: rightKeyType.dataType,
+                            type: rightKeyType.fieldType,
                             optional: false,
                             unique: false)
         }

--- a/Sources/Fluent/Schema/Schema+Field.swift
+++ b/Sources/Fluent/Schema/Schema+Field.swift
@@ -11,7 +11,7 @@ extension Schema {
         public var `default`: Node?
 
         public enum DataType {
-            case id(type: KeyType?)
+            case id(keyType: KeyType?)
             case int
             case string(length: Int?)
             case double
@@ -25,7 +25,7 @@ extension Schema {
             case string(length: Int?)
             case custom(type: String)
             
-            var dataType: DataType {
+            var fieldType: DataType {
                 switch self {
                 case .int:
                     return .int

--- a/Sources/FluentTester/Atom.swift
+++ b/Sources/FluentTester/Atom.swift
@@ -38,7 +38,7 @@ public final class Atom: Entity {
 
     public static func prepare(_ database: Database) throws {
         try database.create(entity) { atoms in
-            atoms.id()
+            atoms.id(for: self)
             atoms.string("name")
             atoms.int("protons")
             atoms.double("weight")

--- a/Sources/FluentTester/Compound.swift
+++ b/Sources/FluentTester/Compound.swift
@@ -28,7 +28,7 @@ public final class Compound: Entity {
 
     public static func prepare(_ database: Fluent.Database) throws {
         try database.create(entity) { builder in
-            builder.id()
+            builder.id(for: self)
             builder.string("name")
         }
     }

--- a/Sources/FluentTester/Student.swift
+++ b/Sources/FluentTester/Student.swift
@@ -41,7 +41,7 @@ final class Student: Entity {
     
     static func prepare(_ database: Database) throws {
         try database.create("students") { students in
-            students.id()
+            students.id(for: self)
             students.string("name", length: 64)
             students.int("age")
             students.string("ssn", unique: true)

--- a/Tests/FluentTests/ModelTests.swift
+++ b/Tests/FluentTests/ModelTests.swift
@@ -34,4 +34,38 @@ class ModelTests: XCTestCase {
 
         try atom.delete()
     }
+    
+    func testStringIdentifiedThings() throws {
+        StringIdentifiedThing.database = db
+        var thing = try! StringIdentifiedThing(node: ["id": "derp"], in: EmptyNode)
+        
+        try! thing.save()
+        let saveQ = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
+        XCTAssertEqual(saveQ.0, "INSERT INTO `stringidentifiedthings` (`id`) VALUES (?)")
+        XCTAssertEqual(saveQ.1, ["derp"])
+        XCTAssertTrue(thing.exists)
+        
+        _ = try! StringIdentifiedThing.find("derp")
+        let findQ = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
+
+        XCTAssertEqual(findQ.0, "SELECT `stringidentifiedthings`.* FROM `stringidentifiedthings` WHERE `stringidentifiedthings`.`#id` = ? LIMIT 0, 1")
+        XCTAssertEqual(findQ.1, ["derp"])
+    }
+    
+    func testCustomIdentifiedThings() throws {
+        CustomIdentifiedThing.database = db
+        var thing = try! CustomIdentifiedThing(node: ["id": 123], in: EmptyNode)
+        
+        try! thing.save()
+        let saveQ = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
+        XCTAssertEqual(saveQ.0, "INSERT INTO `customidentifiedthings` (`id`) VALUES (?)")
+        XCTAssertEqual(saveQ.1, [123])
+        XCTAssertTrue(thing.exists)
+        
+        _ = try! CustomIdentifiedThing.find(123)
+        let findQ = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
+        
+        XCTAssertEqual(findQ.0, "SELECT `customidentifiedthings`.* FROM `customidentifiedthings` WHERE `customidentifiedthings`.`#id` = ? LIMIT 0, 1")
+        XCTAssertEqual(findQ.1, [123])
+    }
 }

--- a/Tests/FluentTests/PreparationTests.swift
+++ b/Tests/FluentTests/PreparationTests.swift
@@ -56,6 +56,40 @@ class PreparationTests: XCTestCase {
             XCTFail("Preparation failed: \(error)")
         }
     }
+    
+    func testStringIdentifiedModelPreparation() {
+        let driver = TestSchemaDriver { schema in
+            guard case .create(let entity, let fields) = schema else {
+                XCTFail("Invalid schema")
+                return
+            }
+            
+            XCTAssertEqual(entity, "stringidentifiedthings")
+            
+            guard fields.count == 1 else {
+                XCTFail("Invalid field count")
+                return
+            }
+            
+            guard case .id(let keyType?) = fields[0].type else {
+                XCTFail("Invalid first field \(fields[0])")
+                return
+            }
+            
+            guard case .string(let length) = keyType, length == 10 else {
+                XCTFail("Invalid key type \(keyType) for id")
+                return
+            }
+        }
+        
+        let database = Database(driver)
+        
+        do {
+            try database.prepare(StringIdentifiedThing.self)
+        } catch {
+            XCTFail("Preparation failed: \(error)")
+        }
+    }
 
     func testModelPreparation() {
         let driver = TestSchemaDriver { schema in

--- a/Tests/FluentTests/PreparationTests.swift
+++ b/Tests/FluentTests/PreparationTests.swift
@@ -124,7 +124,7 @@ final class TestModel: Entity {
 
     static func prepare(_ database: Database) throws {
         try database.create(entity) { builder in
-            builder.id()
+            builder.id(for: self)
             builder.string("name")
             builder.int("age")
         }

--- a/Tests/FluentTests/SchemaCreateTests.swift
+++ b/Tests/FluentTests/SchemaCreateTests.swift
@@ -26,74 +26,24 @@ class SchemaCreateTests: XCTestCase {
         XCTAssertEqual(values.count, 0)
     }
     
-    private struct StringlyIdentifiedThing: Entity {
-        
-        var id:Node? = nil
-        
-        // for structs, it appears the name mangled version makes it through to SQL serializer otherwise.
-        static var name = "StringlyIdentifiedThings"
-        
-        init(node: Node, in context: Context) throws {
-            id = try node.extract("id")
-        }
-        
-        func makeNode(context: Context = EmptyNode) throws -> Node {
-            return try Node(node: ["id": id])
-        }
-        
-        static var idType: Schema.Field.KeyType { return .string(length: 10) }
-        
-        static func prepare(_ database: Database) throws {
-            preconditionFailure("This type exists purely to drive a specific schema creation test.")
-        }
-        
-        static func revert(_ database: Database) throws {
-            preconditionFailure("This type exists purely to drive a specific schema creation test.")
-        }
-    }
     
-    func testStringlyIdentifiedEntity() throws {
-        let builder = Schema.Creator(StringlyIdentifiedThing.name)
+    func testStringIdentifiedEntity() throws {
+        let builder = Schema.Creator(StringIdentifiedThing.entity)
         
-        builder.id(for: StringlyIdentifiedThing.self)
+        builder.id(for: StringIdentifiedThing.self)
         
         let sql = builder.schema.sql
         let serializer = GeneralSQLSerializer(sql: sql)
         
         let (statement, values) = serializer.serialize()
         
-        XCTAssertEqual(statement, "CREATE TABLE `StringlyIdentifiedThings` (`id` VARCHAR(10) PRIMARY KEY NOT NULL)")
+        XCTAssertEqual(statement, "CREATE TABLE `stringidentifiedthings` (`id` VARCHAR(10) PRIMARY KEY NOT NULL)")
         XCTAssertEqual(values.count, 0)
     }
-    
-    private struct CustomIdentifiedThing: Entity {
-        
-        var id:Node? = nil
-        
-        // for structs, it appears the name mangled version makes it through to SQL serializer otherwise.
-        static var name = "CustomIdentifiedThings"
-        
-        init(node: Node, in context: Context) throws {
-            id = try node.extract("id")
-        }
-        
-        func makeNode(context: Context = EmptyNode) throws -> Node {
-            return try Node(node: ["id": id])
-        }
-        
-        static var idType: Schema.Field.KeyType { return .custom(type: "INTEGER") }
-        
-        static func prepare(_ database: Database) throws {
-            preconditionFailure("This type exists purely to drive a specific schema creation test.")
-        }
-        
-        static func revert(_ database: Database) throws {
-            preconditionFailure("This type exists purely to drive a specific schema creation test.")
-        }
-    }
+ 
     
     func testCustomIdentifiedEntity() throws {
-        let builder = Schema.Creator(CustomIdentifiedThing.name)
+        let builder = Schema.Creator(CustomIdentifiedThing.entity)
         
         builder.id(for: CustomIdentifiedThing.self)
         
@@ -102,7 +52,7 @@ class SchemaCreateTests: XCTestCase {
         
         let (statement, values) = serializer.serialize()
         
-        XCTAssertEqual(statement, "CREATE TABLE `CustomIdentifiedThings` (`id` INTEGER PRIMARY KEY NOT NULL)")
+        XCTAssertEqual(statement, "CREATE TABLE `customidentifiedthings` (`id` INTEGER PRIMARY KEY NOT NULL)")
         XCTAssertEqual(values.count, 0)
     }
     

--- a/Tests/FluentTests/SchemaCreateTests.swift
+++ b/Tests/FluentTests/SchemaCreateTests.swift
@@ -26,6 +26,86 @@ class SchemaCreateTests: XCTestCase {
         XCTAssertEqual(values.count, 0)
     }
     
+    private struct StringlyIdentifiedThing: Entity {
+        
+        var id:Node? = nil
+        
+        // for structs, it appears the name mangled version makes it through to SQL serializer otherwise.
+        static var name = "StringlyIdentifiedThings"
+        
+        init(node: Node, in context: Context) throws {
+            id = try node.extract("id")
+        }
+        
+        func makeNode(context: Context = EmptyNode) throws -> Node {
+            return try Node(node: ["id": id])
+        }
+        
+        static var idType: Schema.Field.KeyType { return .string(length: 10) }
+        
+        static func prepare(_ database: Database) throws {
+            preconditionFailure("This type exists purely to drive a specific schema creation test.")
+        }
+        
+        static func revert(_ database: Database) throws {
+            preconditionFailure("This type exists purely to drive a specific schema creation test.")
+        }
+    }
+    
+    func testStringlyIdentifiedEntity() throws {
+        let builder = Schema.Creator(StringlyIdentifiedThing.name)
+        
+        builder.id(for: StringlyIdentifiedThing.self)
+        
+        let sql = builder.schema.sql
+        let serializer = GeneralSQLSerializer(sql: sql)
+        
+        let (statement, values) = serializer.serialize()
+        
+        XCTAssertEqual(statement, "CREATE TABLE `StringlyIdentifiedThings` (`id` VARCHAR(10) PRIMARY KEY NOT NULL)")
+        XCTAssertEqual(values.count, 0)
+    }
+    
+    private struct CustomIdentifiedThing: Entity {
+        
+        var id:Node? = nil
+        
+        // for structs, it appears the name mangled version makes it through to SQL serializer otherwise.
+        static var name = "CustomIdentifiedThings"
+        
+        init(node: Node, in context: Context) throws {
+            id = try node.extract("id")
+        }
+        
+        func makeNode(context: Context = EmptyNode) throws -> Node {
+            return try Node(node: ["id": id])
+        }
+        
+        static var idType: Schema.Field.KeyType { return .custom(type: "INTEGER") }
+        
+        static func prepare(_ database: Database) throws {
+            preconditionFailure("This type exists purely to drive a specific schema creation test.")
+        }
+        
+        static func revert(_ database: Database) throws {
+            preconditionFailure("This type exists purely to drive a specific schema creation test.")
+        }
+    }
+    
+    func testCustomIdentifiedEntity() throws {
+        let builder = Schema.Creator(CustomIdentifiedThing.name)
+        
+        builder.id(for: CustomIdentifiedThing.self)
+        
+        let sql = builder.schema.sql
+        let serializer = GeneralSQLSerializer(sql: sql)
+        
+        let (statement, values) = serializer.serialize()
+        
+        XCTAssertEqual(statement, "CREATE TABLE `CustomIdentifiedThings` (`id` INTEGER PRIMARY KEY NOT NULL)")
+        XCTAssertEqual(values.count, 0)
+    }
+    
     func testStringDefault() throws {
         let builder = Schema.Creator("table")
         

--- a/Tests/FluentTests/Utilities/Atom.swift
+++ b/Tests/FluentTests/Utilities/Atom.swift
@@ -43,7 +43,7 @@ struct Atom: Entity {
 
     static func prepare(_ database: Fluent.Database) throws {
         try database.create(entity) { builder in
-            builder.id()
+            builder.id(for: self)
             builder.string("name")
             builder.int("group_id")
         }

--- a/Tests/FluentTests/Utilities/Compound.swift
+++ b/Tests/FluentTests/Utilities/Compound.swift
@@ -19,7 +19,7 @@ final class Compound: Entity {
 
     static func prepare(_ database: Fluent.Database) throws {
         try database.create(entity) { builder in
-            builder.id()
+            builder.id(for: self)
             builder.string("name")
         }
     }

--- a/Tests/FluentTests/Utilities/CustomIdentifiedThing.swift
+++ b/Tests/FluentTests/Utilities/CustomIdentifiedThing.swift
@@ -1,0 +1,36 @@
+//
+//  CustomIdentifiedThing.swift
+//  Fluent
+//
+//  Created by Matias Piipari on 10/02/2017.
+//
+//
+
+import Foundation
+import Fluent
+
+struct CustomIdentifiedThing: Entity {
+    
+    var id:Node? = nil
+    var exists: Bool = false
+    
+    init(node: Node, in context: Context) throws {
+        id = try node.extract("id")
+    }
+    
+    func makeNode(context: Context = EmptyNode) throws -> Node {
+        return try Node(node: ["id": id])
+    }
+    
+    static var idType: Schema.Field.KeyType { return .custom(type: "INTEGER") }
+    
+    static func prepare(_ database: Database) throws {
+        try database.create(entity) { creator throws in
+            creator.id(for: self)
+        }
+    }
+    
+    static func revert(_ database: Database) throws {
+        try database.delete(entity)
+    }
+}

--- a/Tests/FluentTests/Utilities/StringIdentifiedThing.swift
+++ b/Tests/FluentTests/Utilities/StringIdentifiedThing.swift
@@ -1,0 +1,37 @@
+//
+//  StringIdentifiedThing.swift
+//  Fluent
+//
+//  Created by Matias Piipari on 10/02/2017.
+//
+//
+
+import Foundation
+
+import Fluent
+
+struct StringIdentifiedThing: Entity {
+    
+    var id:Node? = nil
+    var exists: Bool = false
+    
+    init(node: Node, in context: Context) throws {
+        id = try node.extract("id")
+    }
+    
+    func makeNode(context: Context = EmptyNode) throws -> Node {
+        return try Node(node: ["id": id])
+    }
+    
+    static var idType: Schema.Field.KeyType { return .string(length: 10) }
+    
+    static func prepare(_ database: Database) throws {
+        try database.create(entity) { creator throws in
+            creator.id(for: self)
+        }
+    }
+    
+    static func revert(_ database: Database) throws {
+        try database.delete(entity)
+    }
+}

--- a/Tests/FluentTests/Utilities/User.swift
+++ b/Tests/FluentTests/Utilities/User.swift
@@ -5,7 +5,7 @@ final class User: Entity {
     
     static func prepare(_ database: Fluent.Database) throws {
         try database.create(entity) { builder in
-            builder.id()
+            builder.id(for: self)
             builder.string("name")
             builder.string("email")
         }


### PR DESCRIPTION
In this PR I have tried to address the issue noted in https://github.com/vapor/postgresql-driver/issues/17, of adding support for non-numerical primary IDs. As discussed in the thread, the problem is not really with PostgreSQL, but a limitation of the SQL serializer, and indeed on a closer look also the schema creator needed adaptation.

## Summary of changes proposed here

- Add a `KeyType` enum next to `DataType` in `Schema.Field` to allow describing the type used as an identifier. 
- Associate a `KeyType?` with the `id` case of `DataType` to optionally allow describing the kind of identifier that is to be used.
- Move the creation of a pivot field to the schema creator, as it belongs in that domain (later on one might want to add for example foreign key constraints into the schema as well?).
- Add a `KeyType?` argument where necessary to pass context to schema creation etc. 

## Impact on existing code

No existing code (that implicitly assumes a single primary ID type exists per driver) should break as a result of these changes, as all methods which now accept a `KeyType` or `KeyType?` have no new required arguments, and the existing switch/cases which deal with the id case simply continue to work (on the contrary, there may be additional changes still required for non-integral keys that I may not have foreseen). The key type given for an id is in other words just a hint that the drivers may choose to interpret in some way, or choose not to interpret (I suppose given the associated value is marked optional, it would make sense for drivers to error out if you try using a key type that is not supported, for example a numerical ID with Mongo).

## Alternatives considered

- A stringly typed associated value to `id`. This would not be good for backend agnosticism in mind. Also, because the `KeyType` which I preferred in this solution includes a `custom` case, unforeseen key types are still possible include.
- Avoid introducing a new `KeyType` by recursively associating to `DataType`. I decided against this because not all field types make sense as a primary identifier and the implementation burden to concrete providers / drivers is increased, especially if the API is to remain enough to be used with no-SQL databases as well.

## Limitations

Only string and "custom" cases are present there in `KeyType`. I figured this would be a limitation lifted in subsequent iterative changes – for example these changes are a helpful prerequisite to adding support for specifically UUID typed IDs (https://github.com/vapor/fluent/issues/107).