### PR TITLE
pagination

### DIFF
--- a/Sources/Fluent/Pagination/Page.swift
+++ b/Sources/Fluent/Pagination/Page.swift
@@ -1,0 +1,22 @@
+// Represents a page of results for the entity
+public struct Page<T: Entity & Paginatable> {
+    public let number: Int
+    public let data: [T]
+    public let size: Int
+    public let total: Int
+
+    // The query used must already be filtered for
+    // pagination and ready for `.all()` call
+    public init(
+        number: Int,
+        data: [T],
+        size: Int = T.pageSize,
+        total: Int
+    ) {
+        self.number = number > 0 ? number : 1
+        self.data = data
+        self.size = size
+        self.total = total
+    }
+}
+

--- a/Sources/Fluent/Pagination/Page.swift
+++ b/Sources/Fluent/Pagination/Page.swift
@@ -12,11 +12,13 @@ public struct Page<T: Entity & Paginatable> {
         data: [T],
         size: Int = T.pageSize,
         total: Int
-    ) {
-        self.number = number > 0 ? number : 1
+    ) throws {
+        guard number > 0 else {
+            throw PaginationError.invalidPageNumber(number)
+        }
+        self.number = number
         self.data = data
         self.size = size
         self.total = total
     }
 }
-

--- a/Sources/Fluent/Pagination/Paginatable.swift
+++ b/Sources/Fluent/Pagination/Paginatable.swift
@@ -1,0 +1,22 @@
+// Conforming to this protocol allows the entity
+// to be paginated using `query.paginate()`
+public protocol Paginatable: Entity {
+    static var pageSize: Int { get }
+    static var pageSorts: [Sort] { get }
+}
+
+// MARK: Optional
+
+public var defaultPageSize: Int = 10
+
+extension Paginatable {
+    public static var pageSize: Int {
+        return defaultPageSize
+    }
+
+    public static var pageSorts: [Sort] {
+        return [
+            Sort(self, "createdAt", .descending)
+        ]
+    }
+}

--- a/Sources/Fluent/Pagination/PaginationError.swift
+++ b/Sources/Fluent/Pagination/PaginationError.swift
@@ -1,0 +1,39 @@
+public enum PaginationError: Error {
+    case invalidPageNumber(Int)
+    case unspecified(Error)
+}
+
+import Debugging
+
+extension PaginationError: Debuggable {
+    public var reason: String {
+        switch self {
+        case .invalidPageNumber(let num):
+            return "'\(num)' is not a valid page number."
+        case .unspecified(let error):
+            return "Unknown: \(error)"
+        }
+    }
+
+    public var identifier: String {
+        switch self {
+        case .invalidPageNumber:
+            return "invalidPageNumber"
+        case .unspecified:
+            return "unknown"
+        }
+    }
+
+    public var possibleCauses: [String] {
+        switch self {
+        case .invalidPageNumber:
+            return ["Using a page number that is less than 1"]
+        case .unspecified:
+            return []
+        }
+    }
+
+    public var suggestedFixes: [String] {
+        return []
+    }
+}

--- a/Sources/Fluent/Pagination/Query+Page.swift
+++ b/Sources/Fluent/Pagination/Query+Page.swift
@@ -1,0 +1,33 @@
+extension QueryRepresentable where T: Paginatable {
+    public func paginate(
+        page: Int,
+        count: Int = T.pageSize,
+        _ sorts: [Sort] = T.pageSorts
+    ) throws -> Page<T> {
+        // require page 1 or greater
+        let page = page > 0 ? page : 1
+
+        // create the query and get a total count
+        let query = try makeQuery()
+        let total = try query.count()
+
+        // limit the query to the desired page
+        query.limit = Limit(
+            count: count,
+            offset: (page - 1) * count
+        )
+
+        // add the sorts w/o replacing
+        query.sorts += sorts
+
+        // fetch the data
+        let data = try query.all()
+
+        return Page(
+            number: page,
+            data: data,
+            size: count,
+            total: total
+        )
+    }
+}

--- a/Sources/Fluent/Pagination/Query+Page.swift
+++ b/Sources/Fluent/Pagination/Query+Page.swift
@@ -4,6 +4,9 @@ extension QueryRepresentable where T: Paginatable {
         count: Int = T.pageSize,
         _ sorts: [Sort] = T.pageSorts
     ) throws -> Page<T> {
+        guard page > 0 else {
+            throw PaginationError.invalidPageNumber(page)
+        }
         // require page 1 or greater
         let page = page > 0 ? page : 1
 
@@ -23,7 +26,7 @@ extension QueryRepresentable where T: Paginatable {
         // fetch the data
         let data = try query.all()
 
-        return Page(
+        return try Page(
             number: page,
             data: data,
             size: count,

--- a/Sources/FluentTester/Compound.swift
+++ b/Sources/FluentTester/Compound.swift
@@ -2,7 +2,7 @@ public final class Compound: Entity {
     public var name: String
     public let storage = Storage()
 
-    public init(id: Identifier?, name: String) {
+    public init(id: Identifier? = nil, name: String) {
         self.name = name
         self.id = id
     }
@@ -22,9 +22,6 @@ public final class Compound: Entity {
         return siblings()
     }
 
-    // wish this would work!
-    // lazy var atoms = Siblings(from: self, to: Atom.self, through: Pivot<Compound, Atom>.self)
-
     public static func prepare(_ database: Fluent.Database) throws {
         try database.create(self) { builder in
             builder.id(for: self)
@@ -34,5 +31,17 @@ public final class Compound: Entity {
 
     public static func revert(_ database: Fluent.Database) throws {
         try database.delete(self)
+    }
+}
+
+extension Compound: Paginatable {
+    public static var pageSize: Int {
+        return 2
+    }
+
+    public static var pageSorts: [Sort] {
+        return [
+            Sort(self, "name", .ascending)
+        ]
     }
 }

--- a/Sources/FluentTester/Tester+Paginate.swift
+++ b/Sources/FluentTester/Tester+Paginate.swift
@@ -1,0 +1,47 @@
+extension Tester {
+    public func testPaginate() throws {
+        Compound.database = database
+        try Compound.prepare(database)
+        defer {
+            try? Compound.revert(database)
+        }
+
+        let ethanol = Compound(name: "Ethanol")
+        let hcl = Compound(name: "Hydrochloric Acid")
+        let methanol = Compound(name: "Methanol")
+        let water = Compound(name: "Water")
+
+        try ethanol.save()
+        try hcl.save()
+        try methanol.save()
+        try water.save()
+
+        let page = try Compound
+            .query()
+            .paginate(page: 2)
+
+        guard page.data.count == 2 else {
+            throw Error.failed("Page data count did not equal 2.")
+        }
+
+        guard page.data.first?.name == "Methanol" else {
+            throw Error.failed("Page data failed. Expected methanol got \(page.data.first?.name ?? "nil")")
+        }
+
+        guard page.data.last?.name == "Water" else {
+            throw Error.failed("Page data failed. Expected water got \(page.data.last?.name ?? "nil")")
+        }
+
+        guard page.total == 4 else {
+            throw Error.failed("Expected 4 in total.")
+        }
+
+        guard page.number == 2 else {
+            throw Error.failed("Expected page 2.")
+        }
+
+        guard page.size == 2 else {
+            throw Error.failed("Expected page size to be 2.")
+        }
+    }
+}

--- a/Sources/FluentTester/Tester.swift
+++ b/Sources/FluentTester/Tester.swift
@@ -18,5 +18,6 @@ public final class Tester {
         try test(testPivotsAndRelations, "Pivots and relations")
         try test(testDoublePivot, "Double pivot")
         try test(testSchema, "Schema")
+        try test(testPaginate, "Pagination")
     }
 }


### PR DESCRIPTION
Adds basic pagination to Fluent.

```swift
public func index(_ req: Request) throws -> ResponseRepresentable {
    return try User.paginate(for: req)
}
```

To work, `User` must conform to `Paginatable`. All properties are currently optional.

```swift
extension User: Paginatable {
    public static var pageSize: Int {
        return 2
    }

    public static var pageSorts: [Sort] {
        return [
            Sort(self, "name", .ascending)
        ]
    }
}
```