### PR TITLE
fluent context

### DIFF
--- a/Sources/Fluent/Database/Database.swift
+++ b/Sources/Fluent/Database/Database.swift
@@ -17,7 +17,6 @@ public class Database {
     */
     public init(_ driver: Driver) {
         self.driver = driver
-        _context = DatabaseContext(self)
     }
 
     /**
@@ -32,8 +31,5 @@ public class Database {
         The default database for all `Model` types.
     */
     public static var `default`: Database?
-
-    // cached context
-    internal weak var _context: DatabaseContext?
 }
 

--- a/Sources/Fluent/Database/Database.swift
+++ b/Sources/Fluent/Database/Database.swift
@@ -17,6 +17,7 @@ public class Database {
     */
     public init(_ driver: Driver) {
         self.driver = driver
+        _context = DatabaseContext(self)
     }
 
     /**
@@ -31,4 +32,8 @@ public class Database {
         The default database for all `Model` types.
     */
     public static var `default`: Database?
+
+    // cached context
+    internal weak var _context: DatabaseContext?
 }
+

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -97,7 +97,10 @@ public class Query<T: Entity>: QueryRepresentable {
         if case .array(let array) = try raw() {
             for result in array {
                 do {
-                    let context = DatabaseContext(database)
+                    let context =
+                        database._context ??
+                        DatabaseContext(database)
+
                     var model = try T(node: result, in: context)
                     if case .object(let dict) = result {
                         model.id = dict[database.driver.idKey]
@@ -202,8 +205,10 @@ extension QueryRepresentable {
     public func save(_ model: inout T) throws {
         let query = try makeQuery()
 
-        let context = DatabaseContext(query.database)
-        
+        let context =
+            query.database._context ??
+            DatabaseContext(query.database)
+
         if let _ = model.id, model.exists {
             model.willUpdate()
             let node = try model.makeNode(context: context)

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -68,12 +68,14 @@ public class Query<T: Entity>: QueryRepresentable {
         self.database = database
         unions = []
         sorts = []
+        _context = DatabaseContext(database)
     }
 
     var idKey: String {
         return database.driver.idKey
     }
 
+    fileprivate let _context: DatabaseContext
 
     /**
         Runs the query given its properties
@@ -97,11 +99,7 @@ public class Query<T: Entity>: QueryRepresentable {
         if case .array(let array) = try raw() {
             for result in array {
                 do {
-                    let context =
-                        database._context ??
-                        DatabaseContext(database)
-
-                    var model = try T(node: result, in: context)
+                    var model = try T(node: result, in: _context)
                     if case .object(let dict) = result {
                         model.id = dict[database.driver.idKey]
                     }
@@ -205,18 +203,14 @@ extension QueryRepresentable {
     public func save(_ model: inout T) throws {
         let query = try makeQuery()
 
-        let context =
-            query.database._context ??
-            DatabaseContext(query.database)
-
         if let _ = model.id, model.exists {
             model.willUpdate()
-            let node = try model.makeNode(context: context)
+            let node = try model.makeNode(context: query._context)
             try modify(node)
             model.didUpdate()
         } else {
             model.willCreate()
-            let node = try model.makeNode(context: context)
+            let node = try model.makeNode(context: query._context)
             model.id = try query.create(node)
             model.didCreate()
         }

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -200,14 +200,18 @@ extension QueryRepresentable {
     */
     public func save(_ model: inout T) throws {
         let query = try makeQuery()
+
+        let context = FluentContext()
         
         if let _ = model.id, model.exists {
             model.willUpdate()
-            try modify(model.makeNode())
+            let node = try model.makeNode(context: context)
+            try modify(node)
             model.didUpdate()
         } else {
             model.willCreate()
-            model.id = try query.create(model.makeNode())
+            let node = try model.makeNode(context: context)
+            model.id = try query.create(node)
             model.didCreate()
         }
         model.exists = true

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -97,7 +97,8 @@ public class Query<T: Entity>: QueryRepresentable {
         if case .array(let array) = try raw() {
             for result in array {
                 do {
-                    var model = try T(node: result)
+                    let context = DatabaseContext(database)
+                    var model = try T(node: result, in: context)
                     if case .object(let dict) = result {
                         model.id = dict[database.driver.idKey]
                     }
@@ -201,7 +202,7 @@ extension QueryRepresentable {
     public func save(_ model: inout T) throws {
         let query = try makeQuery()
 
-        let context = FluentContext()
+        let context = DatabaseContext(query.database)
         
         if let _ = model.id, model.exists {
             model.willUpdate()

--- a/Sources/Fluent/Utilities/Fluent+Node.swift
+++ b/Sources/Fluent/Utilities/Fluent+Node.swift
@@ -1,1 +1,5 @@
 @_exported import Node
+
+public struct FluentContext: Context {
+    public init() {}
+}

--- a/Sources/Fluent/Utilities/Fluent+Node.swift
+++ b/Sources/Fluent/Utilities/Fluent+Node.swift
@@ -1,5 +1,9 @@
 @_exported import Node
 
-public struct FluentContext: Context {
-    public init() {}
+public struct DatabaseContext: Context {
+    public let database: Database
+
+    public init(_ database: Database) {
+        self.database = database
+    }
 }

--- a/Sources/Fluent/Utilities/Fluent+Node.swift
+++ b/Sources/Fluent/Utilities/Fluent+Node.swift
@@ -1,6 +1,6 @@
 @_exported import Node
 
-public struct DatabaseContext: Context {
+public final class DatabaseContext: Context {
     public let database: Database
 
     public init(_ database: Database) {


### PR DESCRIPTION
Adds a `Node.Context` named `DatabaseContext` that will be passed to all `makeNode` calls resulting in a model being converted for saving to a DB.

This will allow users to better clarify what a `makeNode` and `init(node:)` calls are being used for, allowing them to change what fields are serialized.