### PR TITLE
add soft delete

### DIFF
--- a/Sources/Fluent/Database/Database.swift
+++ b/Sources/Fluent/Database/Database.swift
@@ -41,11 +41,6 @@ public final class Database: Executor {
     /// ex: snake_case vs. camelCase.
     public var keyNamingConvention: KeyNamingConvention
 
-    /// If true, timestamps will be added when
-    /// creating a schema for entities in this db
-    /// - note: inherits from driver.timestamps on init
-    public var usesTimestamps: Bool
-
     /// A closure for handling database logs
     public typealias LogCallback = (Log) -> ()
 
@@ -59,7 +54,6 @@ public final class Database: Executor {
         idKey = driver.idKey
         idType = driver.idType
         keyNamingConvention = driver.keyNamingConvention
-        usesTimestamps = driver.usesTimestamps
 
         threadConnectionPool = ThreadConnectionPool(
             makeConnection: driver.makeConnection,

--- a/Sources/Fluent/Database/Driver.swift
+++ b/Sources/Fluent/Database/Driver.swift
@@ -26,11 +26,6 @@ public protocol Driver: Executor {
     /// ex: snake_case vs. camelCase.
     var keyNamingConvention: KeyNamingConvention { get }
 
-    /// If true, timestamps will be added when
-    /// creating a schema for entities under this driver
-    /// - note: true by default
-    var usesTimestamps: Bool { get }
-
     /// Creates a connection for executing
     /// queries. This method is used to
     /// automatically create a connection
@@ -57,15 +52,5 @@ extension Driver {
     @discardableResult
     public func raw(_ raw: String, _ values: [Node]) throws -> Node {
         return try makeConnection().raw(raw, values)
-    }
-}
-
-// MARK: Defaults
-
-public var usesTimestampsDefault = true
-
-extension Driver {
-    public var usesTimestamps: Bool {
-        return usesTimestampsDefault
     }
 }

--- a/Sources/Fluent/Entity/SoftDeletable.swift
+++ b/Sources/Fluent/Entity/SoftDeletable.swift
@@ -23,6 +23,8 @@ public protocol SoftDeletable: Entity {
 extension SoftDeletable {
     /// Soft deletes the entity, setting
     /// its `deletedAt` date to now
+    /// - note: internal since it is meant
+    ///         to be called by `model.delete()`
     internal func softDelete() throws {
         try assertExists()
         try willSoftDelete()
@@ -31,6 +33,7 @@ extension SoftDeletable {
         didSoftDelete()
     }
 
+    /// Permanently deletes the model.
     public func forceDelete() throws {
         try assertExists()
         try willForceDelete()
@@ -39,8 +42,8 @@ extension SoftDeletable {
         didForceDelete()
     }
 
-    /// Restores the entity, setting its
-    /// `deletedAt` date to nil
+    /// Restores a soft deleted entity, 
+    /// setting its `deletedAt` date to nil
     public func restore() throws {
         try assertExists()
         try willRestore()
@@ -93,10 +96,14 @@ extension QueryRepresentable where E: SoftDeletable {
 // MARK: Entity
 
 extension Entity where Self: SoftDeletable {
+    /// Includes soft deleted entities in
+    /// the results
     public static func withSoftDeleted() throws -> Query<Self> {
         return try query().withSoftDeleted()
     }
 
+    /// If true, calls to `model.delete()`
+    /// should permanently delete the model.
     internal var shouldForceDelete: Bool {
         get { return storage.shouldForceDelete }
         set { storage.shouldForceDelete = newValue }

--- a/Sources/Fluent/Entity/SoftDeletable.swift
+++ b/Sources/Fluent/Entity/SoftDeletable.swift
@@ -1,0 +1,104 @@
+/// Conforming an entity to SoftDeletable
+/// allows the entity to be temporarily deleted
+/// with the possibility to restore.
+public protocol SoftDeletable: Entity {
+    /// Table key to use for deleted at date
+    static var deletedAtKey: String { get }
+
+    /// Optional date the entity was deleted at.
+    /// If `nil`, the entity has not been deleted
+    var deletedAt: Date? { get set }
+
+    // hooks
+    func willSoftDelete() throws
+    func didSoftDelete()
+    func willForceDelete() throws
+    func didForceDelete()
+    func willRestore() throws
+    func didRestore()
+}
+
+// MARK: Methods
+
+extension SoftDeletable {
+    /// Soft deletes the entity, setting
+    /// its `deletedAt` date to now
+    internal func softDelete() throws {
+        try assertExists()
+        try willSoftDelete()
+        deletedAt = Date()
+        try save()
+        didSoftDelete()
+    }
+
+    public func forceDelete() throws {
+        try assertExists()
+        try willForceDelete()
+        shouldForceDelete = true
+        try delete()
+        didForceDelete()
+    }
+
+    /// Restores the entity, setting its
+    /// `deletedAt` date to nil
+    public func restore() throws {
+        try assertExists()
+        try willRestore()
+        deletedAt = nil
+        try save()
+        didRestore()
+    }
+}
+
+// MARK: Defaults
+
+extension SoftDeletable {
+    public static var deletedAtKey: String {
+        switch keyNamingConvention {
+        case .camelCase:
+            return "deletedAt"
+        case .snake_case:
+            return "deleted_at"
+        }
+    }
+
+    public var deletedAt: Date? {
+        get { return storage.deletedAt }
+        set { storage.deletedAt = newValue }
+    }
+}
+
+// MARK: Optional
+
+extension SoftDeletable {
+    public func willSoftDelete() {}
+    public func didSoftDelete() {}
+    public func willForceDelete() {}
+    public func didForceDelete() {}
+    public func willRestore() {}
+    public func didRestore() {}
+}
+
+// MARK: Query
+
+extension QueryRepresentable where E: SoftDeletable {
+    /// Include soft deleted entities in the query
+    public func withSoftDeleted() throws -> Query<E> {
+        let query = try makeQuery()
+        query.includeSoftDeleted = true
+        return query
+    }
+}
+
+// MARK: Entity
+
+extension Entity where Self: SoftDeletable {
+    public static func withSoftDeleted() throws -> Query<Self> {
+        return try query().withSoftDeleted()
+    }
+
+    internal var shouldForceDelete: Bool {
+        get { return storage.shouldForceDelete }
+        set { storage.shouldForceDelete = newValue }
+    }
+}

--- a/Sources/Fluent/Entity/Storage.swift
+++ b/Sources/Fluent/Entity/Storage.swift
@@ -1,0 +1,47 @@
+public final class Storage {
+    public init() {}
+
+    // Entity
+    fileprivate var exists: Bool = false
+    fileprivate var id: Identifier? = nil
+
+    // Timestampable
+    internal var createdAt: Date? = nil
+    internal var updatedAt: Date? = nil
+
+    // SoftDeletable
+    internal var deletedAt: Date? = nil
+    internal var shouldForceDelete: Bool = false
+}
+
+public protocol Storable: class {
+    /// General implementation should just be `let storage = Storage()`
+    var storage: Storage { get }
+}
+
+extension Storable {
+    /// Whether or not entity was retrieved from database.
+    ///
+    /// This value shouldn't be interacted w/ external users
+    /// w/o explicit knowledge.
+    ///
+    public var exists: Bool {
+        get {
+            return storage.exists
+        }
+        set {
+            storage.exists = newValue
+        }
+    }
+
+    /// The entity's primary identifier
+    /// used for updating, filtering, deleting, etc.
+    public var id: Identifier? {
+        get {
+            return storage.id
+        }
+        set {
+            storage.id = newValue
+        }
+    }
+}

--- a/Sources/Fluent/Entity/Timestampable.swift
+++ b/Sources/Fluent/Entity/Timestampable.swift
@@ -1,0 +1,41 @@
+/// When added to an entity, timestamps
+/// will automatically be created during
+/// preparation and updated when the model saves.
+public protocol Timestampable: Entity {
+    static var updatedAtKey: String { get }
+    static var createdAtKey: String { get }
+    var createdAt: Date? { get set }
+    var updatedAt: Date? { get set }
+}
+
+// MARK: Defaults
+
+extension Timestampable {
+    public static var updatedAtKey: String {
+        switch keyNamingConvention {
+        case .camelCase:
+            return "updatedAt"
+        case .snake_case:
+            return "updated_at"
+        }
+    }
+
+    public static var createdAtKey: String {
+        switch keyNamingConvention {
+        case .camelCase:
+            return "createdAt"
+        case .snake_case:
+            return "created_at"
+        }
+    }
+
+    public var createdAt: Date? {
+        get { return storage.createdAt }
+        set { storage.createdAt = newValue }
+    }
+
+    public var updatedAt: Date? {
+        get { return storage.updatedAt }
+        set { storage.updatedAt = newValue }
+    }
+}

--- a/Sources/Fluent/Query/Group.swift
+++ b/Sources/Fluent/Query/Group.swift
@@ -1,12 +1,15 @@
 extension QueryRepresentable {
+    @discardableResult
     public func and(_ closure: (Query<E>) throws -> ()) throws -> Query<E> {
         return try group(.and, closure)
     }
 
+    @discardableResult
     public func or(_ closure: (Query<E>) throws -> ()) throws -> Query<E> {
         return try group(.or, closure)
     }
 
+    @discardableResult
     public func group(_ relation: Filter.Relation, _ closure: (Query<E>) throws -> ()) throws -> Query<E> {
         let main = try makeQuery()
 

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -31,6 +31,10 @@ public final class Query<E: Entity> {
         return context
     }()
 
+    /// If true, soft deleted entities will be 
+    /// included (given the Entity type is SoftDeletable)
+    internal var includeSoftDeleted: Bool
+
     /// Creates a new `Query` with the
     /// `Model`'s database.
     public init(_ database: Database) {
@@ -39,6 +43,7 @@ public final class Query<E: Entity> {
         self.database = database
         joins = []
         sorts = []
+        includeSoftDeleted = false
     }
 
     /// Performs the Query returning the raw

--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -221,27 +221,18 @@ extension QueryRepresentable {
             let s = model as? SoftDeletable,
             !s.shouldForceDelete
         {
+            // soft delete the model
             try s.softDelete()
+            // note: model still 'exists'
         } else {
+            // permenantly delete the model
             query.action = .delete
-
-            let filter = Filter(
-                E.self,
-                .compare(
-                    E.idKey,
-                    .equals,
-                    id.makeNode(in: query.context)
-                )
-            )
-
-            query.filters.append(filter)
-
+            try query.filter(E.idKey, id)
             try model.willDelete()
             try query.raw()
             model.didDelete()
+            model.exists = false
         }
-
-        model.exists = false
     }
 }
 

--- a/Sources/Fluent/Schema/Database+Schema.swift
+++ b/Sources/Fluent/Schema/Database+Schema.swift
@@ -32,9 +32,14 @@ extension Database {
         let creator = Schema.Creator(e.entity)
 
         // add timestamps
-        if E.usesTimestamps {
-            creator.date(E.createdAtKey)
-            creator.date(E.updatedAtKey)
+        if let T = E.self as? Timestampable.Type {
+            creator.date(T.createdAtKey)
+            creator.date(T.updatedAtKey)
+        }
+
+        // add soft delete
+        if let S = E.self as? SoftDeletable.Type {
+            creator.date(S.deletedAtKey, optional: true)
         }
 
         try closure(creator)

--- a/Sources/FluentTester/Tester+SoftDelete.swift
+++ b/Sources/FluentTester/Tester+SoftDelete.swift
@@ -1,0 +1,65 @@
+import libc
+
+extension Tester {
+    public func testSoftDelete() throws {
+        Compound.database = database
+        try Compound.prepare(database)
+        defer {
+            try? Compound.revert(database)
+        }
+
+        database.log = { query in
+            print(query)
+        }
+
+        let ethanol = Compound(name: "Ethanol")
+        let hcl = Compound(name: "Hydrochloric Acid")
+        let methanol = Compound(name: "Methanol")
+        let water = Compound(name: "Water")
+
+        try ethanol.save()
+        try hcl.save()
+        try methanol.save()
+        try water.save()
+
+        guard try Compound.count() == 4 else {
+            throw Error.failed("Compound count did not equal 4")
+        }
+
+        try water.delete()
+
+        guard try Compound.count() == 3 else {
+            throw Error.failed("Compound count did not go down to 3")
+        }
+
+        guard try Compound.all().count == 3 else {
+            throw Error.failed("Compound all did not go down to 3")
+        }
+
+        guard let fetched = try Compound.withSoftDeleted().find(water.id) else {
+            throw Error.failed("Soft deleted should be fetchable by id")
+        }
+
+        guard try Compound.query().filter("name", "Water").all().count == 0 else {
+            throw Error.failed("Soft deleted should not be fetchable by query")
+        }
+
+        try fetched.restore()
+
+        guard try Compound.count() == 4 else {
+            throw Error.failed("Compound count did not equal 4 after restore.")
+        }
+
+        try fetched.forceDelete()
+
+        guard try Compound.count() == 3 else {
+            throw Error.failed("Compound count did not equal 3 after force delete.")
+        }
+
+        guard try Compound.withSoftDeleted().find(water.id) == nil else {
+            throw Error.failed("Water was not forced deleted")
+        }
+    }
+}
+
+extension Compound: SoftDeletable { }

--- a/Sources/FluentTester/Tester+Timestamps.swift
+++ b/Sources/FluentTester/Tester+Timestamps.swift
@@ -54,6 +54,8 @@ extension Tester {
     }
 }
 
+extension Compound: Timestampable { }
+
 extension Date {
     public func isWithin(seconds: Double, of other: Date) -> Bool {
         var diff = other.timeIntervalSince1970 - self.timeIntervalSince1970

--- a/Sources/FluentTester/Tester.swift
+++ b/Sources/FluentTester/Tester.swift
@@ -20,5 +20,6 @@ public final class Tester {
         try test(testSchema, "Schema")
         try test(testPaginate, "Pagination")
         try test(testTimestamps, "Timestamps")
+        try test(testSoftDelete, "Soft Delete")
     }
 }

--- a/Tests/FluentTests/ModelTests.swift
+++ b/Tests/FluentTests/ModelTests.swift
@@ -12,7 +12,6 @@ class ModelTests: XCTestCase {
     override func setUp() {
         lqd = LastQueryDriver()
         db = Database(lqd)
-        db.usesTimestamps = false
     }
 
     func testExamples() throws {

--- a/Tests/FluentTests/PivotTests.swift
+++ b/Tests/FluentTests/PivotTests.swift
@@ -8,7 +8,6 @@ class PivotTests: XCTestCase {
     override func setUp() {
         lqd = LastQueryDriver()
         db = Database(lqd)
-        db.usesTimestamps = false
     }
 
     func testEntityAttach() throws {

--- a/Tests/FluentTests/PreparationTests.swift
+++ b/Tests/FluentTests/PreparationTests.swift
@@ -125,7 +125,6 @@ class PreparationTests: XCTestCase {
         }
 
         let database = Database(driver)
-        database.usesTimestamps = false
 
         do {
             try TestModel.prepare(database)


### PR DESCRIPTION
Adds a `SoftDeletable` protocol as well as moves timestamps to a `Timestampable` protocol for more consistency.

```swift
public final class User: Model {
   ...
}

extension User: SoftDeletable { }
```

```swift
let bob = try User.find(42)!
try bob.delete() 
try User.all() // no bob
try User.withSoftDeleted().all() // bob is here
try bob.restore()
try User.all() // bob is here
try bob.forceDelete()
try User.all() // no bob
try User.withSoftDeleted().all() // no bob
```