### PR TITLE
nil/null

### DIFF
--- a/Sources/Fluent/Query/Filter/Query+Filter.swift
+++ b/Sources/Fluent/Query/Filter/Query+Filter.swift
@@ -15,10 +15,10 @@ extension QueryRepresentable {
         _ entity: T.Type,
         _ field: String,
         _ comparison: Filter.Comparison,
-        _ value: NodeRepresentable
+        _ value: NodeRepresentable?
     ) throws -> Query<Self.E> {
         let query = try makeQuery()
-        let value = try value.makeNode(in: query.context)
+        let value = try value?.makeNode(in: query.context) ?? .null
         let filter = Filter(entity, .compare(field, comparison, value))
         return try query.filter(filter)
     }
@@ -28,7 +28,7 @@ extension QueryRepresentable {
     public func filter<T: Entity>(
         _ entity: T.Type,
         _ field: String,
-        _ value: NodeRepresentable
+        _ value: NodeRepresentable?
     ) throws -> Query<Self.E> {
         return try makeQuery()
             .filter(entity, field, .equals, value)
@@ -39,7 +39,7 @@ extension QueryRepresentable {
     public func filter(
         _ field: String,
         _ comparison: Filter.Comparison,
-        _ value: NodeRepresentable
+        _ value: NodeRepresentable?
     ) throws -> Query<Self.E> {
         return try makeQuery()
             .filter(E.self, field, comparison, value)
@@ -49,7 +49,7 @@ extension QueryRepresentable {
     @discardableResult
     public func filter(
         _ field: String,
-        _ value: NodeRepresentable
+        _ value: NodeRepresentable?
     ) throws -> Query<Self.E> {
         return try makeQuery()
             .filter(field, .equals, value)

--- a/Tests/FluentTests/PivotTests.swift
+++ b/Tests/FluentTests/PivotTests.swift
@@ -22,15 +22,17 @@ class PivotTests: XCTestCase {
 
         try atom.compounds.add(compound)
 
-        guard let (sql, _) = lqd.lastQuery else {
+        guard let (sql, values) = lqd.lastQuery else {
             XCTFail("No query recorded")
             return
         }
 
         XCTAssertEqual(
             sql,
-            "INSERT INTO `atom_compound` (`\(Atom.foreignIdKey)`, `\(Compound.foreignIdKey)`) VALUES (?, ?)"
+            "INSERT INTO `atom_compound` (`\(Pivot<Atom, Compound>.idKey)`, `\(Atom.foreignIdKey)`, `\(Compound.foreignIdKey)`) VALUES (?, ?, ?)"
         )
+
+        XCTAssertEqual(values.count, 3)
     }
 
     static let allTests = [

--- a/Tests/FluentTests/SQLSerializerTests.swift
+++ b/Tests/FluentTests/SQLSerializerTests.swift
@@ -216,4 +216,45 @@ class SQLSerializerTests: XCTestCase {
         XCTAssertEqual(statement, "DELETE `compounds` FROM `compounds` JOIN `atoms` ON `compounds`.`id` = `atoms`.`compound_id` WHERE `atoms`.`name` = ?")
         XCTAssertEqual(values.count, 1)
     }
+
+    func testNull() throws {
+        let query = Query<Compound>(db)
+        let string: String? = nil
+        try query.filter("foo", string)
+        let (statement, values) = serialize(query)
+        XCTAssertEqual(statement, "SELECT `compounds`.* FROM `compounds` WHERE `compounds`.`foo` IS NULL")
+        XCTAssertEqual(values.count, 0)
+    }
+
+    func testNotNull() throws {
+        let query = Query<Compound>(db)
+        let string: String? = nil
+        try query.filter("foo", .notEquals, string)
+        let (statement, values) = serialize(query)
+        XCTAssertEqual(statement, "SELECT `compounds`.* FROM `compounds` WHERE `compounds`.`foo` IS NOT NULL")
+        XCTAssertEqual(values.count, 0)
+    }
+
+    func testNodeNull() throws {
+        let query = Query<Compound>(db)
+        try query.filter("foo", Node.null)
+        let (statement, values) = serialize(query)
+        XCTAssertEqual(statement, "SELECT `compounds`.* FROM `compounds` WHERE `compounds`.`foo` IS NULL")
+        XCTAssertEqual(values.count, 0)
+    }
+
+    func testPlainNil() throws {
+        let query = Query<Compound>(db)
+        try query.filter("foo", nil)
+        let (statement, values) = serialize(query)
+        XCTAssertEqual(statement, "SELECT `compounds`.* FROM `compounds` WHERE `compounds`.`foo` IS NULL")
+        XCTAssertEqual(values.count, 0)
+    }
 }
+
+
+
+
+
+
+


### PR DESCRIPTION
```swift
let string: String? = nil
try query.filter("foo", string)
try query.filter("foo", .notEquals, string)
try query.filter("foo", Node.null)
try query.filter("foo", nil)
```

This PR ensures all these methods of filtering by `IS NULL` / `IS NOT NULL` are working.