### PR TITLE
separate preparation from entity

### DIFF
--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -39,7 +39,7 @@ extension Storable {
 
 /// Represents an entity that can be
 /// stored and retrieved from the `Database`.
-public protocol Entity: class, Preparation, RowConvertible, Storable {
+public protocol Entity: class, RowConvertible, Storable {
     /// The entity's primary identifier
     /// used for updating, filtering, deleting, etc.
     /// - note: automatically implemented by Storable

--- a/Tests/FluentTests/CallbackTests.swift
+++ b/Tests/FluentTests/CallbackTests.swift
@@ -9,9 +9,6 @@ class CallbacksTests: XCTestCase {
         var wasModifiedOnCreate: Bool = false
         var wasModifiedOnUpdate: Bool = false
 
-        static func prepare(_ database: Database) throws {}
-        static func revert(_ database: Database) throws {}
-
         init() {
             
         }

--- a/Tests/FluentTests/ModelFindTests.swift
+++ b/Tests/FluentTests/ModelFindTests.swift
@@ -10,9 +10,6 @@ class ModelFindTests: XCTestCase {
             return "dummy_models"
         }
 
-        static func prepare(_ database: Database) throws {}
-        static func revert(_ database: Database) throws {}
-
         init(row: Row) throws {
 
         }

--- a/Tests/FluentTests/ModelTests.swift
+++ b/Tests/FluentTests/ModelTests.swift
@@ -89,8 +89,6 @@ class ModelTests: XCTestCase {
                 try row.set(idKey, id)
                 return row
             }
-            static func prepare(_ database: Database) throws {}
-            static func revert(_ database: Database) throws {}
             static var idType = IdentifierType.uuid
         }
         UUIDModel.database = db
@@ -112,8 +110,6 @@ final class CamelModel: Entity {
     let storage = Storage()
     init(row: Row) throws {}
     func makeRow() throws -> Row { return .null }
-    static func prepare(_ database: Database) throws {}
-    static func revert(_ database: Database) throws {}
     static var keyNamingConvention = KeyNamingConvention.camelCase
 }
 
@@ -121,7 +117,5 @@ final class SnakeModel: Entity {
     let storage = Storage()
     init(row: Row) throws {}
     func makeRow() throws -> Row { return .null }
-    static func prepare(_ database: Database) throws {}
-    static func revert(_ database: Database) throws {}
     static var keyNamingConvention = KeyNamingConvention.snake_case
 }

--- a/Tests/FluentTests/RelationTests.swift
+++ b/Tests/FluentTests/RelationTests.swift
@@ -11,7 +11,7 @@ class RelationTests: XCTestCase {
 
     var memory: MemoryDriver!
     var database: Database!
-    let ents = [Atom.self, Proton.self, Nucleus.self, Group.self] as [Entity.Type]
+    let ents = [Atom.self, Proton.self, Nucleus.self, Group.self] as [(Entity & Preparation).Type]
 
     override func setUp() {
         memory = try! MemoryDriver()

--- a/Tests/FluentTests/Utilities/Atom.swift
+++ b/Tests/FluentTests/Utilities/Atom.swift
@@ -40,17 +40,6 @@ final class Atom: Entity {
         return try children().first()
     }
 
-    static func prepare(_ database: Fluent.Database) throws {
-        try database.create(self) { builder in
-            builder.id(for: self)
-            builder.string("name")
-            builder.int("group_id")
-        }
-    }
-    static func revert(_ database: Fluent.Database) throws {
-        try database.delete(self)
-    }
-
     // MARK: Callbacks
 
     func willCreate() {
@@ -75,5 +64,18 @@ final class Atom: Entity {
 
     func didDelete() {
         print("Atom did delete.")
+    }
+}
+
+extension Atom: Preparation {
+    static func prepare(_ database: Fluent.Database) throws {
+        try database.create(self) { builder in
+            builder.id(for: self)
+            builder.string("name")
+            builder.int("group_id")
+        }
+    }
+    static func revert(_ database: Fluent.Database) throws {
+        try database.delete(self)
     }
 }

--- a/Tests/FluentTests/Utilities/Dummy.swift
+++ b/Tests/FluentTests/Utilities/Dummy.swift
@@ -6,9 +6,6 @@ final class DummyModel: Entity {
         return "dummy_models"
     }
 
-    static func prepare(_ database: Database) throws {}
-    static func revert(_ database: Database) throws {}
-
     init(row: Row) {}
     func makeRow() -> Row { return .null}
 }

--- a/Tests/FluentTests/Utilities/Group.swift
+++ b/Tests/FluentTests/Utilities/Group.swift
@@ -4,6 +4,9 @@ final class Group: Entity {
     let storage = Storage()
     init(row: Row) throws {}
     func makeRow() -> Row { return .null }
+}
+
+extension Group: Preparation {
     static func prepare(_ database: Database) throws {
         try database.create(self) { groups in
             groups.id(for: self)

--- a/Tests/FluentTests/Utilities/Nucleus.swift
+++ b/Tests/FluentTests/Utilities/Nucleus.swift
@@ -6,6 +6,9 @@ final class Nucleus: Entity {
 
     init(row: Row) { }
     func makeRow() -> Row { return .null }
+}
+
+extension Nucleus: Preparation {
     static func prepare(_ database: Database) throws {
         try database.create(self) { nuclei in
             nuclei.id(for: self)

--- a/Tests/FluentTests/Utilities/Proton.swift
+++ b/Tests/FluentTests/Utilities/Proton.swift
@@ -4,6 +4,9 @@ final class Proton: Entity {
     let storage = Storage()
     init(row: Row) throws {}
     func makeRow() -> Row { return .null }
+}
+
+extension Proton: Preparation {
     static func prepare(_ database: Database) throws {
         try database.create(self) { protons in
             protons.id(for: self)


### PR DESCRIPTION
Related to #206 

`Entity` no longer needs to conform to `Preparation`.

Old behavior is achieved as follows

```swift
final class User: Entity {
    var name: String
    var email: String
    let storage = Storage()

    init(row: Row) throws {
        name = try row.get("name")
        email = try row.get("email")
    }

    func makeRow() throws -> Row {
        var row = Row()
        try row.set("name", name)
        try row.set("email", email)
        return row
    }
}

extension User: Preparation {
    static func prepare(_ database: Fluent.Database) throws {
        try database.create(self) { builder in
            builder.id(for: self)
            builder.string("name")
            builder.string("email")
        }
    }
    static func revert(_ database: Fluent.Database) throws {
        try database.delete(self)
    }
}
```