### PR TITLE
Add generic return value to transaction closure

### DIFF
--- a/Sources/Fluent/Database/Transactable.swift
+++ b/Sources/Fluent/Database/Transactable.swift
@@ -1,7 +1,7 @@
 /// Drivers that can perform data transactions should
 /// conform to this protocol.
 public protocol Transactable {
-    func transaction(_ closure: (Connection) throws -> ()) throws
+    func transaction<R>(_ closure: (Connection) throws -> R) throws -> R
 }
 
 extension Database: Transactable {
@@ -11,12 +11,12 @@ extension Database: Transactable {
     /// be rolled back.
     ///
     /// note: the underlying driver must support transactions
-    public func transaction(_ closure: (Connection) throws -> ()) throws {
+    public func transaction<R>(_ closure: (Connection) throws -> R) throws -> R {
         guard let t = driver as? Transactable else {
             throw TransactionError.unsupported(type(of: driver))
         }
         
-        try t.transaction(closure)
+        return try t.transaction(closure)
     }
 }
 

--- a/Sources/Fluent/SQLite/SQLiteDriver.swift
+++ b/Sources/Fluent/SQLite/SQLiteDriver.swift
@@ -150,7 +150,7 @@
             try raw("PRAGMA foreign_keys = OFF")
         }
 
-        public func transaction(_ closure: (Connection) throws -> ()) throws {
+        public func transaction<R>(_ closure: (Connection) throws -> R) throws -> R {
             let conn = try makeConnection(.readWrite)
 
             let rand = OSRandom()
@@ -162,8 +162,9 @@
 
             try conn.raw("SAVEPOINT \(name)")
             do {
-                try closure(conn)
+                let value = try closure(conn)
                 try conn.raw("RELEASE SAVEPOINT \(name)")
+                return value
             } catch {
                 try conn.raw("ROLLBACK TO SAVEPOINT \(name)")
                 throw error


### PR DESCRIPTION
I've taken the liberty to submit a PR without submitting an issue as this seems like a small improvement that many could benefit from - and I figured a diff would be worth a thousand words.

## Changes

Updates `Transactable` allowing its closure to return a generic value. This is quite useful when we'd like to return a value from a transaction closure without having to deal with optional values.

## Before

```swift
var returnValue: User?
try database.transaction { _ in
  let user = User(name: "Fluent")
  try user.save()
  let modelA = ModelA(user: user)
  try modelA.save()
  returnValue = user
}

return returnValue!
```

## After

```swift
return try database.transaction { _ -> User in
  let user = User(name: "Fluent")
  try user.save()
  let modelA = ModelA(user: user)
  try modelA.save()
  return user
}
```

## Compatibility
If nothing is returned from the transaction then `Void` will be inferred as the generic parameter just like it used to be - which won't break client code.

This will require minimal changes in underlying drivers that conform to `Transactable ` - I will be preparing PRs and submit them pending this PR's approval.