### PR TITLE
fix distinct + parent

### DIFF
--- a/Sources/Fluent/Query/Distinct.swift
+++ b/Sources/Fluent/Query/Distinct.swift
@@ -2,7 +2,7 @@ extension QueryRepresentable  where Self: ExecutorRepresentable {
     /// Limits results to be distinct values
     func distinct() throws -> Query<E> {
         let query = try makeQuery()
-        query.distinct = true
+        query.isDistinct = true
         return query
     }
 }

--- a/Sources/Fluent/Query/Query.swift
+++ b/Sources/Fluent/Query/Query.swift
@@ -46,7 +46,7 @@ public final class Query<E: Entity> {
     /// If true, uses appropriate distinct modifiers
     /// on fetch and counts to return only distinct
     /// results for this query.
-    public var distinct: Bool
+    public var isDistinct: Bool
 
     /// Creates a new `Query` with the
     /// `Model`'s database.
@@ -57,7 +57,7 @@ public final class Query<E: Entity> {
         joins = []
         limits = []
         sorts = []
-        distinct = false
+        isDistinct = false
         includeSoftDeleted = false
         data = [:]
         keys = []

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -78,7 +78,7 @@ open class GeneralSQLSerializer<E: Entity>: SQLSerializer {
         var columns: [String] = ["\(table).*"]
         
         statement += "SELECT"
-        if query.distinct {
+        if query.isDistinct {
             statement += "DISTINCT"
         }
         
@@ -124,7 +124,7 @@ open class GeneralSQLSerializer<E: Entity>: SQLSerializer {
         var values: [Node] = []
 
         statement += "SELECT"
-        if query.distinct {
+        if query.isDistinct {
             statement += "DISTINCT"
         }
         statement += "COUNT(*) as _fluent_count FROM"

--- a/Sources/Fluent/Schema/Builder.swift
+++ b/Sources/Fluent/Schema/Builder.swift
@@ -156,33 +156,13 @@ extension Builder {
     public func parent<E: Entity>(
         _ entity: E.Type = E.self,
         optional: Bool = false,
-        unique: Bool = false,
-        default: NodeRepresentable? = nil
+        unique: Bool = false
     ) {
-        parent(
-            idKey: E.idKey,
-            idType: E.idType,
+        foreignId(
+            for: E.self,
             optional: optional,
-            unique: unique,
-            default: `default`
+            unique: unique
         )
-    }
-
-    public func parent(
-        idKey: String,
-        idType: IdentifierType,
-        optional: Bool = false,
-        unique: Bool = false,
-        default: NodeRepresentable? = nil
-    ) {
-        let field = Field(
-            name: idKey,
-            type: .id(type: idType),
-            optional: optional,
-            unique: unique,
-            default: `default`
-        )
-        self.field(field)
     }
     
     // MARK: Foreign Key

--- a/Tests/FluentTests/QueryFiltersTests.swift
+++ b/Tests/FluentTests/QueryFiltersTests.swift
@@ -24,7 +24,7 @@ class QueryFiltersTests: XCTestCase {
         XCTAssert(query.filters.count == 0, "Filters should be empty")
         XCTAssert(query.data.isEmpty == true, "Data should be empty")
         XCTAssert(query.limits.isEmpty == true, "Limit should be empty")
-        XCTAssert(query.distinct == false, "Distinct should be false")
+        XCTAssert(query.isDistinct == false, "Distinct should be false")
     }
 
     func testBasicQuery() throws {
@@ -101,6 +101,6 @@ class QueryFiltersTests: XCTestCase {
 
     func testDistinctQuery() throws {
         let query = try DummyModel.makeQuery().distinct()
-        XCTAssert(query.distinct)
+        XCTAssert(query.isDistinct)
     }
 }

--- a/Tests/FluentTests/SQLSerializerTests.swift
+++ b/Tests/FluentTests/SQLSerializerTests.swift
@@ -38,9 +38,8 @@ class SQLSerializerTests: XCTestCase {
         XCTAssert(values.isEmpty)
     }
     
-    func testDistinctSelect() {
-        let query = Query<Atom>(db)
-        query.distinct = true
+    func testDistinctSelect() throws {
+        let query = try Query<Atom>(db).distinct()
         let (statement, values) = serialize(query)
         
         XCTAssertEqual(statement, "SELECT DISTINCT `atoms`.* FROM `atoms`")
@@ -104,7 +103,7 @@ class SQLSerializerTests: XCTestCase {
     func testDistinctCount() {
         let query = Query<User>(db)
         query.action = .count
-        query.distinct = true
+        query.isDistinct = true
         let (statement, values) = serialize(query)
         
         XCTAssertEqual(statement, "SELECT DISTINCT COUNT(*) as _fluent_count FROM `users`")


### PR DESCRIPTION
- Changes `distinct` to `isDistinct` so `.distinct()` is not ambiguous.
- Fixes the `.parent(User.self)` convenience.