### PR TITLE
Adding a distinct modifier to Query

### DIFF
--- a/Sources/Fluent/Query/Distinct.swift
+++ b/Sources/Fluent/Query/Distinct.swift
@@ -1,0 +1,8 @@
+extension QueryRepresentable {
+    /// Limits results to be distinct values
+    func distinct() throws -> Query<E> {
+        let query = try makeQuery()
+        query.distinct = true
+        return query
+    }
+}

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -38,6 +38,11 @@ public final class Query<E: Entity> {
     /// If true, soft deleted entities will be 
     /// included (given the Entity type is SoftDeletable)
     internal var includeSoftDeleted: Bool
+    
+    /// If true, uses appropriate distinct modifiers
+    /// on fetch and counts to return only distinct
+    /// results for this query.
+    public var distinct: Bool
 
     /// Creates a new `Query` with the
     /// `Model`'s database.
@@ -48,6 +53,7 @@ public final class Query<E: Entity> {
         joins = []
         limits = []
         sorts = []
+        distinct = false
         includeSoftDeleted = false
         data = [:]
         keys = []

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -64,6 +64,10 @@ open class GeneralSQLSerializer<E: Entity>: SQLSerializer {
         var columns: [String] = ["\(table).*"]
         
         statement += "SELECT"
+        if query.distinct {
+            statement += "DISTINCT"
+        }
+        
         for key in query.keys {
             switch key {
             case .raw(let raw, _):
@@ -105,7 +109,11 @@ open class GeneralSQLSerializer<E: Entity>: SQLSerializer {
         var statement: [String] = []
         var values: [Node] = []
 
-        statement += "SELECT COUNT(*) as _fluent_count FROM"
+        statement += "SELECT"
+        if query.distinct {
+            statement += "DISTINCT"
+        }
+        statement += "COUNT(*) as _fluent_count FROM"
         statement += escape(E.entity)
 
         if !query.joins.isEmpty {

--- a/Tests/FluentTests/QueryFiltersTests.swift
+++ b/Tests/FluentTests/QueryFiltersTests.swift
@@ -24,6 +24,7 @@ class QueryFiltersTests: XCTestCase {
         XCTAssert(query.filters.count == 0, "Filters should be empty")
         XCTAssert(query.data.isEmpty == true, "Data should be empty")
         XCTAssert(query.limits.isEmpty == true, "Limit should be empty")
+        XCTAssert(query.distinct == false, "Distinct should be false")
     }
 
     func testBasicQuery() throws {
@@ -98,4 +99,8 @@ class QueryFiltersTests: XCTestCase {
         XCTAssertEqual(query.limits.first?.wrapped?.count, 5)
     }
 
+    func testDistinctQuery() throws {
+        let query = try DummyModel.query().distinct()
+        XCTAssert(query.distinct)
+    }
 }

--- a/Tests/FluentTests/SQLSerializerTests.swift
+++ b/Tests/FluentTests/SQLSerializerTests.swift
@@ -4,11 +4,13 @@ import XCTest
 class SQLSerializerTests: XCTestCase {
     static let allTests = [
         ("testBasicSelect", testBasicSelect),
+        ("testDistinctSelect", testDistinctSelect),
         ("testRegularSelect", testRegularSelect),
         ("testOffsetSelect", testOffsetSelect),
         ("testFilterCompareSelect", testFilterCompareSelect),
         ("testFilterLikeSelect", testFilterLikeSelect),
         ("testBasicCount", testBasicCount),
+        ("testDistinctCount", testDistinctCount),
         ("testRegularCount", testRegularCount),
         ("testFilterCompareCount", testFilterCompareCount),
         ("testFilterLikeCount", testFilterLikeCount),
@@ -33,6 +35,15 @@ class SQLSerializerTests: XCTestCase {
         let (statement, values) = serialize(query)
 
         XCTAssertEqual(statement, "SELECT `atoms`.* FROM `atoms`")
+        XCTAssert(values.isEmpty)
+    }
+    
+    func testDistinctSelect() {
+        let query = Query<Atom>(db)
+        query.distinct = true
+        let (statement, values) = serialize(query)
+        
+        XCTAssertEqual(statement, "SELECT DISTINCT `atoms`.* FROM `atoms`")
         XCTAssert(values.isEmpty)
     }
 
@@ -81,13 +92,22 @@ class SQLSerializerTests: XCTestCase {
         XCTAssertEqual(values.count, 1)
     }
 
-
     func testBasicCount() {
         let query = Query<User>(db)
         query.action = .count
         let (statement, values) = serialize(query)
 
         XCTAssertEqual(statement, "SELECT COUNT(*) as _fluent_count FROM `users`")
+        XCTAssert(values.isEmpty)
+    }
+    
+    func testDistinctCount() {
+        let query = Query<User>(db)
+        query.action = .count
+        query.distinct = true
+        let (statement, values) = serialize(query)
+        
+        XCTAssertEqual(statement, "SELECT DISTINCT COUNT(*) as _fluent_count FROM `users`")
         XCTAssert(values.isEmpty)
     }
 


### PR DESCRIPTION
This pull request aims to add the ability to express distinct results queries with Fluent. In SQL, the DISTINCT modifier is used to eliminate duplicated result tuples from results.

In queries that return models using joints that are one-to-many with another table, it's useful to express results should be distinct to avoid duplicated results.

Let there be two tables:

Owner
|-|
|id|

Dog
|-|
|id|
|owner_id|
|breed|
|name|

To select all owners that own at least one dog of breed Fox Paulistinha, you'd do the following SQL join:

```
SELECT
    owner.*
FROM
    owner
        JOIN
    dog ON dog.owner_id = owner.id
WHERE
    dog.breed = 'Fox Paulistinha';
```

This will result in duplicates in case of owners with more than one paulistinha, so a DISTINCT fixes that:


```
SELECT DISTINCT
    owner.*
FROM
    owner
        JOIN
    dog ON dog.owner_id = owner.id
WHERE
    dog.breed = 'Fox Paulistinha';
```

This was a simple change that modified the Query and general SQL serializer classes.

This is a replacement proposal to #188, which has the same basic objective but was noted to not being so applicable to NoSQL databases.

I'm still not exactly sure about adding DISTINCT to count queries, too; my SQL is rusty in that aspect.

Feedback would be appreciated!