### PR TITLE
executor representable

### DIFF
--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -107,18 +107,18 @@ extension Entity {
     }
 
     /// Returns all entities for this `Model`.
-    public static func all(_ executor: Executor? = nil) throws -> [Self] {
-        return try Self.makeQuery(executor).all()
+    public static func all() throws -> [Self] {
+        return try Self.makeQuery().all()
     }
 
     /// Returns all entities for this `Model`.
-    public static func count(_ executor: Executor? = nil) throws -> Int {
-        return try Self.makeQuery(executor).count()
+    public static func count() throws -> Int {
+        return try Self.makeQuery().count()
     }
 
     /// Finds the entity with the given `id`.
-    public static func find(_ id: NodeRepresentable, _ executor: Executor? = nil) throws -> Self? {
-        return try Self.makeQuery(executor).find(id)
+    public static func find(_ id: NodeRepresentable) throws -> Self? {
+        return try Self.makeQuery().find(id)
     }
 }
 

--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -65,6 +65,24 @@ public protocol Entity: class, RowConvertible, Storable {
     func didDelete()
 }
 
+extension Entity {
+    //// Creates a `Query` instance for this `Model`.
+    public static func makeQuery(_ executor: Executor) throws -> Query<Self> {
+        return Query(executor)
+    }
+    
+    public static func makeQuery() throws -> Query<Self> {
+        return try makeQuery(makeExecutor())
+    }
+    
+    public static func makeExecutor() throws -> Executor {
+        guard let db = database else {
+            throw EntityError.noDatabase(self)
+        }
+        return db
+    }
+}
+
 // MARK: Optional
 
 extension Entity {
@@ -81,37 +99,29 @@ extension Entity {
 extension Entity {
     /// Persists the entity into the
     /// data store and sets the `id` property.
-    public func save() throws {
-        try Self.query().save(self)
+    public func save(_ ) throws {
+        try Self.makeQuery().save(self)
     }
 
     /// Deletes the entity from the data
     /// store if the `id` property is set.
     public func delete() throws {
-        try Self.query().delete(self)
+        try Self.makeQuery().delete(self)
     }
 
     /// Returns all entities for this `Model`.
     public static func all() throws -> [Self] {
-        return try Self.query().all()
+        return try Self.makeQuery().all()
     }
 
     /// Returns all entities for this `Model`.
     public static func count() throws -> Int {
-        return try Self.query().count()
+        return try Self.makeQuery().count()
     }
 
     /// Finds the entity with the given `id`.
     public static func find(_ id: NodeRepresentable) throws -> Self? {
-        return try Self.query().find(id)
-    }
-
-    //// Creates a `Query` instance for this `Model`.
-    public static func query() throws -> Query<Self> {
-        guard let db = database else {
-            throw EntityError.noDatabase(self)
-        }
-        return Query(db)
+        return try Self.makeQuery().find(id)
     }
 }
 

--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -67,12 +67,9 @@ public protocol Entity: class, RowConvertible, Storable {
 
 extension Entity {
     //// Creates a `Query` instance for this `Model`.
-    public static func makeQuery(_ executor: Executor) throws -> Query<Self> {
+    public static func makeQuery(_ executor: Executor? = nil) throws -> Query<Self> {
+        let executor = try executor ?? makeExecutor()
         return Query(executor)
-    }
-    
-    public static func makeQuery() throws -> Query<Self> {
-        return try makeQuery(makeExecutor())
     }
     
     public static func makeExecutor() throws -> Executor {
@@ -99,29 +96,29 @@ extension Entity {
 extension Entity {
     /// Persists the entity into the
     /// data store and sets the `id` property.
-    public func save(_ ) throws {
-        try Self.makeQuery().save(self)
+    public func save(_ executor: Executor? = nil) throws {
+        try Self.makeQuery(executor).save(self)
     }
 
     /// Deletes the entity from the data
     /// store if the `id` property is set.
-    public func delete() throws {
-        try Self.makeQuery().delete(self)
+    public func delete(_ executor: Executor? = nil) throws {
+        try Self.makeQuery(executor).delete(self)
     }
 
     /// Returns all entities for this `Model`.
-    public static func all() throws -> [Self] {
-        return try Self.makeQuery().all()
+    public static func all(_ executor: Executor? = nil) throws -> [Self] {
+        return try Self.makeQuery(executor).all()
     }
 
     /// Returns all entities for this `Model`.
-    public static func count() throws -> Int {
-        return try Self.makeQuery().count()
+    public static func count(_ executor: Executor? = nil) throws -> Int {
+        return try Self.makeQuery(executor).count()
     }
 
     /// Finds the entity with the given `id`.
-    public static func find(_ id: NodeRepresentable) throws -> Self? {
-        return try Self.makeQuery().find(id)
+    public static func find(_ id: NodeRepresentable, _ executor: Executor? = nil) throws -> Self? {
+        return try Self.makeQuery(executor).find(id)
     }
 }
 

--- a/Sources/Fluent/Entity/SoftDeletable.swift
+++ b/Sources/Fluent/Entity/SoftDeletable.swift
@@ -84,7 +84,7 @@ extension SoftDeletable {
 
 // MARK: Query
 
-extension QueryRepresentable where E: SoftDeletable {
+extension QueryRepresentable where E: SoftDeletable, Self: ExecutorRepresentable {
     /// Include soft deleted entities in the query
     public func withSoftDeleted() throws -> Query<E> {
         let query = try makeQuery()
@@ -99,7 +99,7 @@ extension Entity where Self: SoftDeletable {
     /// Includes soft deleted entities in
     /// the results
     public static func withSoftDeleted() throws -> Query<Self> {
-        return try query().withSoftDeleted()
+        return try makeQuery().withSoftDeleted()
     }
 
     /// If true, calls to `model.delete()`

--- a/Sources/Fluent/Pagination/Query+Page.swift
+++ b/Sources/Fluent/Pagination/Query+Page.swift
@@ -1,4 +1,4 @@
-extension QueryRepresentable where E: Paginatable {
+extension QueryRepresentable where E: Paginatable, Self: ExecutorRepresentable {
     public func paginate(
         page: Int,
         count: Int = E.defaultPageSize,

--- a/Sources/Fluent/Pivot/DoublePivot.swift
+++ b/Sources/Fluent/Pivot/DoublePivot.swift
@@ -14,7 +14,7 @@ extension PivotProtocol where Left: PivotProtocol, Self: Entity {
         let rightId = try right.assertExists()
 
         let result = try Left
-            .query()
+            .makeQuery()
             .join(self)
             .filter(Left.self, Left.Left.foreignIdKey == leftId)
             .filter(Left.self, Left.Right.foreignIdKey, middleId)
@@ -38,7 +38,7 @@ extension PivotProtocol where Right: PivotProtocol, Self: Entity {
         let rightId = try right.assertExists()
         
         let result = try Right
-            .query()
+            .makeQuery()
             .join(self)
             .filter(self, Left.foreignIdKey, leftId)
             .filter(Right.self, Right.Left.foreignIdKey, middleId)

--- a/Sources/Fluent/Pivot/PivotProtocol.swift
+++ b/Sources/Fluent/Pivot/PivotProtocol.swift
@@ -29,7 +29,7 @@ extension PivotProtocol where Self: Entity {
         let leftId = try left.assertExists()
         let rightId = try right.assertExists()
 
-        let results = try query()
+        let results = try makeQuery()
             .filter(type(of: left).foreignIdKey, leftId)
             .filter(type(of: right).foreignIdKey, rightId)
             .first()
@@ -58,7 +58,7 @@ extension PivotProtocol where Self: Entity {
         let leftId = try left.assertExists()
         let rightId = try right.assertExists()
 
-        try query()
+        try makeQuery()
             .filter(Left.foreignIdKey, leftId)
             .filter(Right.foreignIdKey, rightId)
             .delete()

--- a/Sources/Fluent/Preparation/Database+Preparation.swift
+++ b/Sources/Fluent/Preparation/Database+Preparation.swift
@@ -8,7 +8,7 @@ extension Database {
 
         do {
             // check to see if this preparation has already run
-            if let _ = try Migration.query().filter("name", preparation.name).first() {
+            if let _ = try Migration.makeQuery().filter("name", preparation.name).first() {
                 // already prepared, set entity db
                 if let model = preparation as? Entity.Type {
                     model.database = self

--- a/Sources/Fluent/Preparation/Migration.swift
+++ b/Sources/Fluent/Preparation/Migration.swift
@@ -29,3 +29,5 @@ final class Migration: Entity {
         try database.delete(self)
     }
 }
+
+extension Migration: Timestampable {}

--- a/Sources/Fluent/Query/Distinct.swift
+++ b/Sources/Fluent/Query/Distinct.swift
@@ -1,4 +1,4 @@
-extension QueryRepresentable {
+extension QueryRepresentable  where Self: ExecutorRepresentable {
     /// Limits results to be distinct values
     func distinct() throws -> Query<E> {
         let query = try makeQuery()

--- a/Sources/Fluent/Query/Filter/Query+Filter.swift
+++ b/Sources/Fluent/Query/Filter/Query+Filter.swift
@@ -1,4 +1,4 @@
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     /// Manually create and append filter
     @discardableResult
     public func filter(

--- a/Sources/Fluent/Query/Filter/Query+Group.swift
+++ b/Sources/Fluent/Query/Filter/Query+Group.swift
@@ -1,6 +1,6 @@
 public typealias QueryClosure<E: Entity> = (Query<E>) throws -> ()
 
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     /// Grouped filter closure with specified relation.
     @discardableResult
     public func group(
@@ -9,7 +9,7 @@ extension QueryRepresentable {
     ) throws -> Query<E> {
         let main = try makeQuery()
 
-        let sub = Query<E>(main.database)
+        let sub = Query<E>(main.executor)
         try closure(sub)
 
         let group = Filter(E.self, .group(relation, sub.filters))

--- a/Sources/Fluent/Query/Join.swift
+++ b/Sources/Fluent/Query/Join.swift
@@ -51,7 +51,7 @@ public struct Join {
     }
 }
 
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     /// Create and add a Join to this Query.
     /// See Join for more information.
     @discardableResult

--- a/Sources/Fluent/Query/Limit.swift
+++ b/Sources/Fluent/Query/Limit.swift
@@ -15,7 +15,7 @@ public struct Limit {
     }
 }
 
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     /// Limits the count of results returned
     /// by the `Query`.
     @discardableResult

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -31,7 +31,7 @@ public final class Query<E: Entity> {
 
     private(set) lazy var context: RowContext = {
         let context = RowContext()
-        context.database = self.database
+        // context.database = self.database
         return context
     }()
 
@@ -46,10 +46,10 @@ public final class Query<E: Entity> {
 
     /// Creates a new `Query` with the
     /// `Model`'s database.
-    public init(_ database: Database) {
+    public init(_ executor: Executor) {
         filters = []
         action = .fetch
-        self.database = database
+        self.executor = executor
         joins = []
         limits = []
         sorts = []
@@ -63,19 +63,25 @@ public final class Query<E: Entity> {
     /// Node data from the driver.
     @discardableResult
     public func raw() throws -> Node {
-        return try database.query(.some(self))
+        return try executor.query(.some(self))
     }
+    
+    public let executor: Executor
 
     //MARK: Internal
 
     /// The database to which the query
     /// should be sent.
-    internal let database: Database
+    // internal let database: Database
 }
 
-extension Query: QueryRepresentable {
+extension Query: QueryRepresentable, ExecutorRepresentable {
     /// Conformance to `QueryRepresentable`
-    public func makeQuery() -> Query<E> {
+    public func makeQuery(_ executor: Executor) -> Query<E> {
         return self
+    }
+    
+    public func makeExecutor() -> Executor {
+        return executor
     }
 }

--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -1,10 +1,21 @@
 public protocol QueryRepresentable {
     associatedtype E: Entity
-    func makeQuery() throws -> Query<E>
+    func makeQuery(_ executor: Executor) throws -> Query<E>
+}
+
+public protocol ExecutorRepresentable {
+    func makeExecutor() throws -> Executor
+}
+
+
+extension QueryRepresentable where Self: ExecutorRepresentable {
+    public func makeQuery() throws -> Query<E> {
+        return try makeQuery(makeExecutor())
+    }
 }
 
 // MARK: Fetch
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     /// Returns all entities retrieved by the query.
     public func all() throws -> [E] {
         let query = try makeQuery()
@@ -108,7 +119,7 @@ extension QueryRepresentable {
 }
 
 // MARK: Create
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     /// Attempts the create action for the supplied
     /// serialized data.
     /// Returns the new entity's identifier.
@@ -192,7 +203,7 @@ extension QueryRepresentable {
 }
 
 // MARK: Delete
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     /// Attempts to delete all entities
     /// in the model's collection.
     public func delete() throws {
@@ -230,7 +241,7 @@ extension QueryRepresentable {
 }
 
 // MARK: Update
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     /// Attempts to modify model's collection with
     /// the supplied serialized data.
     public func modify(_ row: Row?) throws {

--- a/Sources/Fluent/Query/Raw.swift
+++ b/Sources/Fluent/Query/Raw.swift
@@ -49,7 +49,7 @@ extension Node {
 
 // MARK: Filter
 
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     @discardableResult
     public func filter(
         raw string: String,
@@ -80,7 +80,7 @@ extension Array where Element == RawOr<Filter> {
 
 // MARK: Join
 
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     @discardableResult
     public func join(
         raw string: String
@@ -110,7 +110,7 @@ extension RawOr: CustomStringConvertible {
 
 // MARK: Key
 
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     @discardableResult
     public func set(raw rawKey: String, equals rawValue: String) throws -> Query<E> {
         let query = try makeQuery()
@@ -128,7 +128,7 @@ extension QueryRepresentable {
 
 // MARK: Sort
 
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     @discardableResult
     public func sort(raw: String) throws -> Query<E> {
         let query = try makeQuery()
@@ -139,7 +139,7 @@ extension QueryRepresentable {
 
 // MARK: Limit
 
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     @discardableResult
     public func limit(raw: String) throws -> Query<E> {
         let query = try makeQuery()

--- a/Sources/Fluent/Query/Sort.swift
+++ b/Sources/Fluent/Query/Sort.swift
@@ -23,7 +23,7 @@ public struct Sort {
     }
 }
 
-extension QueryRepresentable {
+extension QueryRepresentable where Self: ExecutorRepresentable {
     /// Add a Sort to the Query.
     /// See Sort for more information.
     @discardableResult

--- a/Sources/Fluent/Relations/Children.swift
+++ b/Sources/Fluent/Relations/Children.swift
@@ -19,12 +19,18 @@ public final class Children<
 }
 
 extension Children: QueryRepresentable {
-    public func makeQuery() throws -> Query<Child> {
+    public func makeQuery(_ executor: Executor) throws -> Query<Child> {
         guard let parentId = parent.id else {
             throw RelationError.idRequired(parent)
         }
 
-        return try Child.query().filter(Parent.foreignIdKey == parentId)
+        return try Child.makeQuery().filter(Parent.foreignIdKey == parentId)
+    }
+}
+
+extension Children: ExecutorRepresentable {
+    public func makeExecutor() throws -> Executor {
+        return try Child.makeExecutor()
     }
 }
 

--- a/Sources/Fluent/Relations/Parent.swift
+++ b/Sources/Fluent/Relations/Parent.swift
@@ -28,9 +28,15 @@ public final class Parent<
 }
 
 extension Parent: QueryRepresentable {
-    public func makeQuery() throws -> Query<Parent> {
-        let query = try Parent.query()
+    public func makeQuery(_ executor: Executor) throws -> Query<Parent> {
+        let query = try Parent.makeQuery()
         return try query.filter(Parent.idKey, parentId)
+    }
+}
+
+extension Parent: ExecutorRepresentable {
+    public func makeExecutor() throws -> Executor {
+        return try Parent.makeExecutor()
     }
 }
 

--- a/Sources/Fluent/Relations/Siblings.swift
+++ b/Sources/Fluent/Relations/Siblings.swift
@@ -43,17 +43,23 @@ extension Siblings
 extension Siblings: QueryRepresentable {
     /// Creates a Query from the Siblings relation.
     /// This includes a pivot, join, and filter.
-    public func makeQuery() throws -> Query<Foreign> {
+    public func makeQuery(_ executor: Executor) throws -> Query<Foreign> {
         guard let localId = local.id else {
             throw RelationError.idRequired(local)
         }
 
-        let query = try Foreign.query()
+        let query = try Foreign.makeQuery()
 
         try query.join(Through.self)
         try query.filter(Through.self, Local.foreignIdKey, localId)
 
         return query
+    }
+}
+
+extension Siblings: ExecutorRepresentable {
+    public func makeExecutor() throws -> Executor {
+        return try Foreign.makeExecutor()
     }
 }
 

--- a/Sources/FluentTester/Tester+Paginate.swift
+++ b/Sources/FluentTester/Tester+Paginate.swift
@@ -17,7 +17,7 @@ extension Tester {
         try water.save()
 
         let page = try Compound
-            .query()
+            .makeQuery()
             .paginate(page: 2)
 
         guard page.data.count == 2 else {

--- a/Sources/FluentTester/Tester+SoftDelete.swift
+++ b/Sources/FluentTester/Tester+SoftDelete.swift
@@ -36,7 +36,7 @@ extension Tester {
             throw Error.failed("Soft deleted should be fetchable by id")
         }
 
-        guard try Compound.query().filter("name", "Water").all().count == 0 else {
+        guard try Compound.makeQuery().filter("name", "Water").all().count == 0 else {
             throw Error.failed("Soft deleted should not be fetchable by query")
         }
 

--- a/Tests/FluentTests/QueryFiltersTests.swift
+++ b/Tests/FluentTests/QueryFiltersTests.swift
@@ -18,7 +18,7 @@ class QueryFiltersTests: XCTestCase {
     var database: Database!
 
     func testBasalQuery() throws {
-        let query = try DummyModel.query()
+        let query = try DummyModel.makeQuery()
 
         XCTAssert(query.action == .fetch, "Default action should be fetch")
         XCTAssert(query.filters.count == 0, "Filters should be empty")
@@ -28,7 +28,7 @@ class QueryFiltersTests: XCTestCase {
     }
 
     func testBasicQuery() throws {
-        let query = try DummyModel.query().filter("name", "Vapor")
+        let query = try DummyModel.makeQuery().filter("name", "Vapor")
 
         guard
             let filter = query.filters.first?.wrapped,
@@ -49,7 +49,7 @@ class QueryFiltersTests: XCTestCase {
     }
 
     func testLikeQuery() throws {
-        let query = try DummyModel.query().filter("name", .hasPrefix, "Vap")
+        let query = try DummyModel.makeQuery().filter("name", .hasPrefix, "Vap")
 
         guard
             let filter = query.filters.first?.wrapped,
@@ -70,7 +70,7 @@ class QueryFiltersTests: XCTestCase {
     }
  
     func testCountQuery() throws {
-        let query = try DummyModel.query().filter(DummyModel.idKey, 5)
+        let query = try DummyModel.makeQuery().filter(DummyModel.idKey, 5)
 
         do {
             let numberOfResults = try query.count()
@@ -83,7 +83,7 @@ class QueryFiltersTests: XCTestCase {
     }
 
     func testDeleteQuery() throws {
-        let query = try DummyModel.query().filter(DummyModel.idKey, 5)
+        let query = try DummyModel.makeQuery().filter(DummyModel.idKey, 5)
 
         do {
             try query.delete()
@@ -95,12 +95,12 @@ class QueryFiltersTests: XCTestCase {
     }
   
     func testLimitQuery() throws {
-        let query = try DummyModel.query().limit(5)
+        let query = try DummyModel.makeQuery().limit(5)
         XCTAssertEqual(query.limits.first?.wrapped?.count, 5)
     }
 
     func testDistinctQuery() throws {
-        let query = try DummyModel.query().distinct()
+        let query = try DummyModel.makeQuery().distinct()
         XCTAssert(query.distinct)
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -13,7 +13,7 @@ XCTMain([
     testCase(SchemaCreateTests.allTests),
     testCase(SQLSerializerTests.allTests),
     testCase(JoinTests.allTests),
-    testCase(MemoryBenchmarkTests.allTests)
+    testCase(MemoryBenchmarkTests.allTests),
     testCase(SQLiteTests.allTests)
 ])
 


### PR DESCRIPTION
- allows all fluent queries to be run on a specific connection

## Implicit Executor (using the Model's Database)

```swift
User.all()
let user = try User.find(42)
user.pets.all()
user.pets.delete()
```

## Passing the Executor

```swift
let conn = mysql().makeConnection()
User.makeQuery(conn).all()
let user = try User.makeQuery(conn).find(42)
user.pets.makeQuery(conn).all()
user.pets.makeQuery(conn).delete()
```