### PR TITLE
joins in delete and update

### DIFF
--- a/Sources/Fluent/Query/Join.swift
+++ b/Sources/Fluent/Query/Join.swift
@@ -18,10 +18,34 @@ public struct Join {
     /// the local data
     public let foreign: Entity.Type
 
+    /// Direction the foreign key goes
+    public let child: ChildDirection
+
+    /// Indicates one of two directions the join can have.
+    /// 
+    /// Foreign: The foreign entity has a key
+    ///     that points to the local entity's
+    ///     primary key.
+    ///
+    /// Local: The local entity has a key
+    ///     that points to the foreign entity's
+    ///     primary key.
+    public enum ChildDirection {
+        case foreign
+        case local
+    }
+
     /// Create a new Join
-    public init(local: Entity.Type, foreign: Entity.Type) {
+    ///
+    /// See Join and ChildDirection for more information.
+    public init(
+        local: Entity.Type,
+        foreign: Entity.Type,
+        child: ChildDirection = .foreign
+    ) {
         self.local = local
         self.foreign = foreign
+        self.child = child
     }
 }
 
@@ -31,13 +55,15 @@ extension QueryRepresentable {
     @discardableResult
     public func join(
         _ foreign: Entity.Type,
-        local: Entity.Type = T.self
+        local: Entity.Type = T.self,
+        child: Join.ChildDirection = .foreign
     ) throws -> Query<Self.T> {
         let query = try makeQuery()
 
         let join = Join(
             local: local,
-            foreign: foreign
+            foreign: foreign,
+            child: child
         )
         
         query.joins.append(join)

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -88,17 +88,35 @@ open class GeneralSQLSerializer: SQLSerializer {
                 sql(statement),
                 values
             )
-        case .delete(let table, let filters, let limit):
+        case .delete(let table, let filters, let unions, let orders, let limit):
             var statement: [String] = []
             var values: [Node] = []
 
+            let tableSQL = sql(table)
             statement += "DELETE FROM"
-            statement += sql(table)
+            statement += tableSQL
+            
+            // When performing a join, use WHERE EXISTS with the first join
+            if !unions.isEmpty {
+                let (whereExistsStatement, whereExistsValues) = serializeWhereExists(entity: table, joins: unions, filters: filters, orders: orders, limit: limit)
+                
+                statement += whereExistsStatement
+                values += whereExistsValues
+                
+                return (
+                    sql(statement),
+                    values
+                )
+            }
 
             if !filters.isEmpty {
                 let (filtersClause, filtersValues) = sql(filters)
                 statement += filtersClause
                 values += filtersValues
+            }
+            
+            if !orders.isEmpty {
+                statement += sql(orders)
             }
 
             if let limit = limit {
@@ -109,24 +127,44 @@ open class GeneralSQLSerializer: SQLSerializer {
                 sql(statement),
                 values
             )
-        case .update(let table, let filters, let data):
+        case .update(let table, let filters, let unions, let data):
             var statement: [String] = []
 
             var values: [Node] = []
 
+            let tableSQL = sql(table)
             statement += "UPDATE"
-            statement += sql(table)
+            statement += tableSQL
             statement += "SET"
-
+            
             if let data = data, case .object(let obj) = data {
                 let (dataClause, dataValues) = sql(update: obj)
                 statement += dataClause
                 values += dataValues
             }
-
-            let (filterclause, filterValues) = sql(filters)
-            statement += filterclause
-            values += filterValues
+            
+            // When performing a join, use WHERE EXISTS with the first join
+            if !unions.isEmpty {
+                let (whereExistsStatement, whereExistsValues) = serializeWhereExists(entity: table, joins: unions, filters: filters)
+                
+                statement += whereExistsStatement
+                values += whereExistsValues
+                
+                return (
+                    sql(statement),
+                    values
+                )
+            }
+            
+            if !filters.isEmpty {
+                let (filterclause, filterValues) = self.sql(filters)
+                statement += filterclause
+                values += filterValues
+            }
+            
+            if !unions.isEmpty {
+                statement += ")"
+            }
 
             return (
                 sql(statement),
@@ -513,6 +551,65 @@ open class GeneralSQLSerializer: SQLSerializer {
 
     open func sql(_ string: String) -> String {
         return "`\(string)`"
+    }
+    
+    open func serializeWhereExists(entity: String, joins: [Union], filters: [Filter] = [], orders: [Sort] = [], limit: Limit? = nil) -> (String, [Node]) {
+        var statement: [String] = []
+        var values: [Node] = []
+        
+        // Add all the filters on the local entity first, then start the EXISTS query
+        let localFilters = filters.filter { $0.entity.entity == entity }
+        if !localFilters.isEmpty {
+            let (filterclause, filterValues) = self.sql(localFilters)
+            statement += filterclause
+            values += filterValues
+            
+            statement += "AND EXISTS ("
+        }
+        else {
+            statement += "WHERE EXISTS ("
+        }
+        
+        statement += "SELECT * FROM"
+        
+        // Add all joins as FROM in the EXISTS query
+        statement += joins
+            .map { sql($0.foreign.entity) }
+            .joined(separator: ", ")
+        
+        // Add all joins as `WHERE foreign.id = local.id`
+        statement += "WHERE"
+        statement += joins
+            .map { join in
+                return "\(sql(join.foreign.entity)).\(sql(join.foreignKey)) = \(sql(join.local.entity)).\(sql(join.localKey))"
+            }
+            .joined(separator: " AND ")
+
+        // Add remaining filters to EXISTS query
+        let joinFilters = filters.filter { $0.entity.entity != entity }
+        if !joinFilters.isEmpty {
+            statement += "AND"
+            
+            let (filterClause, filterValues) = sql(joinFilters, relation: .and)
+            statement += filterClause
+            values += filterValues
+        }
+
+        if !orders.isEmpty {
+            statement += sql(orders)
+        }
+
+        if let limit = limit {
+            statement += sql(limit: limit)
+        }
+        
+        // End EXISTS query
+        statement += ")"
+        
+        return (
+            sql(statement),
+            values
+        )
     }
 }
 

--- a/Sources/Fluent/SQL/SQL+Query.swift
+++ b/Sources/Fluent/SQL/SQL+Query.swift
@@ -24,7 +24,7 @@ extension SQL {
             self = .delete(
                 table: T.entity,
                 filters: query.filters,
-                joins: query.unions,
+                joins: query.joins,
                 orders: query.sorts,
                 limit: query.limit
             )
@@ -32,7 +32,7 @@ extension SQL {
             self = .update(
                 table: T.entity,
                 filters: query.filters,
-                joins: query.unions,
+                joins: query.joins,
                 data: query.data
             )
         }

--- a/Sources/Fluent/SQL/SQL+Query.swift
+++ b/Sources/Fluent/SQL/SQL+Query.swift
@@ -24,12 +24,15 @@ extension SQL {
             self = .delete(
                 table: T.entity,
                 filters: query.filters,
+                joins: query.unions,
+                orders: query.sorts,
                 limit: query.limit
             )
         case .modify:
             self = .update(
                 table: T.entity,
                 filters: query.filters,
+                joins: query.unions,
                 data: query.data
             )
         }

--- a/Sources/Fluent/SQL/SQL.swift
+++ b/Sources/Fluent/SQL/SQL.swift
@@ -9,9 +9,9 @@ public enum SQL {
     }
     
     case insert(table: String, data: Node?)
-    case select(table: String, filters: [Filter], joins: [Join], orders: [Sort], limit: Limit?)
     case count(table: String, filters: [Filter], joins: [Join])
-    case update(table: String, filters: [Filter], data: Node?)
-    case delete(table: String, filters: [Filter], limit: Limit?)
+    case select(table: String, filters: [Filter], joins: [Join], orders: [Sort], limit: Limit?)
+    case update(table: String, filters: [Filter], joins: [Join], data: Node?)
+    case delete(table: String, filters: [Filter], joins: [Join], orders: [Sort], limit: Limit?)
     case table(action: TableAction, table: String)
 }

--- a/Tests/FluentTests/SQLSerializerTests.swift
+++ b/Tests/FluentTests/SQLSerializerTests.swift
@@ -2,29 +2,6 @@ import XCTest
 @testable import Fluent
 
 class SQLSerializerTests: XCTestCase {
-    static let allTests = [
-        ("testBasicSelect", testBasicSelect),
-        ("testRegularSelect", testRegularSelect),
-        ("testOffsetSelect", testOffsetSelect),
-        ("testFilterCompareSelect", testFilterCompareSelect),
-        ("testFilterLikeSelect", testFilterLikeSelect),
-        ("testBasicCount", testBasicCount),
-        ("testRegularCount", testRegularCount),
-        ("testFilterCompareCount", testFilterCompareCount),
-        ("testFilterLikeCount", testFilterLikeCount),
-        ("testFilterEqualsNullSelect", testFilterEqualsNullSelect),
-        ("testFilterNotEqualsNullSelect", testFilterNotEqualsNullSelect),
-        ("testFilterCompareUpdate", testFilterCompareUpdate),
-        ("testFilterCompareDelete", testFilterCompareDelete),
-        ("testFilterGroup", testFilterGroup),
-        ("testSort", testSort),
-        ("testSortMultiple", testSortMultiple),
-        ("testJoinSelect", testJoinSelect),
-        ("testJoinDelete", testJoinDelete),
-        ("testJoinUpdate", testJoinUpdate),
-        ("testMultipleJoinUpdate", testMultipleJoinUpdate),
-    ]
-
     func testBasicSelect() {
         let sql = SQL.select(table: "users", filters: [], joins: [], orders: [], limit: nil)
         let (statement, values) = serialize(sql)
@@ -134,17 +111,6 @@ class SQLSerializerTests: XCTestCase {
         XCTAssertEqual(values.count, 0)
     }
 
-    func testFilterCompareUpdate() {
-        let filter = Filter(User.self, .compare("name", .equals, "duck"))
-
-        let update = SQL.update(table: "friends", filters: [filter], joins: [], data: ["not it": true])
-        let (statement, values) = serialize(update)
-        XCTAssertEqual(statement, "UPDATE `friends` SET `not it` = ? WHERE `users`.`name` = ?")
-        XCTAssertEqual(values.first?.bool, true)
-        XCTAssertEqual(values.last?.string, "duck")
-        XCTAssertEqual(values.count, 2)
-    }
-
     func testFilterCompareDelete() {
         let filter = Filter(User.self, .compare("name", .greaterThan, .string("duck")))
 
@@ -191,11 +157,11 @@ class SQLSerializerTests: XCTestCase {
     
     func testJoinSelect() throws {
         let filter = Filter(Atom.self, .compare("name", .equals, "test"))
-        let union = Union(local: Atom.self, foreign: Group.self, idKey: "id", localKey: "groupId", foreignKey: "id")
+        let union = Join(local: Atom.self, foreign: Group.self)
         let sql = SQL.select(table: "atoms", filters: [filter], joins: [union], orders: [], limit: Limit(count: 5))
         let (statement, values) = serialize(sql)
 
-        XCTAssertEqual(statement, "SELECT `atoms`.* FROM `atoms` JOIN `groups` ON `atoms`.`groupId` = `groups`.`id` WHERE `atoms`.`name` = ? LIMIT 0, 5")
+        XCTAssertEqual(statement, "SELECT `atoms`.* FROM `atoms` JOIN `groups` ON `atoms`.`id` = `groups`.`atom_id` WHERE `atoms`.`name` = ? LIMIT 0, 5")
         XCTAssertEqual(values.first?.string, "test")
         XCTAssertEqual(values.count, 1)
     }
@@ -203,39 +169,75 @@ class SQLSerializerTests: XCTestCase {
     func testJoinDelete() throws {
         let filter = Filter(Atom.self, .compare("name", .equals, "test"))
         let name = Sort(Atom.self, "name", .ascending)
-        let union = Union(local: Atom.self, foreign: Group.self, idKey: "id", localKey: "groupId", foreignKey: "id")
+        let union = Join(local: Atom.self, foreign: Group.self)
         let sql = SQL.delete(table: "atoms", filters: [filter], joins: [union], orders: [name], limit: Limit(count: 5))
         let (statement, values) = serialize(sql)
         
-        XCTAssertEqual(statement, "DELETE FROM `atoms` WHERE `atoms`.`name` = ? AND EXISTS ( SELECT * FROM `groups` WHERE `groups`.`id` = `atoms`.`groupId` ORDER BY `atoms`.`name` ASC LIMIT 0, 5 )")
+        XCTAssertEqual(statement, "DELETE FROM `atoms` JOIN `groups` ON `atoms`.`id` = `groups`.`atom_id` WHERE `atoms`.`name` = ? ORDER BY `atoms`.`name` ASC LIMIT 0, 5")
         XCTAssertEqual(values.first?.string, "test")
         XCTAssertEqual(values.count, 1)
     }
     
     func testJoinUpdate() throws {
         let filter = Filter(Atom.self, .compare("name", .equals, "test"))
-        let union = Union(local: Atom.self, foreign: Group.self, idKey: "id", localKey: "groupId", foreignKey: "id")
-        let sql = SQL.update(table: "atoms", filters: [filter], joins: [union], data: ["name": "test2"])
+        let filter2 = Filter(Group.self, .compare("foo", .equals, "bar"))
+        let union = Join(local: Atom.self, foreign: Group.self)
+        let sql = SQL.update(table: "atoms", filters: [filter, filter2], joins: [union], data: ["name": "test2"])
         let (statement, values) = serialize(sql)
         
-        XCTAssertEqual(statement, "UPDATE `atoms` SET `name` = ? WHERE `atoms`.`name` = ? AND EXISTS ( SELECT * FROM `groups` WHERE `groups`.`id` = `atoms`.`groupId` )")
+        XCTAssertEqual(statement, "UPDATE `atoms` JOIN `groups` ON `atoms`.`id` = `groups`.`atom_id` SET `atoms`.`name` = ? WHERE `atoms`.`name` = ? AND `groups`.`foo` = ?")
         XCTAssertEqual(values.first?.string, "test2")
-        XCTAssertEqual(values.last?.string, "test")
-        XCTAssertEqual(values.count, 2)
+        XCTAssertEqual(values.last?.string, "bar")
+        XCTAssertEqual(values.count, 3)
     }
-    
+
+    func testJoinUpdateOpposite() throws {
+        let filter = Filter(Atom.self, .compare("name", .equals, "test"))
+        let filter2 = Filter(Group.self, .compare("foo", .equals, "bar"))
+        let union = Join(local: Atom.self, foreign: Group.self, child: .local)
+        let sql = SQL.update(table: "atoms", filters: [filter, filter2], joins: [union], data: ["name": "test2"])
+        let (statement, values) = serialize(sql)
+
+        XCTAssertEqual(statement, "UPDATE `atoms` JOIN `groups` ON `atoms`.`groupId` = `groups`.`id` SET `atoms`.`name` = ? WHERE `atoms`.`name` = ? AND `groups`.`foo` = ?")
+        XCTAssertEqual(values.first?.string, "test2")
+        XCTAssertEqual(values.last?.string, "bar")
+        XCTAssertEqual(values.count, 3)
+    }
+
     func testMultipleJoinUpdate() throws {
         let filter = Filter(Atom.self, .compare("name", .equals, "test"))
-        let union1 = Union(local: Atom.self, foreign: Group.self, idKey: "id", localKey: "groupId", foreignKey: "id")
-        let union2 = Union(local: Atom.self, foreign: Nucleus.self, idKey: "id", localKey: "nucleusId", foreignKey: "id")
+        let union1 = Join(local: Atom.self, foreign: Group.self)
+        let union2 = Join(local: Atom.self, foreign: Nucleus.self)
         let sql = SQL.update(table: "atoms", filters: [filter], joins: [union1, union2], data: ["name": "test2"])
         let (statement, values) = serialize(sql)
         
-        XCTAssertEqual(statement, "UPDATE `atoms` SET `name` = ? WHERE `atoms`.`name` = ? AND EXISTS ( SELECT * FROM `groups`, `nuclei` WHERE `groups`.`id` = `atoms`.`groupId` AND `nuclei`.`id` = `atoms`.`nucleusId` )")
+        XCTAssertEqual(statement, "UPDATE `atoms` JOIN `groups` ON `atoms`.`id` = `groups`.`atom_id` JOIN `nuclei` ON `atoms`.`id` = `nuclei`.`atom_id` SET `atoms`.`name` = ? WHERE `atoms`.`name` = ?")
         XCTAssertEqual(values.first?.string, "test2")
         XCTAssertEqual(values.last?.string, "test")
         XCTAssertEqual(values.count, 2)
     }
+
+    static let allTests = [
+        ("testBasicSelect", testBasicSelect),
+        ("testRegularSelect", testRegularSelect),
+        ("testOffsetSelect", testOffsetSelect),
+        ("testFilterCompareSelect", testFilterCompareSelect),
+        ("testFilterLikeSelect", testFilterLikeSelect),
+        ("testBasicCount", testBasicCount),
+        ("testRegularCount", testRegularCount),
+        ("testFilterCompareCount", testFilterCompareCount),
+        ("testFilterLikeCount", testFilterLikeCount),
+        ("testFilterEqualsNullSelect", testFilterEqualsNullSelect),
+        ("testFilterNotEqualsNullSelect", testFilterNotEqualsNullSelect),
+        ("testFilterCompareDelete", testFilterCompareDelete),
+        ("testFilterGroup", testFilterGroup),
+        ("testSort", testSort),
+        ("testSortMultiple", testSortMultiple),
+        ("testJoinSelect", testJoinSelect),
+        ("testJoinDelete", testJoinDelete),
+        ("testJoinUpdate", testJoinUpdate),
+        ("testMultipleJoinUpdate", testMultipleJoinUpdate),
+    ]
 }
 
 // MARK: Utilities

--- a/Tests/FluentTests/Utilities/Group.swift
+++ b/Tests/FluentTests/Utilities/Group.swift
@@ -8,4 +8,6 @@ final class Group: Entity {
     func makeNode(context: Context = EmptyNode) -> Node { return .null }
     static func prepare(_ database: Database) throws {}
     static func revert(_ database: Database) throws {}
+
+    static var foreignIdKey = "groupId"
 }


### PR DESCRIPTION
Allows joins to be used in delete and updates. Currently works for MySQL-like SQLs only, but this could be overridden by sql serializers.