### PR TITLE
support camelCase and snake_case key naming conventions

### DIFF
--- a/Sources/Fluent/Database/Database.swift
+++ b/Sources/Fluent/Database/Database.swift
@@ -36,6 +36,10 @@ public final class Database: Executor {
     /// which do not themselves implement `Entity.idType`.
     public var idType: IdentifierType
 
+    /// The naming convetion to use for foreign
+    /// id keys, ex: snake_case vs. camelCase.
+    public var keyNamingConvention: KeyNamingConvention
+
     /// A closure for handling database logs
     public typealias LogCallback = (Log) -> ()
 
@@ -48,6 +52,7 @@ public final class Database: Executor {
     public init(_ driver: Driver, maxConnections: Int = 128) {
         idKey = driver.idKey
         idType = driver.idType
+        keyNamingConvention = driver.keyNamingConvention
 
         threadConnectionPool = ThreadConnectionPool(
             makeConnection: driver.makeConnection,

--- a/Sources/Fluent/Database/Database.swift
+++ b/Sources/Fluent/Database/Database.swift
@@ -37,7 +37,8 @@ public final class Database: Executor {
     public var idType: IdentifierType
 
     /// The naming convetion to use for foreign
-    /// id keys, ex: snake_case vs. camelCase.
+    /// id keys, table names, etc.
+    /// ex: snake_case vs. camelCase.
     public var keyNamingConvention: KeyNamingConvention
 
     /// A closure for handling database logs

--- a/Sources/Fluent/Database/Driver.swift
+++ b/Sources/Fluent/Database/Driver.swift
@@ -21,6 +21,10 @@ public protocol Driver: Executor {
     /// which do not themselves implement `Entity.idType`.
     var idType: IdentifierType { get }
 
+    /// The naming convetion to use for foreign
+    /// id keys, ex: snake_case vs. camelCase.
+    var keyNamingConvention: KeyNamingConvention { get }
+
     /// Creates a connection for executing
     /// queries. This method is used to
     /// automatically create a connection

--- a/Sources/Fluent/Database/Driver.swift
+++ b/Sources/Fluent/Database/Driver.swift
@@ -20,9 +20,10 @@ public protocol Driver: Executor {
     /// The `idType` will be accessed by those Entity implementations
     /// which do not themselves implement `Entity.idType`.
     var idType: IdentifierType { get }
-
+    
     /// The naming convetion to use for foreign
-    /// id keys, ex: snake_case vs. camelCase.
+    /// id keys, table names, etc.
+    /// ex: snake_case vs. camelCase.
     var keyNamingConvention: KeyNamingConvention { get }
 
     /// Creates a connection for executing

--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -52,6 +52,10 @@ public protocol Entity: class, Preparation, NodeConvertible, Storable {
     /// ex: uuid, integer, etc
     static var idType: IdentifierType { get }
 
+    /// The naming convetion to use for foreign
+    /// id keys, ex: snake_case vs. camelCase.
+    static var keyNamingConvention: KeyNamingConvention { get }
+
     /// The name of the column that corresponds
     /// to this entity's identifying key.
     /// The default is 'database.driver.idKey',
@@ -166,6 +170,10 @@ extension Entity {
     public static var foreignIdKey: String {
         return "\(name)_\(idKey)"
     }
+
+    public static var keyNamingConvention: KeyNamingConvention {
+        return database?.keyNamingConvention ?? .snake_case
+    }
 }
 
 // MARK: Database
@@ -200,4 +208,9 @@ extension Entity {
 
         return id
     }
+}
+
+public enum KeyNamingConvention {
+    case snake_case
+    case camelCase
 }

--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -208,7 +208,6 @@ extension Entity {
     /// relatable object from the static database map.
     public static var database: Database? {
         get {
-            print(Database.map)
             if let db = Database.map[Self.identifier] {
                 return db
             } else {

--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -53,7 +53,8 @@ public protocol Entity: class, Preparation, NodeConvertible, Storable {
     static var idType: IdentifierType { get }
 
     /// The naming convetion to use for foreign
-    /// id keys, ex: snake_case vs. camelCase.
+    /// id keys, table names, etc.
+    /// ex: snake_case vs. camelCase.
     static var keyNamingConvention: KeyNamingConvention { get }
 
     /// The name of the column that corresponds

--- a/Sources/Fluent/Entity/KeyNamingConvention.swift
+++ b/Sources/Fluent/Entity/KeyNamingConvention.swift
@@ -1,5 +1,6 @@
 /// The naming convetion to use for foreign
-/// id keys, ex: snake_case vs. camelCase.
+/// id keys, table names, etc.
+/// ex: snake_case vs. camelCase.
 public enum KeyNamingConvention {
     case snake_case
     case camelCase

--- a/Sources/Fluent/Entity/KeyNamingConvention.swift
+++ b/Sources/Fluent/Entity/KeyNamingConvention.swift
@@ -1,0 +1,46 @@
+/// The naming convetion to use for foreign
+/// id keys, ex: snake_case vs. camelCase.
+public enum KeyNamingConvention {
+    case snake_case
+    case camelCase
+}
+
+extension String {
+    internal func snake_case() -> String {
+        let characters = Array(self.characters)
+
+        guard var expanded = characters
+            .first
+            .flatMap({ String($0) })
+            else {
+                return ""
+        }
+
+        characters.suffix(from: 1).forEach { char in
+            if char.isUppercase {
+                expanded.append("_")
+            }
+
+            expanded.append(char)
+        }
+
+        return expanded.lowercased()
+    }
+
+    internal func camelCase() -> String {
+        return
+            String(characters.prefix(1)).lowercased() +
+            String(characters.dropFirst())
+    }
+}
+
+extension Character {
+    internal var isUppercase: Bool {
+        switch self {
+        case "A"..."Z":
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/Fluent/Entity/KeyNamingConvention.swift
+++ b/Sources/Fluent/Entity/KeyNamingConvention.swift
@@ -13,8 +13,8 @@ extension String {
         guard var expanded = characters
             .first
             .flatMap({ String($0) })
-            else {
-                return ""
+        else {
+            return self
         }
 
         characters.suffix(from: 1).forEach { char in
@@ -29,6 +29,10 @@ extension String {
     }
 
     internal func camelCase() -> String {
+        guard characters.count > 0 else {
+            return self
+        }
+
         return
             String(characters.prefix(1)).lowercased() +
             String(characters.dropFirst())

--- a/Sources/Fluent/Pivot/Pivot.swift
+++ b/Sources/Fluent/Pivot/Pivot.swift
@@ -18,6 +18,14 @@ public final class Pivot<
         }
     }
 
+    public static var identifier: String {
+        if Left.name < Right.name {
+            return "Pivot<\(Left.identifier),\(Right.identifier)>"
+        } else {
+            return "Pivot<\(Right.identifier),\(Left.identifier)>"
+        }
+    }
+
     public static var name: String {
         return entity
     }

--- a/Sources/Fluent/SQLite/SQLiteDriver.swift
+++ b/Sources/Fluent/SQLite/SQLiteDriver.swift
@@ -41,6 +41,10 @@ extension SQLiteDriverProtocol {
         return .int
     }
 
+    public var keyNamingConvention: KeyNamingConvention {
+        return .snake_case
+    }
+
     public var closed: Bool {
         // TODO: FIXME
         return false

--- a/Tests/FluentTests/ModelFindTests.swift
+++ b/Tests/FluentTests/ModelFindTests.swift
@@ -25,6 +25,8 @@ class ModelFindTests: XCTestCase {
 
     /// Dummy Driver implementation for testing.
     class DummyDriver: Driver {
+        var keyNamingConvention: KeyNamingConvention = .snake_case
+
         var idType: IdentifierType = .int
         
         var idKey: String {

--- a/Tests/FluentTests/ModelTests.swift
+++ b/Tests/FluentTests/ModelTests.swift
@@ -41,14 +41,14 @@ class ModelTests: XCTestCase {
         
         try! thing.save()
         let saveQ = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
-        XCTAssertEqual(saveQ.0, "INSERT INTO `stringidentifiedthings` (`#id`) VALUES (?)")
+        XCTAssertEqual(saveQ.0, "INSERT INTO `string_identified_things` (`#id`) VALUES (?)")
         XCTAssertEqual(saveQ.1, ["derp"])
         XCTAssertTrue(thing.exists)
         
         _ = try! StringIdentifiedThing.find("derp")
         let findQ = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
 
-        XCTAssertEqual(findQ.0, "SELECT `stringidentifiedthings`.* FROM `stringidentifiedthings` WHERE `stringidentifiedthings`.`#id` = ? LIMIT 0, 1")
+        XCTAssertEqual(findQ.0, "SELECT `string_identified_things`.* FROM `string_identified_things` WHERE `string_identified_things`.`#id` = ? LIMIT 0, 1")
         XCTAssertEqual(findQ.1, ["derp"])
     }
     
@@ -59,7 +59,7 @@ class ModelTests: XCTestCase {
 
         try! thing.save()
         let saveQ = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
-        XCTAssertEqual(saveQ.0, "INSERT INTO `customidentifiedthings` (`#id`) VALUES (?)")
+        XCTAssertEqual(saveQ.0, "INSERT INTO `custom_identified_things` (`#id`) VALUES (?)")
         XCTAssertEqual(saveQ.1, [123])
         XCTAssertTrue(thing.exists)
 
@@ -67,7 +67,7 @@ class ModelTests: XCTestCase {
         if let sql = lqd.lastQuery {
             let findQ = GeneralSQLSerializer(sql: sql).serialize()
 
-            XCTAssertEqual(findQ.0, "SELECT `customidentifiedthings`.* FROM `customidentifiedthings` WHERE `customidentifiedthings`.`#id` = ? LIMIT 0, 1")
+            XCTAssertEqual(findQ.0, "SELECT `custom_identified_things`.* FROM `custom_identified_things` WHERE `custom_identified_things`.`#id` = ? LIMIT 0, 1")
             XCTAssertEqual(findQ.1, [123])
         } else {
             XCTFail("No last query")
@@ -95,4 +95,29 @@ class ModelTests: XCTestCase {
         do { try test.save() } catch {}
         XCTAssert(test.id != nil)
     }
+
+
+    func testKeyNamingConvention() throws {
+        Database.default = nil
+        XCTAssertEqual(CamelModel.foreignIdKey, "camelModelId")
+        XCTAssertEqual(SnakeModel.foreignIdKey, "snake_model_id")
+    }
+}
+
+final class CamelModel: Entity {
+    let storage = Storage()
+    init(node: Node, in context: Context) throws {}
+    func makeNode(context: Context) throws -> Node { return .null }
+    static func prepare(_ database: Database) throws {}
+    static func revert(_ database: Database) throws {}
+    static var keyNamingConvention = KeyNamingConvention.camelCase
+}
+
+final class SnakeModel: Entity {
+    let storage = Storage()
+    init(node: Node, in context: Context) throws {}
+    func makeNode(context: Context) throws -> Node { return .null }
+    static func prepare(_ database: Database) throws {}
+    static func revert(_ database: Database) throws {}
+    static var keyNamingConvention = KeyNamingConvention.snake_case
 }

--- a/Tests/FluentTests/PreparationTests.swift
+++ b/Tests/FluentTests/PreparationTests.swift
@@ -64,7 +64,7 @@ class PreparationTests: XCTestCase {
                 return
             }
             
-            XCTAssertEqual(entity, "stringidentifiedthings")
+            XCTAssertEqual(entity, "string_identified_things")
             
             guard fields.count == 1 else {
                 XCTFail("Invalid field count")
@@ -98,7 +98,7 @@ class PreparationTests: XCTestCase {
                 return
             }
 
-            XCTAssertEqual(entity, "testmodels")
+            XCTAssertEqual(entity, "test_models")
 
             guard fields.count == 3 else {
                 XCTFail("Invalid field count")
@@ -184,6 +184,7 @@ class TestPreparation: Preparation {
 }
 
 class TestSchemaDriver: Driver {
+    var keyNamingConvention: KeyNamingConvention = .snake_case
     var idType: IdentifierType = .int
     var idKey: String = "id"
 

--- a/Tests/FluentTests/SchemaCreateTests.swift
+++ b/Tests/FluentTests/SchemaCreateTests.swift
@@ -37,7 +37,7 @@ class SchemaCreateTests: XCTestCase {
         
         let (statement, values) = serializer.serialize()
         
-        XCTAssertEqual(statement, "CREATE TABLE `stringidentifiedthings` (`#id` STRING(10) PRIMARY KEY NOT NULL)")
+        XCTAssertEqual(statement, "CREATE TABLE `string_identified_things` (`#id` STRING(10) PRIMARY KEY NOT NULL)")
         XCTAssertEqual(values.count, 0)
     }
  
@@ -52,7 +52,7 @@ class SchemaCreateTests: XCTestCase {
         
         let (statement, values) = serializer.serialize()
         
-        XCTAssertEqual(statement, "CREATE TABLE `customidentifiedthings` (`#id` INTEGER PRIMARY KEY NOT NULL)")
+        XCTAssertEqual(statement, "CREATE TABLE `custom_identified_things` (`#id` INTEGER PRIMARY KEY NOT NULL)")
         XCTAssertEqual(values.count, 0)
     }
     

--- a/Tests/FluentTests/Utilities/Dummy.swift
+++ b/Tests/FluentTests/Utilities/Dummy.swift
@@ -19,6 +19,8 @@ final class DummyModel: Entity {
 }
 
 class DummyDriver: Driver {
+    var keyNamingConvention: KeyNamingConvention = .snake_case
+    
     var idType: IdentifierType = .int
 
     var idKey: String {

--- a/Tests/FluentTests/Utilities/LastQueryDriver.swift
+++ b/Tests/FluentTests/Utilities/LastQueryDriver.swift
@@ -1,6 +1,7 @@
 import Fluent
 
 class LastQueryDriver: Driver {
+    var keyNamingConvention: KeyNamingConvention = .snake_case
     var idType: IdentifierType = .int
     var idKey: String = "#id"
 


### PR DESCRIPTION
To change on all models:

```swift
database?.keyNamingConvention = .camelCase
```