### PR TITLE
Adding support for Group By clause

### DIFF
--- a/Sources/Fluent/Query/GroupBy.swift
+++ b/Sources/Fluent/Query/GroupBy.swift
@@ -1,0 +1,29 @@
+/// Limits the count of results
+/// returned by the `Query`
+
+/// Groups results by an entity's
+/// field.
+public struct GroupBy {
+    
+    /// The entity to group by.
+    public let entity: Entity.Type
+    
+    /// The field to group by.
+    public let field: String
+    
+    public init(_ entity: Entity.Type, _ field: String) {
+        self.entity = entity
+        self.field = field
+    }
+}
+
+extension QueryRepresentable {
+    /// Groups results by a given entity's
+    /// field.
+    public func groupBy(_ field: String) throws -> Query<E> {
+        let query = try makeQuery()
+        let group = GroupBy(E.self, field)
+        query.groups.append(group)
+        return query
+    }
+}

--- a/Sources/Fluent/Query/GroupBy.swift
+++ b/Sources/Fluent/Query/GroupBy.swift
@@ -1,6 +1,3 @@
-/// Limits the count of results
-/// returned by the `Query`
-
 /// Groups results by an entity's
 /// field.
 public struct GroupBy {

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -15,7 +15,11 @@ public final class Query<E: Entity> {
     /// Optionally limit the amount of
     /// entities affected by the action.
     public var limit: Limit?
-
+    
+    /// An array of groups that will
+    /// be applied to the result.
+    public var groups: [GroupBy]
+    
     /// An array of sorts that will
     /// be applied to the results.
     public var sorts: [Sort]
@@ -42,6 +46,7 @@ public final class Query<E: Entity> {
         action = .fetch
         self.database = database
         joins = []
+        groups = []
         sorts = []
         includeSoftDeleted = false
     }

--- a/Sources/Fluent/SQL/SQL+Query.swift
+++ b/Sources/Fluent/SQL/SQL+Query.swift
@@ -6,6 +6,7 @@ extension SQL {
                 table: T.entity,
                 filters: query.filters,
                 joins: query.joins,
+                groups: query.groups,
                 orders: query.sorts,
                 limit: query.limit
             )
@@ -13,7 +14,8 @@ extension SQL {
             self = .count(
                 table: T.entity,
                 filters: query.filters,
-                joins: query.joins
+                joins: query.joins,
+                groups: query.groups
             )
         case .create:
             self = .insert(

--- a/Sources/Fluent/SQL/SQL.swift
+++ b/Sources/Fluent/SQL/SQL.swift
@@ -9,8 +9,8 @@ public enum SQL {
     }
     
     case insert(table: String, data: Node?)
-    case select(table: String, filters: [Filter], joins: [Join], orders: [Sort], limit: Limit?)
-    case count(table: String, filters: [Filter], joins: [Join])
+    case select(table: String, filters: [Filter], joins: [Join], groups: [GroupBy], orders: [Sort], limit: Limit?)
+    case count(table: String, filters: [Filter], joins: [Join], groups: [GroupBy])
     case update(table: String, filters: [Filter], data: Node?)
     case delete(table: String, filters: [Filter], limit: Limit?)
     case table(action: TableAction, table: String)

--- a/Tests/FluentTests/GoupByTests.swift
+++ b/Tests/FluentTests/GoupByTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import Fluent
+
+class GroupByTests: XCTestCase {
+    static let allTests = [
+        ("testBasic", testBasic),
+    ]
+    
+    var database: Database!
+    override func setUp() {
+        database = Database(DummyDriver())
+    }
+    
+    func testBasic() throws {
+        let query = try Query<User>(database)
+            .filter("age", .greaterThan, 17)
+            .groupBy("name")
+            .groupBy("surname")
+        
+        XCTAssertEqual(query.groups.count, 2)
+    }
+}

--- a/Tests/FluentTests/JoinTests.swift
+++ b/Tests/FluentTests/JoinTests.swift
@@ -28,9 +28,10 @@ class JoinTests: XCTestCase {
 
         if let sql = lqd.lastQuery {
             switch sql {
-            case .select(let table, let filters, let joins, let orders, let limit):
+            case .select(let table, let filters, let joins, let groups, let orders, let limit):
                 XCTAssertEqual(table, "atoms")
                 XCTAssertEqual(filters.count, 0)
+                XCTAssertEqual(groups.count, 0)
                 XCTAssertEqual(orders.count, 0)
                 XCTAssertEqual(joins.count, 1)
                 if let join = joins.first {
@@ -55,9 +56,10 @@ class JoinTests: XCTestCase {
 
         if let sql = lqd.lastQuery {
             switch sql {
-            case .select(let table, let filters, let joins, let orders, let limit):
+            case .select(let table, let filters, let joins, let groups, let orders, let limit):
                 XCTAssertEqual(table, "atoms")
                 XCTAssertEqual(filters.count, 0)
+                XCTAssertEqual(groups.count, 0)
                 XCTAssertEqual(orders.count, 0)
                 XCTAssertEqual(joins.count, 1)
                 if let join = joins.first {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -13,7 +13,8 @@ XCTMain([
     testCase(SchemaCreateTests.allTests),
     testCase(SQLSerializerTests.allTests),
     testCase(JoinTests.allTests),
-    testCase(MemoryBenchmarkTests.allTests)
+    testCase(MemoryBenchmarkTests.allTests),
+    testCase(GroupByTests.allTests)
 ])
 
 #endif


### PR DESCRIPTION
This pull requests aims to add support for `GROUP BY` clauses in Fluent by adding an array of fields to group by to `Query<T>` and `SQL.select`/`SQL.count` cases.

A new struct `GroupBy` was created to encapsulate the group clause, composed of an Entity.type and field, and multiple group-by columns can be applied to the same Query. I've added support to apply groups to `SQL.count` case, as well, since it may prove useful there. `MemoryDriver` was also updated to support group clauses.

Changes to `SQL` enumeration are source-breaking.

Would appreciate some feedback!