### PR TITLE
row convertible

### DIFF
--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -2,7 +2,7 @@ public final class Storage {
     public init() {}
 
     fileprivate var exists: Bool = false
-    fileprivate var id: Node? = nil
+    fileprivate var id: Identifier? = nil
 }
 
 public protocol Storable: class {
@@ -25,7 +25,7 @@ extension Storable {
         }
     }
 
-    public var id: Node? {
+    public var id: Identifier? {
         get {
             return storage.id
         }
@@ -37,7 +37,8 @@ extension Storable {
 
 /// Represents an entity that can be
 /// stored and retrieved from the `Database`.
-public protocol Entity: class, Preparation, NodeConvertible, Storable {
+public protocol Entity: class, Preparation, RowConvertible, Storable {
+    var id: Identifier? { get set }
 
     /// The plural relational name of this model.
     /// Used as the collection or table name.
@@ -222,7 +223,7 @@ extension Entity {
 
 extension Entity {
     @discardableResult
-    public func assertExists() throws -> Node {
+    public func assertExists() throws -> Identifier {
         guard let id = self.id else {
             throw EntityError.noId(Self.self)
         }

--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -25,6 +25,8 @@ extension Storable {
         }
     }
 
+    /// The entity's primary identifier
+    /// used for updating, filtering, deleting, etc.
     public var id: Identifier? {
         get {
             return storage.id
@@ -38,6 +40,10 @@ extension Storable {
 /// Represents an entity that can be
 /// stored and retrieved from the `Database`.
 public protocol Entity: class, Preparation, RowConvertible, Storable {
+    /// The entity's primary identifier
+    /// used for updating, filtering, deleting, etc.
+    /// - note: automatically implemented by Storable
+    ///         only override for custom use cases
     var id: Identifier? { get set }
 
     /// The plural relational name of this model.

--- a/Sources/Fluent/Pivot/DoublePivot.swift
+++ b/Sources/Fluent/Pivot/DoublePivot.swift
@@ -9,7 +9,9 @@ extension PivotProtocol where Left: PivotProtocol, Self: Entity {
         middle: Left.Right,
         right: Right
     ) throws -> Bool {
-        let (leftId, middleId, rightId) = try assertSaved(left, middle, right)
+        let leftId = try left.assertExists()
+        let middleId = try middle.assertExists()
+        let rightId = try right.assertExists()
 
         let result = try Left
             .query()
@@ -31,7 +33,9 @@ extension PivotProtocol where Right: PivotProtocol, Self: Entity {
         middle: Right.Left,
         right: Right.Right
     ) throws -> Bool {
-        let (leftId, middleId, rightId) = try assertSaved(left, middle, right)
+        let leftId = try left.assertExists()
+        let middleId = try middle.assertExists()
+        let rightId = try right.assertExists()
         
         let result = try Right
             .query()
@@ -43,38 +47,4 @@ extension PivotProtocol where Right: PivotProtocol, Self: Entity {
 
         return result != nil
     }
-}
-
-// MARK: Convenience
-
-private func assertSaved(
-    _ left: Entity,
-    _ middle: Entity,
-    _ right: Entity
-) throws -> (Node, Node, Node) {
-    guard left.exists else {
-        throw PivotError.existRequired(left)
-    }
-
-    guard let leftId = left.id else {
-        throw PivotError.idRequired(left)
-    }
-
-    guard middle.exists else {
-        throw PivotError.existRequired(middle)
-    }
-
-    guard let middleId = middle.id else {
-        throw PivotError.idRequired(middle)
-    }
-
-    guard right.exists else {
-        throw PivotError.existRequired(right)
-    }
-
-    guard let rightId = right.id else {
-        throw PivotError.idRequired(right)
-    }
-    
-    return (leftId, middleId, rightId)
 }

--- a/Sources/Fluent/Pivot/Pivot.swift
+++ b/Sources/Fluent/Pivot/Pivot.swift
@@ -30,8 +30,8 @@ public final class Pivot<
         return entity
     }
 
-    public var leftId: Node
-    public var rightId: Node
+    public var leftId: Identifier
+    public var rightId: Identifier
     public let storage = Storage()
 
     public init(_ left: Left, _ right: Right) throws {
@@ -55,21 +55,19 @@ public final class Pivot<
         self.rightId = rightId
     }
 
-    public init(node: Node) throws {
-        leftId = try node.get(Left.foreignIdKey)
-        rightId = try node.get(Right.foreignIdKey)
+    public init(row: Row) throws {
+        leftId = try row.get(Left.foreignIdKey)
+        rightId = try row.get(Right.foreignIdKey)
 
-        id = try node.get(idKey)
+        id = try row.get(idKey)
     }
 
-    public func makeNode(in context: Context?) throws -> Node {
-        let node = [
-            idKey: id,
-            Left.foreignIdKey: leftId,
-            Right.foreignIdKey: rightId,
-        ]
-
-        return try Node(node: node)
+    public func makeRow() throws -> Row {
+        var row = Row()
+        try row.set(idKey, id)
+        try row.set(Left.foreignIdKey, leftId)
+        try row.set(Right.foreignIdKey, rightId)
+        return row
     }
 
     public static func prepare(_ database: Database) throws {

--- a/Sources/Fluent/Preparation/Migration.swift
+++ b/Sources/Fluent/Preparation/Migration.swift
@@ -7,16 +7,16 @@ final class Migration: Entity {
         self.name = name
     }
 
-    init(node: Node) throws {
-        name = try node.get("name")
-        id = try node.get(idKey)
+    init(row: Row) throws {
+        name = try row.get("name")
+        id = try row.get(idKey)
     }
 
-    func makeNode(in context: Context?) throws -> Node {
-        var node = Node([:])
-        try node.set(idKey, id)
-        try node.set("name", name)
-        return node
+    func makeRow() throws -> Row {
+        var row = Row()
+        try row.set(idKey, id)
+        try row.set("name", name)
+        return row
     }
 
     static func prepare(_ database: Database) throws {

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -67,9 +67,13 @@ public final class Query<T: Entity> {
 
         for result in array {
             do {
-                let model = try T(node: result, in: context)
-                if let dict = result.typeObject {
-                    model.id = dict[T.idKey]
+                let row = Row(node: result)
+                let model = try T(row: row)
+                if 
+                    let dict = result.typeObject, 
+                    let id = dict[T.idKey]
+                {
+                    model.id = Identifier(id)
                 }
                 models.append(model)
             } catch {

--- a/Sources/Fluent/Row/Identifier.swift
+++ b/Sources/Fluent/Row/Identifier.swift
@@ -1,7 +1,6 @@
-/// Represents a database row or entity. 
-/// Fluent parses Rows from fetch queries and serializes
-/// Rows to create and update queries.
-public struct Row: StructuredDataWrapper {
+/// Represents a database row identifier.
+/// Uses the same context as Row.
+public struct Identifier: StructuredDataWrapper {
     public static let defaultContext = rowContext
     public var wrapped: StructuredData
     public let context: Context

--- a/Sources/Fluent/Row/RowContext.swift
+++ b/Sources/Fluent/Row/RowContext.swift
@@ -1,0 +1,25 @@
+public final class RowContext: Context {
+    public var database: Database?
+    public init() {}
+}
+
+public let rowContext = RowContext()
+
+extension Context {
+    public var isRow: Bool {
+        guard let _ = self as? RowContext else { return false }
+        return true
+    }
+
+    public var database: Database? {
+        guard let val = self as? RowContext else { return nil }
+        return val.database
+    }
+}
+
+// MARK: Error
+
+public enum RowContextError: Error {
+    case unexpectedContext(Context?)
+    case unspecified(Swift.Error)
+}

--- a/Sources/Fluent/Row/RowConvertible.swift
+++ b/Sources/Fluent/Row/RowConvertible.swift
@@ -1,0 +1,33 @@
+// MARK: Convertible
+
+public protocol RowConvertible: RowRepresentable, RowInitializable, NodeConvertible {}
+
+// MARK: Representable
+
+public protocol RowRepresentable: NodeRepresentable {
+    func makeRow() throws -> Row
+}
+
+extension NodeRepresentable where Self: RowRepresentable {
+    public func makeNode(in context: Context?) throws -> Node {
+        guard
+            let unwrapped = context,
+            unwrapped.isRow
+            else { throw RowContextError.unexpectedContext(context) }
+        return try makeRow().converted()
+    }
+}
+
+// MARK: Initializable
+
+public protocol RowInitializable: NodeInitializable {
+    init(row: Row) throws
+}
+
+extension NodeInitializable where Self: RowInitializable {
+    public init(node: Node) throws {
+        guard node.context.isRow else { throw RowContextError.unexpectedContext(node.context) }
+        let row = node.converted(to: Row.self)
+        try self.init(row: row)
+    }
+}

--- a/Sources/Fluent/Utilities/Exports.swift
+++ b/Sources/Fluent/Utilities/Exports.swift
@@ -1,0 +1,6 @@
+#if COCOAPODS
+    @_exported import NodeCocoapods
+#else
+    @_exported import Node
+#endif
+

--- a/Sources/FluentTester/Atom.swift
+++ b/Sources/FluentTester/Atom.swift
@@ -5,28 +5,25 @@ public final class Atom: Entity {
 
     public let storage = Storage()
 
-    public init(id: Node?, name: String, protons: Int, weight: Double) {
+    public init(id: Identifier?, name: String, protons: Int, weight: Double) {
         self.name = name
         self.protons = protons
         self.weight = weight
         self.id = id
     }
 
-    public init(node: Node) throws {
-        name = try node.get("name")
-        protons = try node.get("protons")
-        weight = try node.get("weight")
-
-        id = try node.get(idKey)
+    public init(row: Row) throws {
+        name = try row.get("name")
+        protons = try row.get("protons")
+        weight = try row.get("weight")
     }
 
-    public func makeNode(in context: Context?) throws -> Node {
-        return try Node(node: [
-            idKey: id ?? nil,
-            "name": name,
-            "protons": protons,
-            "weight": weight
-        ])
+    public func makeRow() throws -> Row {
+        var row = Row()
+        try row.set("name", name)
+        try row.set("protons", protons)
+        try row.set("weight", weight)
+        return row
     }
 
     var compounds: Siblings<Atom, Compound, Pivot<Atom, Compound>> {

--- a/Sources/FluentTester/Compound.swift
+++ b/Sources/FluentTester/Compound.swift
@@ -2,21 +2,20 @@ public final class Compound: Entity {
     public var name: String
     public let storage = Storage()
 
-    public init(id: Node?, name: String) {
+    public init(id: Identifier?, name: String) {
         self.name = name
         self.id = id
     }
 
-    public init(node: Node) throws {
-        name = try node.get("name")
-        id = try node.get(idKey)
+    public init(row: Row) throws {
+        name = try row.get("name")
     }
 
-    public func makeNode(in context: Context?) throws -> Node {
-        return try Node(node: [
-            idKey: id ?? nil,
-            "name": name
-        ])
+    public func makeRow() throws -> Row {
+        var row = Row()
+        try row.set(idKey, id)
+        try row.set("name", name)
+        return row
     }
 
     var atoms: Siblings<Compound, Atom, Pivot<Compound, Atom>> {

--- a/Sources/FluentTester/Student.swift
+++ b/Sources/FluentTester/Student.swift
@@ -15,24 +15,24 @@ final class Student: Entity {
         self.meta = meta
     }
     
-    init(node: Node) throws {
-        name = try node.get("name")
-        age = try node.get("age")
-        ssn = try node.get("ssn")
-        donor = try node.get("donor")
-        meta = try node.get("meta")
-        id = try node.get(idKey)
+    init(row: Row) throws {
+        name = try row.get("name")
+        age = try row.get("age")
+        ssn = try row.get("ssn")
+        donor = try row.get("donor")
+        meta = try row.get("meta")
+        id = try row.get(idKey)
     }
     
-    func makeNode(in context: Context?) throws -> Node {
-        var node = Node([:])
-        try node.set(idKey, id)
-        try node.set("name", name)
-        try node.set("age", age)
-        try node.set("ssn", ssn)
-        try node.set("donor", donor)
-        try node.set("meta", meta)
-        return node
+    func makeRow() throws -> Row {
+        var row = Row()
+        try row.set(idKey, id)
+        try row.set("name", name)
+        try row.set("age", age)
+        try row.set("ssn", ssn)
+        try row.set("donor", donor)
+        try row.set("meta", meta)
+        return row
     }
     
     static func prepare(_ database: Database) throws {

--- a/Tests/FluentTests/CallbackTests.swift
+++ b/Tests/FluentTests/CallbackTests.swift
@@ -16,11 +16,11 @@ class CallbacksTests: XCTestCase {
             
         }
         
-        init(node: Node) throws {
+        init(row: Row) throws {
 
         }
 
-        func makeNode(in context: Context?) -> Node {
+        func makeRow() -> Row {
             return .null
         }
         

--- a/Tests/FluentTests/JoinTests.swift
+++ b/Tests/FluentTests/JoinTests.swift
@@ -120,7 +120,7 @@ class JoinTests: XCTestCase {
 
     func testSiblings() throws {
         let atom = Atom(name: "Hydrogen")
-        atom.id = Node(42)
+        atom.id = 42
 
         do {
             _ = try atom.compounds.all()

--- a/Tests/FluentTests/ModelFindTests.swift
+++ b/Tests/FluentTests/ModelFindTests.swift
@@ -13,11 +13,11 @@ class ModelFindTests: XCTestCase {
         static func prepare(_ database: Database) throws {}
         static func revert(_ database: Database) throws {}
 
-        init(node: Node) throws {
+        init(row: Row) throws {
 
         }
 
-        func makeNode(in context: Context?) -> Node {
+        func makeRow() -> Row {
             return .null
         }
 

--- a/Tests/FluentTests/ModelTests.swift
+++ b/Tests/FluentTests/ModelTests.swift
@@ -37,7 +37,8 @@ class ModelTests: XCTestCase {
     
     func testStringIdentifiedThings() throws {
         StringIdentifiedThing.database = db
-        let thing = try! StringIdentifiedThing(node: ["#id": "derp"], in: nil)
+        let thing = StringIdentifiedThing()
+        thing.id = "derp"
         
         try! thing.save()
         let saveQ = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
@@ -55,7 +56,8 @@ class ModelTests: XCTestCase {
     func testCustomIdentifiedThings() throws {
         CustomIdentifiedThing.database = db
 
-        let thing = try! CustomIdentifiedThing(node: ["#id": 123], in: nil)
+        let thing = CustomIdentifiedThing()
+        thing.id = 123
 
         try! thing.save()
         let saveQ = GeneralSQLSerializer(sql: lqd.lastQuery!).serialize()
@@ -79,11 +81,13 @@ class ModelTests: XCTestCase {
             let storage = Storage()
             
             init() {}
-            init(node: Node) throws {
-                id = try node.get(idKey)
+            init(row: Row) throws {
+                id = try row.get(idKey)
             }
-            func makeNode(in context: Context?) throws -> Node {
-                return try Node(node: [idKey: id])
+            func makeRow() throws -> Row {
+                var row = Row()
+                try row.set(idKey, id)
+                return row
             }
             static func prepare(_ database: Database) throws {}
             static func revert(_ database: Database) throws {}
@@ -106,8 +110,8 @@ class ModelTests: XCTestCase {
 
 final class CamelModel: Entity {
     let storage = Storage()
-    init(node: Node) throws {}
-    func makeNode(in context: Context?) throws -> Node { return .null }
+    init(row: Row) throws {}
+    func makeRow() throws -> Row { return .null }
     static func prepare(_ database: Database) throws {}
     static func revert(_ database: Database) throws {}
     static var keyNamingConvention = KeyNamingConvention.camelCase
@@ -115,8 +119,8 @@ final class CamelModel: Entity {
 
 final class SnakeModel: Entity {
     let storage = Storage()
-    init(node: Node) throws {}
-    func makeNode(in context: Context?) throws -> Node { return .null }
+    init(row: Row) throws {}
+    func makeRow() throws -> Row { return .null }
     static func prepare(_ database: Database) throws {}
     static func revert(_ database: Database) throws {}
     static var keyNamingConvention = KeyNamingConvention.snake_case

--- a/Tests/FluentTests/PivotTests.swift
+++ b/Tests/FluentTests/PivotTests.swift
@@ -22,7 +22,6 @@ class PivotTests: XCTestCase {
 
         try atom.compounds.add(compound)
 
-
         guard let query = lqd.lastQuery else {
             XCTFail("No query recorded")
             return
@@ -32,7 +31,7 @@ class PivotTests: XCTestCase {
 
         XCTAssertEqual(
             sql,
-            "INSERT INTO `atom_compound` (`\(lqd.idKey)`, `\(Atom.foreignIdKey)`, `\(Compound.foreignIdKey)`) VALUES (?, ?, ?)"
+            "INSERT INTO `atom_compound` (`\(Atom.foreignIdKey)`, `\(Compound.foreignIdKey)`) VALUES (?, ?)"
         )
     }
 

--- a/Tests/FluentTests/PreparationTests.swift
+++ b/Tests/FluentTests/PreparationTests.swift
@@ -141,18 +141,16 @@ final class TestModel: Entity {
     var age: Int
     let storage = Storage()
 
-    init(node: Node) throws {
-        name = try node.get("name")
-        age = try node.get("age")
-        id = try node.get(idKey)
+    init(row: Row) throws {
+        name = try row.get("name")
+        age = try row.get("age")
     }
 
-    func makeNode(in context: Context?) throws -> Node {
-        return try Node(node: [
-            idKey: id ?? nil,
-            "name": name,
-            "age": age
-        ])
+    func makeRow() throws -> Row {
+        var row = Row()
+        try row.set("name", name)
+        try row.set("age", age)
+        return row
     }
 
     static func prepare(_ database: Database) throws {

--- a/Tests/FluentTests/RelationTests.swift
+++ b/Tests/FluentTests/RelationTests.swift
@@ -28,12 +28,11 @@ class RelationTests: XCTestCase {
     }
 
     func testHasMany() throws {
-
-        let hydrogen = try Atom(node: [
-            Atom.idKey: 42,
+        let hydrogen = try Atom(row: [
             "name": "Hydrogen",
             "group_id": 1337
         ])
+        hydrogen.id = 42
 
         let protons = try hydrogen.protons()
         _ = try protons.all()
@@ -42,7 +41,7 @@ class RelationTests: XCTestCase {
     }
 
     func testBelongsToMany() throws {
-        let hydrogen = try Atom(node: [
+        let hydrogen = try Atom(row: [
             "name": "Hydrogen",
             "group_id": 1337
         ])
@@ -50,7 +49,7 @@ class RelationTests: XCTestCase {
         hydrogen.id = 42
         try hydrogen.save()
 
-        let water = try Compound(node: [
+        let water = try Compound(row: [
             "name": "Water"
         ])
         try water.save()
@@ -64,11 +63,11 @@ class RelationTests: XCTestCase {
     }
 
     func testCustomForeignKey() throws {
-        let hydrogen = try Atom(node: [
-            Atom.idKey: 42,
+        let hydrogen = try Atom(row: [
             "name": "Hydrogen",
             "group_id": 1337
         ])
+        hydrogen.id = 42
         Atom.database = database
         Nucleus.database = database
 

--- a/Tests/FluentTests/Utilities/Atom.swift
+++ b/Tests/FluentTests/Utilities/Atom.swift
@@ -5,25 +5,23 @@ final class Atom: Entity {
     var groupId: Node
     let storage = Storage()
 
-    init(name: String, id: Node? = nil) {
+    init(name: String, id: Identifier? = nil) {
         self.name = name
         self.groupId = 0
         self.id = id
     }
 
-    init(node: Node) throws {
-        name = try node.get("name")
-        groupId = try node.get("group_id")
-
-        id = try node.get(idKey)
+    init(row: Row) throws {
+        name = try row.get("name")
+        groupId = try row.get("group_id")
     }
 
-    func makeNode(in context: Context?) throws -> Node {
-        return try Node(node: [
-            idKey: id ?? nil,
-            "name": name,
-            "group_id": groupId
-        ])
+    func makeRow() throws -> Row {
+        var row = Row()
+        try row.set(idKey, id)
+        try row.set("name", name)
+        try row.set("group_id", groupId)
+        return row
     }
 
     var compounds: Siblings<Atom, Compound, Pivot<Atom, Compound>> {

--- a/Tests/FluentTests/Utilities/Compound.swift
+++ b/Tests/FluentTests/Utilities/Compound.swift
@@ -8,16 +8,16 @@ final class Compound: Entity {
         self.name = name
     }
 
-    init(node: Node) throws {
-        name = try node.get("name")
-        id = try node.get(idKey)
+    init(row: Row) throws {
+        name = try row.get("name")
+        id = try row.get(idKey)
     }
 
-    func makeNode(in context: Context?) throws -> Node {
-        return try Node(node: [
-            idKey: id ?? nil,
-            "name": name
-        ])
+    func makeRow() throws -> Row {
+        var row = Row()
+        try row.set(idKey, id)
+        try row.set("name", name)
+        return row
     }
 
     static func prepare(_ database: Fluent.Database) throws {

--- a/Tests/FluentTests/Utilities/CustomIdKey.swift
+++ b/Tests/FluentTests/Utilities/CustomIdKey.swift
@@ -19,20 +19,18 @@ final class CustomIdKey: Entity {
     
     var label: String
     
-    init(id: Node?, label: String) {
+    init(id: Identifier?, label: String) {
         self.label = label
         self.id = id
     }
     
-    init(node: Node) throws {
-        label = try node.get("label")
-        id = try node.get(idKey)
+    init(row: Row) throws {
+        label = try row.get("label")
     }
     
-    func makeNode(in context: Context?) throws -> Node {
-        return try Node(node: [
-            idKey: id ?? nil,
-            "label": label,
-        ])
+    func makeRow() throws -> Row {
+        var row = Row()
+        try row.set("label", label)
+        return row
     }
 }

--- a/Tests/FluentTests/Utilities/CustomIdentifiedThing.swift
+++ b/Tests/FluentTests/Utilities/CustomIdentifiedThing.swift
@@ -12,13 +12,11 @@ import Fluent
 final class CustomIdentifiedThing: Entity {
     let storage = Storage()
     static let idKey = "#id"
+    init() {}
     
-    init(node: Node) throws {
-        id = try node.get(idKey)
-    }
-    
-    func makeNode(in context: Context?) throws -> Node {
-        return try Node(node: [idKey: id])
+    init(row: Row) throws {}
+    func makeRow() throws -> Row {
+        return Row()
     }
     
     static var idType: IdentifierType { return .custom("INTEGER") }

--- a/Tests/FluentTests/Utilities/Dummy.swift
+++ b/Tests/FluentTests/Utilities/Dummy.swift
@@ -9,13 +9,8 @@ final class DummyModel: Entity {
     static func prepare(_ database: Database) throws {}
     static func revert(_ database: Database) throws {}
 
-    init(node: Node) throws {
-
-    }
-
-    func makeNode(in context: Context?) -> Node {
-        return .null
-    }
+    init(row: Row) {}
+    func makeRow() -> Row { return .null}
 }
 
 class DummyDriver: Driver {

--- a/Tests/FluentTests/Utilities/Group.swift
+++ b/Tests/FluentTests/Utilities/Group.swift
@@ -2,9 +2,8 @@ import Fluent
 
 final class Group: Entity {
     let storage = Storage()
-    init(node: Node) throws {}
-
-    func makeNode(in context: Context?) -> Node { return .null }
+    init(row: Row) throws {}
+    func makeRow() -> Row { return .null }
     static func prepare(_ database: Database) throws {
         try database.create(self) { groups in
             groups.id(for: self)

--- a/Tests/FluentTests/Utilities/Nucleus.swift
+++ b/Tests/FluentTests/Utilities/Nucleus.swift
@@ -4,9 +4,8 @@ final class Nucleus: Entity {
     let storage = Storage()
     static var entity = "nuclei"
 
-    init(node: Node) throws { }
-
-    func makeNode(in context: Context?) -> Node { return .null }
+    init(row: Row) { }
+    func makeRow() -> Row { return .null }
     static func prepare(_ database: Database) throws {
         try database.create(self) { nuclei in
             nuclei.id(for: self)

--- a/Tests/FluentTests/Utilities/Proton.swift
+++ b/Tests/FluentTests/Utilities/Proton.swift
@@ -2,9 +2,8 @@ import Fluent
 
 final class Proton: Entity {
     let storage = Storage()
-    init(node: Node) throws {}
-
-    func makeNode(in context: Context?) -> Node { return .null }
+    init(row: Row) throws {}
+    func makeRow() -> Row { return .null }
     static func prepare(_ database: Database) throws {
         try database.create(self) { protons in
             protons.id(for: self)

--- a/Tests/FluentTests/Utilities/StringIdentifiedThing.swift
+++ b/Tests/FluentTests/Utilities/StringIdentifiedThing.swift
@@ -13,13 +13,17 @@ import Fluent
 final class StringIdentifiedThing: Entity {
     static var idKey = "#id"
     let storage = Storage()
+
+    init() {}
     
-    init(node: Node) throws {
-        id = try node.get(idKey)
+    init(row: Row) throws {
+        id = try row.get(idKey)
     }
     
-    func makeNode(in context: Context?) throws -> Node {
-        return try Node(node: [idKey: id])
+    func makeRow() throws -> Row {
+        var row = Row()
+        try row.set(idKey, id)
+        return row
     }
     
     static var idType: IdentifierType { return .custom("STRING(10)") }

--- a/Tests/FluentTests/Utilities/User.swift
+++ b/Tests/FluentTests/Utilities/User.swift
@@ -17,24 +17,24 @@ final class User: Entity {
     var name: String
     var email: String
 
-    init(id: Node?, name: String, email: String) {
+    init(id: Identifier?, name: String, email: String) {
         self.name = name
         self.email = email
         self.id = id
     }
 
-    init(node: Node) throws {
-        name = try node.get("name")
-        email = try node.get("email")
-        id = try node.get(idKey)
+    init(row: Row) throws {
+        name = try row.get("name")
+        email = try row.get("email")
+        id = try row.get(idKey)
     }
 
-    func makeNode(in context: Context?) throws -> Node {
-        return try Node(node: [
-            idKey: id ?? nil,
-            "name": name,
-            "email": email
-        ])
+    func makeRow() throws -> Row {
+        var row = Row()
+        try row.set(idKey, id)
+        try row.set("name", name)
+        try row.set("email", email)
+        return row
     }
 }
 


### PR DESCRIPTION
- Fluent now parses and serializes `Row`s. 
- Makes `Entity` conform to `RowConvertible` 
- New `Identifier` type instead of `Node` for ids