### PR TITLE
improved siblings + conveniences

### DIFF
--- a/Sources/Fluent/Database/Database.swift
+++ b/Sources/Fluent/Database/Database.swift
@@ -18,15 +18,46 @@ public final class Database: Executor {
     /// one for each thread
     public let threadConnectionPool: ThreadConnectionPool
 
+    /// The string value for the
+    /// default identifier key.
+    ///
+    /// The `idKey` will be used when
+    /// `Model.find(_:)` or other find
+    /// by identifier methods are used.
+    ///
+    /// This value is overriden by
+    /// entities that implement the
+    /// `Entity.idKey` static property.
+    public var idKey: String
+
+    /// The default type for values stored against the identifier key.
+    ///
+    /// The `idType` will be accessed by those Entity implementations
+    /// which do not themselves implement `Entity.idType`.
+    public var idType: IdentifierType
+
     /// Creates a `Database` with the supplied
     /// `Driver`. This cannot be changed later.
     public init(_ driver: Driver, maxConnections: Int = 128) {
+        idKey = driver.idKey
+        idType = driver.idType
+        shouldLog = false
+        logs = []
+
         threadConnectionPool = ThreadConnectionPool(
             makeConnection: driver.makeConnection,
             maxConnections: maxConnections // some number larger than the max threads
         )
         self.driver = driver
     }
+
+    /// If set to true, the database will store
+    /// all queries ran in the `logs` property.
+    public var shouldLog: Bool
+
+    /// If `shouldLog` is set to true, all queries
+    /// performed by this database will be stored here.
+    public var logs: [Log]
 }
 
 // MARK: Executor
@@ -35,17 +66,26 @@ extension Database {
     /// See Executor protocol.
     @discardableResult
     public func query<T: Entity>(_ query: Query<T>) throws -> Node {
+        if shouldLog {
+            logs.append(Log(query))
+        }
         return try threadConnectionPool.connection().query(query)
     }
     
     /// Seeee Executor protocol.
     public func schema(_ schema: Schema) throws {
+        if shouldLog {
+            logs.append(Log(schema))
+        }
         try threadConnectionPool.connection().schema(schema)
     }
     
     /// Seeee Executor protocol.
     @discardableResult
     public func raw(_ raw: String, _ values: [Node]) throws -> Node {
+        if shouldLog {
+            logs.append(Log(raw: raw))
+        }
         return try threadConnectionPool.connection().raw(raw, values)
     }
 }

--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -154,12 +154,12 @@ extension Entity {
 
     /// See Entity.idType
     public static var idType: IdentifierType {
-        return database?.driver.idType ?? .int
+        return database?.idType ?? .int
     }
 
     /// See Entity.idKey
     public static var idKey: String {
-        return database?.driver.idKey ?? "id"
+        return database?.idKey ?? "id"
     }
 
     /// See Entity.foreignIdKey

--- a/Sources/Fluent/Memory/MemoryDriver.swift
+++ b/Sources/Fluent/Memory/MemoryDriver.swift
@@ -30,8 +30,8 @@ public final class MemoryDriver: Driver {
     
     func prepare(union: Join) -> Group {
         // create unioned table from two groups
-        let local = prepare(group: union.local.entity)
-        let foreign = prepare(group: union.foreign.entity)
+        let local = prepare(group: union.base.entity)
+        let foreign = prepare(group: union.joined.entity)
         
         var unioned: [Node] = []
         
@@ -39,7 +39,7 @@ public final class MemoryDriver: Driver {
         // into one group
         for l in local.data {
             for f in foreign.data {
-                if l[union.local.idKey] == f[union.local.foreignIdKey] {
+                if l[union.base.idKey] == f[union.base.foreignIdKey] {
                     var lf: [String: Node] = [:]
                     
                     if let of = f.nodeObject {

--- a/Sources/Fluent/Pivot/Pivot.swift
+++ b/Sources/Fluent/Pivot/Pivot.swift
@@ -12,9 +12,9 @@ public final class Pivot<
 
     public static var entity: String {
         if Left.name < Right.name {
-            return "\(Left.name)_\(Right.name)"
+            return "\(Left.name)\(pivotNameConnector)\(Right.name)"
         } else {
-            return "\(Right.name)_\(Left.name)"
+            return "\(Right.name)\(pivotNameConnector)\(Left.name)"
         }
     }
 
@@ -74,3 +74,5 @@ public final class Pivot<
         try database.delete(entity)
     }
 }
+
+public var pivotNameConnector: String = "_"

--- a/Sources/Fluent/Pivot/PivotProtocol.swift
+++ b/Sources/Fluent/Pivot/PivotProtocol.swift
@@ -37,6 +37,7 @@ extension PivotProtocol where Self: Entity {
     }
 
     /// See PivotProtocol.attach
+    @discardableResult
     public static func attach(_ left: Left, _ right: Right) throws -> Self {
         _ = try assertSaved(left, right)
 

--- a/Sources/Fluent/Pivot/PivotProtocol.swift
+++ b/Sources/Fluent/Pivot/PivotProtocol.swift
@@ -13,7 +13,8 @@ public protocol PivotProtocol {
 
     /// Attaches the two entities
     /// Entities must be saved before attempting attach.
-    static func attach(_ left: Left, _ right: Right) throws
+    @discardableResult
+    static func attach(_ left: Left, _ right: Right) throws -> Self
 
     /// Detaches the two entities.
     /// Entities must be saved before attempting detach.
@@ -36,11 +37,16 @@ extension PivotProtocol where Self: Entity {
     }
 
     /// See PivotProtocol.attach
-    public static func attach(_ left: Left, _ right: Right) throws {
+    public static func attach(_ left: Left, _ right: Right) throws -> Self {
         _ = try assertSaved(left, right)
 
-        let pivot = try Pivot<Left, Right>(left, right)
+        let pivot = try self.init(node: [
+            Left.foreignIdKey: left.id,
+            Right.foreignIdKey: right.id
+        ])
         try pivot.save()
+
+        return pivot
     }
 
     /// See PivotProtocol.detach

--- a/Sources/Fluent/Query/Join.swift
+++ b/Sources/Fluent/Query/Join.swift
@@ -15,7 +15,7 @@ public struct Join {
     public let base: Entity.Type
 
     /// Entity that will be joining
-    /// the local data
+    /// the base data
     public let joined: Entity.Type
 
     /// See Child enum
@@ -25,10 +25,20 @@ public struct Join {
     /// a foreign id pointer to the other entity
     public enum Child {
         /// The base entity contains
-        /// a foreign id pointer
+        /// a foreign id pointer to the joined data
+        ///
+        /// base        | joined
+        /// ------------+-------
+        /// joined_id   | id
         case base
         /// The joined entity contains
-        /// a foreign id pointer
+        /// a foreign id pointer to the base data
+        /// 
+        /// base | joined
+        /// -----+--------
+        /// id   | base_id
+        ///
+        /// This is the default case.
         case joined
     }
 

--- a/Sources/Fluent/Query/Join.swift
+++ b/Sources/Fluent/Query/Join.swift
@@ -12,16 +12,31 @@
 public struct Join {
     /// Entity that will be accepting
     /// the joined data
-    public let local: Entity.Type
+    public let base: Entity.Type
 
     /// Entity that will be joining
     /// the local data
-    public let foreign: Entity.Type
+    public let joined: Entity.Type
+
+    /// See Child enum
+    public let child: Child
+
+    /// Indicates which entity contains
+    /// a foreign id pointer to the other entity
+    public enum Child {
+        /// The base entity contains
+        /// a foreign id pointer
+        case base
+        /// The joined entity contains
+        /// a foreign id pointer
+        case joined
+    }
 
     /// Create a new Join
-    public init(local: Entity.Type, foreign: Entity.Type) {
-        self.local = local
-        self.foreign = foreign
+    public init(base: Entity.Type, joined: Entity.Type, child: Child = .joined) {
+        self.base = base
+        self.joined = joined
+        self.child = child
     }
 }
 
@@ -30,14 +45,16 @@ extension QueryRepresentable {
     /// See Join for more information.
     @discardableResult
     public func join(
-        _ foreign: Entity.Type,
-        local: Entity.Type = T.self
+        _ joined: Entity.Type,
+        base: Entity.Type = T.self,
+        child: Join.Child = .joined
     ) throws -> Query<Self.T> {
         let query = try makeQuery()
 
         let join = Join(
-            local: local,
-            foreign: foreign
+            base: base,
+            joined: joined,
+            child: child
         )
         
         query.joins.append(join)

--- a/Sources/Fluent/Query/Log.swift
+++ b/Sources/Fluent/Query/Log.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public struct Log {
+    /// The time the query was logged
+    public var time: Date
+
+    /// Output of the log
+    public var log: String
+
+    /// Create a log from a raw log string.
+    init(raw: String) {
+        time = Date()
+        log = raw
+    }
+
+    /// Create a log from raw sql and values.
+    init(sql: String, values: [Node]) {
+        var log = sql
+        if values.count > 0 {
+            let valuesString = values.map({ $0.string ?? "" }).joined(separator: ", ")
+            log += " [\(valuesString)]"
+        }
+
+        self.init(raw: log)
+    }
+
+    /// Create a log from a Query
+    init<T: Entity>(_ query: Query<T>) {
+        let serializer = GeneralSQLSerializer(sql: query.sql)
+        let (sql, values) = serializer.serialize()
+        self.init(sql: sql, values: values)
+    }
+
+    /// Create a log from a Schema query
+    init(_ schema: Schema) {
+        let serializer = GeneralSQLSerializer(sql: schema.sql)
+        let (sql, values) = serializer.serialize()
+        self.init(sql: sql, values: values)
+    }
+}
+
+extension Log: CustomStringConvertible {
+    public var description: String {
+        return "[\(time)] \(log)"
+    }
+}

--- a/Sources/Fluent/Relations/Children.swift
+++ b/Sources/Fluent/Relations/Children.swift
@@ -31,8 +31,7 @@ extension Children: QueryRepresentable {
 extension Entity {
     public func children<Child: Entity>(
         type childType: Child.Type = Child.self
-    ) throws -> Children<Self, Child> {
-
+    ) -> Children<Self, Child> {
         return Children(from: self)
     }
 }

--- a/Sources/Fluent/Relations/Parent.swift
+++ b/Sources/Fluent/Relations/Parent.swift
@@ -38,7 +38,7 @@ extension Entity {
     public func parent<P: Entity>(
         id parentId: Node,
         type parentType: P.Type = P.self
-    ) throws -> Parent<Self, P> {
+    ) -> Parent<Self, P> {
         return Parent(from: self, withId: parentId)
     }
 }

--- a/Sources/Fluent/Relations/Siblings.swift
+++ b/Sources/Fluent/Relations/Siblings.swift
@@ -2,8 +2,8 @@
 /// through a Pivot table from the Local 
 /// entity to the Foreign entity.
 public final class Siblings<
-    Local: Entity, Foreign: Entity, Through: PivotProtocol & Entity
-> where Through.Left == Local, Through.Right == Foreign {
+    Local: Entity, Foreign: Entity, Through: Entity
+> {
     /// This will be used to filter the 
     /// collection of foreign entities related
     /// to the local entity type.
@@ -20,7 +20,12 @@ public final class Siblings<
     }
 }
 
-extension Siblings {
+extension Siblings
+    where
+        Through: PivotProtocol,
+        Through.Left == Local,
+        Through.Right == Foreign
+{
     public func add(_ foreign: Foreign) throws {
         try Through.attach(local, foreign)
     }

--- a/Sources/Fluent/Relations/Siblings.swift
+++ b/Sources/Fluent/Relations/Siblings.swift
@@ -26,8 +26,8 @@ extension Siblings
         Through.Left == Local,
         Through.Right == Foreign
 {
-    public func add(_ foreign: Foreign) throws {
-        try Through.attach(local, foreign)
+    public func add(_ foreign: Foreign) throws -> Through {
+        return try Through.attach(local, foreign)
     }
 
     public func remove(_ foreign: Foreign) throws {

--- a/Sources/Fluent/Relations/Siblings.swift
+++ b/Sources/Fluent/Relations/Siblings.swift
@@ -49,9 +49,8 @@ extension Siblings: QueryRepresentable {
 
         let query = try Foreign.query()
 
-        let pivot = Through.self
-        try query.join(pivot)
-        try query.filter(pivot, Local.foreignIdKey, localId)
+        try query.join(Through.self)
+        try query.filter(Through.self, Local.foreignIdKey, localId)
 
         return query
     }
@@ -61,13 +60,11 @@ extension Entity {
     /// Creates a Siblings relation using the current
     /// entity as the Local entity in the relation.
     public func siblings<
-        Foreign: Entity, Through: PivotProtocol & Entity
+        Foreign: Entity, Through: Entity
     > (
         to foreignType: Foreign.Type = Foreign.self,
         through pivotType: Through.Type = Through.self
-    ) -> Siblings<Self, Foreign, Through>
-        where Through.Left == Self, Through.Right == Foreign
-    {
+    ) -> Siblings<Self, Foreign, Through> {
         return Siblings(from: self)
     }
 }

--- a/Sources/Fluent/Relations/Siblings.swift
+++ b/Sources/Fluent/Relations/Siblings.swift
@@ -26,6 +26,7 @@ extension Siblings
         Through.Left == Local,
         Through.Right == Foreign
 {
+    @discardableResult
     public func add(_ foreign: Foreign) throws -> Through {
         return try Through.attach(local, foreign)
     }

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -471,11 +471,24 @@ open class GeneralSQLSerializer: SQLSerializer {
         var clause: [String] = []
 
         clause += "JOIN"
-        clause += sql(join.foreign.entity)
+        clause += sql(join.joined.entity)
         clause += "ON"
-        clause += "\(sql(join.local.entity)).\(sql(join.local.idKey))"
+
+        let baseKey: String
+        let joinedKey: String
+
+        switch join.child {
+        case .base:
+            baseKey = join.joined.foreignIdKey
+            joinedKey = join.base.idKey
+        case .joined:
+            baseKey = join.base.idKey
+            joinedKey = join.base.foreignIdKey
+        }
+
+        clause += "\(sql(join.base.entity)).\(sql(baseKey))"
         clause += "="
-        clause += "\(sql(join.foreign.entity)).\(sql(join.local.foreignIdKey))"
+        clause += "\(sql(join.joined.entity)).\(sql(joinedKey))"
 
         return sql(clause)
     }

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -474,21 +474,9 @@ open class GeneralSQLSerializer: SQLSerializer {
         clause += sql(join.joined.entity)
         clause += "ON"
 
-        let baseKey: String
-        let joinedKey: String
-
-        switch join.child {
-        case .base:
-            baseKey = join.joined.foreignIdKey
-            joinedKey = join.base.idKey
-        case .joined:
-            baseKey = join.base.idKey
-            joinedKey = join.base.foreignIdKey
-        }
-
-        clause += "\(sql(join.base.entity)).\(sql(baseKey))"
+        clause += "\(sql(join.base.entity)).\(sql(join.baseKey))"
         clause += "="
-        clause += "\(sql(join.joined.entity)).\(sql(joinedKey))"
+        clause += "\(sql(join.joined.entity)).\(sql(join.joinedKey))"
 
         return sql(clause)
     }

--- a/Sources/FluentTester/Atom.swift
+++ b/Sources/FluentTester/Atom.swift
@@ -32,8 +32,8 @@ public final class Atom: Entity {
         ])
     }
 
-    public func compounds() throws -> Siblings<Atom, Compound> {
-        return try siblings()
+    var compounds: Siblings<Atom, Compound, Pivot<Atom, Compound>> {
+        return siblings()
     }
 
     public static func prepare(_ database: Database) throws {

--- a/Sources/FluentTester/Compound.swift
+++ b/Sources/FluentTester/Compound.swift
@@ -22,9 +22,12 @@ public final class Compound: Entity {
         ])
     }
 
-    public func atoms() throws -> Siblings<Compound, Atom> {
-        return try siblings()
+    var atoms: Siblings<Compound, Atom, Pivot<Compound, Atom>> {
+        return siblings()
     }
+
+    // wish this would work!
+    // lazy var atoms = Siblings(from: self, to: Atom.self, through: Pivot<Compound, Atom>.self)
 
     public static func prepare(_ database: Fluent.Database) throws {
         try database.create(entity) { builder in

--- a/Sources/FluentTester/Tester+PivotsAndRelations.swift
+++ b/Sources/FluentTester/Tester+PivotsAndRelations.swift
@@ -36,16 +36,16 @@ extension Tester {
         try Pivot<Atom, Compound>.attach(oxygen, sugar)
         try Pivot<Atom, Compound>.attach(carbon, sugar)
 
-        let hydrogenCompounds = try hydrogen.compounds().all()
+        let hydrogenCompounds = try hydrogen.compounds.all()
         try testEquals(hydrogenCompounds, [water, sugar])
-        let carbonCompounds = try carbon.compounds().all()
+        let carbonCompounds = try carbon.compounds.all()
         try testEquals(carbonCompounds, [sugar])
-        let oxygenCompounds = try oxygen.compounds().all()
+        let oxygenCompounds = try oxygen.compounds.all()
         try testEquals(oxygenCompounds, [water, sugar])
 
-        let sugarAtoms = try sugar.atoms().all()
+        let sugarAtoms = try sugar.atoms.all()
         try testEquals(sugarAtoms, [carbon, oxygen, hydrogen])
-        let waterAtoms = try water.atoms().all()
+        let waterAtoms = try water.atoms.all()
         try testEquals(waterAtoms, [oxygen, hydrogen])
     }
 

--- a/Tests/FluentTests/JoinTests.swift
+++ b/Tests/FluentTests/JoinTests.swift
@@ -34,10 +34,10 @@ class JoinTests: XCTestCase {
                 XCTAssertEqual(orders.count, 0)
                 XCTAssertEqual(joins.count, 1)
                 if let join = joins.first {
-                    XCTAssert(join.local == Atom.self)
-                    XCTAssertEqual(join.foreign.foreignIdKey, "compound_\(lqd.idKey)")
-                    XCTAssert(join.foreign == Compound.self)
-                    XCTAssertEqual(join.foreign.idKey, lqd.idKey)
+                    XCTAssert(join.base == Atom.self)
+                    XCTAssertEqual(join.joined.foreignIdKey, "compound_\(lqd.idKey)")
+                    XCTAssert(join.joined == Compound.self)
+                    XCTAssertEqual(join.joined.idKey, lqd.idKey)
                 }
                 XCTAssert(limit == nil)
             default:
@@ -61,10 +61,10 @@ class JoinTests: XCTestCase {
                 XCTAssertEqual(orders.count, 0)
                 XCTAssertEqual(joins.count, 1)
                 if let join = joins.first {
-                    XCTAssert(join.local == Atom.self)
-                    XCTAssertEqual(join.foreign.idKey, Compound.idKey)
-                    XCTAssert(join.foreign == Compound.self)
-                    XCTAssertEqual(join.foreign.foreignIdKey, Compound.foreignIdKey)
+                    XCTAssert(join.base == Atom.self)
+                    XCTAssertEqual(join.joined.idKey, Compound.idKey)
+                    XCTAssert(join.joined == Compound.self)
+                    XCTAssertEqual(join.joined.foreignIdKey, Compound.foreignIdKey)
                 }
                 XCTAssert(limit == nil)
             default:

--- a/Tests/FluentTests/JoinTests.swift
+++ b/Tests/FluentTests/JoinTests.swift
@@ -123,7 +123,7 @@ class JoinTests: XCTestCase {
         atom.id = Node(42)
 
         do {
-            _ = try atom.compounds().all()
+            _ = try atom.compounds.all()
         }
 
         if let sql = lqd.lastQuery {

--- a/Tests/FluentTests/PivotTests.swift
+++ b/Tests/FluentTests/PivotTests.swift
@@ -20,7 +20,7 @@ class PivotTests: XCTestCase {
         compound.id = 1337
         compound.exists = true
 
-        try atom.compounds().pivot().attach(atom, compound)
+        try atom.compounds.add(compound)
 
 
         guard let query = lqd.lastQuery else {

--- a/Tests/FluentTests/RelationTests.swift
+++ b/Tests/FluentTests/RelationTests.swift
@@ -56,7 +56,7 @@ class RelationTests: XCTestCase {
         var pivot = try Pivot<Atom, Compound>(hydrogen, water)
         try pivot.save()
 
-        _ = try hydrogen.compounds().all()
+        _ = try hydrogen.compounds.all()
     }
 
     func testCustomForeignKey() throws {

--- a/Tests/FluentTests/Utilities/Atom.swift
+++ b/Tests/FluentTests/Utilities/Atom.swift
@@ -26,8 +26,8 @@ struct Atom: Entity {
         ])
     }
 
-    func compounds() throws -> Siblings<Atom, Compound> {
-        return try siblings()
+    var compounds: Siblings<Atom, Compound, Pivot<Atom, Compound>> {
+        return siblings()
     }
 
     func group() throws -> Parent<Atom, Group> {

--- a/Tests/FluentTests/Utilities/Atom.swift
+++ b/Tests/FluentTests/Utilities/Atom.swift
@@ -31,11 +31,11 @@ final class Atom: Entity {
     }
 
     func group() throws -> Parent<Atom, Group> {
-        return try parent(id: groupId)
+        return parent(id: groupId)
     }
 
     func protons() throws -> Children<Atom, Proton> {
-        return try children()
+        return children()
     }
 
     func nucleus() throws -> Nucleus? {


### PR DESCRIPTION
Adds `idType` and `idKey` to `Database` to allow easy overriding of defaults. For example, an application using MySQL that wants UUIDs for everything has to set `uuid` on each model and even then pivots don't get UUID.

Adds query log convenience. We'll have to test this out a bit to see what is easiest, but this is a start. There's no way otherwise to get access to the queries that have been run.

Adds a third generic parameter to siblings. This will allow great protocol extensions.

Adds a pivot name connector string. This will allow people to custom how pivot names are generated.

Adds `Join` child direction as well as simplifying the naming used for joins (hopefully a lot more intuitive now)