### PR TITLE
Allow Fluent table name to be mutated

### DIFF
--- a/Sources/Fluent/Preparation/Migration.swift
+++ b/Sources/Fluent/Preparation/Migration.swift
@@ -1,5 +1,5 @@
 final class Migration: Entity {
-    static var entity = "fluent"
+    static var entity = fluentTableName
     let storage = Storage()
     var name: String
     var batch: Int
@@ -38,3 +38,5 @@ extension Migration: Preparation {
 }
 
 extension Migration: Timestampable {}
+
+public var fluentTableName: String = "fluent"

--- a/Sources/Fluent/Preparation/Migration.swift
+++ b/Sources/Fluent/Preparation/Migration.swift
@@ -1,5 +1,5 @@
 final class Migration: Entity {
-    static var entity = fluentTableName
+    static var entity = migrationEntityName
     let storage = Storage()
     var name: String
     var batch: Int
@@ -39,4 +39,4 @@ extension Migration: Preparation {
 
 extension Migration: Timestampable {}
 
-public var fluentTableName: String = "fluent"
+public var migrationEntityName: String = "fluent"


### PR DESCRIPTION
This PR makes it easy to work with Vapor 1 and 2 projects in the same database. If/when this is merged I'll add a PR to `fluent-provider` that enables json configuration of this field.