### PR TITLE
Child relation fix

### DIFF
--- a/Sources/Fluent/Relations/Children.swift
+++ b/Sources/Fluent/Relations/Children.swift
@@ -14,7 +14,7 @@ extension Children: QueryRepresentable {
             throw RelationError.noIdentifier
         }
         
-        let foreignId = foreignKey ?? "\(type(of: parent))_\(T.idKey)".lowercased()
+        let foreignId = foreignKey ?? "\(type(of: parent).name)_\(T.idKey)".lowercased()
         return try T.query().filter(foreignId, ident)
     }
 }

--- a/Sources/Fluent/Relations/Children.swift
+++ b/Sources/Fluent/Relations/Children.swift
@@ -14,7 +14,7 @@ extension Children: QueryRepresentable {
             throw RelationError.noIdentifier
         }
         
-        let foreignId = foreignKey ?? "\(T.name)_\(T.idKey)"
+        let foreignId = foreignKey ?? "\(type(of: parent))_\(T.idKey)".lowercased()
         return try T.query().filter(foreignId, ident)
     }
 }

--- a/Tests/FluentTests/ChildTests.swift
+++ b/Tests/FluentTests/ChildTests.swift
@@ -47,13 +47,13 @@ class Owner: Entity {
     }
     
     static func prepare(_ database: Fluent.Database) throws {
-        try database.create("Owners") { pet in
+        try database.create(entity) { pet in
             pet.id()
             pet.string("name")
         }
     }
     static func revert(_ database: Fluent.Database) throws {
-        try database.delete("Pets")
+        try database.delete(Owner.entity)
     }
     
     func makeNode(context: Context) throws -> Node {
@@ -86,14 +86,14 @@ class Pet: Entity {
     }
     
     static func prepare(_ database: Fluent.Database) throws {
-        try database.create("Pets") { pet in
+        try database.create(entity) { pet in
             pet.id()
             pet.string("name")
             pet.parent(Owner.self, optional: false)
         }
     }
     static func revert(_ database: Fluent.Database) throws {
-        try database.delete("Pets")
+        try database.delete(Pet.entity)
     }
     
     func makeNode(context: Context) throws -> Node {

--- a/Tests/FluentTests/ChildTests.swift
+++ b/Tests/FluentTests/ChildTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+import Fluent
+
+class ChildTests: XCTestCase {
+    
+    static let allTests = [
+        ("testChildRelations", testChildRelations)
+    ]
+    
+    func testChildRelations() throws {
+        let memoryDriver = MemoryDriver()
+        let database = Database(memoryDriver)
+        
+        try database.prepare(Owner.self)
+        try database.prepare(Pet.self)
+        
+        var owner1 = Owner(name: "John")
+        try owner1.save()
+        
+        var pet1 = Pet(name: "Fodo", owner: owner1)
+        try pet1.save()
+        
+        let petsOwner = try pet1.getOwner()
+        
+        XCTAssertNotNil(petsOwner)
+        
+        let pets = try owner1.getPets()
+        
+        XCTAssertNotEqual(0, pets.count)
+    }
+    
+}
+
+class Owner: Entity {
+    var id: Node?
+    var exists: Bool = false
+    
+    var name: String
+    
+    init(name: String) {
+        self.name = name
+    }
+    
+    required init(node: Node, in context: Context) throws {
+        id = try node.extract("id")
+        name = try node.extract("name")
+    }
+    
+    static func prepare(_ database: Fluent.Database) throws {
+        try database.create("Owners") { pet in
+            pet.id()
+            pet.string("name")
+        }
+    }
+    static func revert(_ database: Fluent.Database) throws {
+        try database.delete("Pets")
+    }
+    
+    func makeNode(context: Context) throws -> Node {
+        return try Node(node:[
+            "id": id,
+            "name": name,
+            ])
+    }
+    
+    func getPets() throws -> [Pet] {
+        return try children(nil, Pet.self).all()
+    }
+}
+
+class Pet: Entity {
+    var id: Node?
+    var name: String
+    var exists: Bool = false
+    var ownerId: Node?
+    
+    init(name: String, owner: Owner) {
+        self.name = name
+        self.ownerId = owner.id
+    }
+    
+    required init(node: Node, in context: Context) throws {
+        id = try node.extract("id")
+        name = try node.extract("name")
+        ownerId = try node.extract("owner_id")
+    }
+    
+    static func prepare(_ database: Fluent.Database) throws {
+        try database.create("Pets") { pet in
+            pet.id()
+            pet.string("name")
+            pet.parent(Owner.self, optional: false)
+        }
+    }
+    static func revert(_ database: Fluent.Database) throws {
+        try database.delete("Pets")
+    }
+    
+    func makeNode(context: Context) throws -> Node {
+        return try Node(node:[
+            "id": id,
+            "name": name,
+            "owner_id": ownerId
+        ])
+    }
+    
+    func getOwner() throws -> Owner? {
+        return try parent(ownerId, nil, Owner.self).get()
+    }
+    
+}
+

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -14,7 +14,8 @@ XCTMain([
     testCase(SchemaCreateTests.allTests),
     testCase(SQLSerializerTests.allTests),
     testCase(UnionTests.allTests),
-    testCase(MemoryBenchmarkTests.allTests)
+    testCase(MemoryBenchmarkTests.allTests),
+    testCase(ChildTests.allTests)
 ])
 
 #endif


### PR DESCRIPTION
This PR fixes getting children from the database when using the default Foreign ID caused by a bug where it was assuming the Parent was the same type as the Child

Unsure about the `lowercased()` call - it needs to be done somewhere, but not sure if this is the correct place or not.

Also I've chosen 138 to merge into, but we probably need a 1.4 branch to put these changes onto for a release as Fluent 2 has changed completely (though the tests may be useful)