### PR TITLE
ignore null or 0 id results

### DIFF
--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -211,7 +211,10 @@ extension QueryRepresentable {
         } else {
             model.willCreate()
             let node = try model.makeNode(context: query._context)
-            model.id = try query.create(node)
+            let id = try query.create(node)
+            if id != nil, id != .null, id != 0 {
+                model.id = id
+            }
             model.didCreate()
         }
         model.exists = true


### PR DESCRIPTION
MySQL returns 0 for `SELECT LAST_INSERT_ID()` if the inserted id is a `UUID`.

This is causing the `id` property of the model to be incorrectly set to `0` for IDs that are preset by internal app logic.