### PR TITLE
Correction to EntityError's suggested fix

### DIFF
--- a/Sources/Fluent/Entity/EntityError.swift
+++ b/Sources/Fluent/Entity/EntityError.swift
@@ -66,7 +66,7 @@ extension EntityError: Debuggable {
         switch self {
         case .noDatabase(let e):
             return [
-                "make sure to call `database.prepare(\(e).self)` or ensure that it's added to your Droplet's `preparations` with `drop.preprations.append(\(e).self)"
+                "make sure to call `\(e).prepare(database)` or ensure that it's added to your Droplet's `preparations` with `drop.preprations.append(\(e).self)"
             ]
         case .noId(_):
             return [


### PR DESCRIPTION
For my entity `MyEntity`, I was suggested to call `database.prepare(MyEntity.self)`.

However this is not valid, and Fluent's tests use the format `MyEntity.prepare(database)` instead.

This PR changes the suggestion text to the latter format.