### PR TITLE
Fix index and foreign keys ignoring the escape function

### DIFF
--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -345,8 +345,8 @@ open class GeneralSQLSerializer<E: Entity>: SQLSerializer {
         case .raw(let string, _):
             return string
         case .some(let idx):
-            let list = idx.fields.joined(separator: ", ")
-            return "INDEX `\(idx.name)` ON `\(E.entity)` (`\(list)`)"
+            let list = idx.fields.map(escape).joined(separator: ", ")
+            return "INDEX \(escape(idx.name)) ON \(escape(E.entity)) (\(list))"
         }
     }
 
@@ -360,7 +360,7 @@ open class GeneralSQLSerializer<E: Entity>: SQLSerializer {
         case .raw(let string, _):
             return string
         case .some(let foreignKey):
-            return "CONSTRAINT `\(foreignKey.name)` FOREIGN KEY (`\(foreignKey.field)`) REFERENCES `\(foreignKey.foreignEntity.entity)` (`\(foreignKey.foreignField)`)"
+            return "CONSTRAINT \(escape(foreignKey.name)) FOREIGN KEY (\(escape(foreignKey.field))) REFERENCES \(escape(foreignKey.foreignEntity.entity)) (\(escape(foreignKey.foreignField)))"
         }
     }
 


### PR DESCRIPTION
The backtick was hardcoded in these functions, which is not compatible with Postgres. I presume this is a leftover from a previous version, as table and column names are all dynamically escaped.

With this change, index and foreign key definitions will be too.