### PR TITLE
List of preparation reverted in revert operations

### DIFF
--- a/Sources/Fluent/Preparation/Database+Preparation.swift
+++ b/Sources/Fluent/Preparation/Database+Preparation.swift
@@ -13,6 +13,7 @@ extension Database {
     
     public func revertAll(_ preparations: [Preparation.Type]) throws {
         try prepareMetadata()
+        let preparations: ReversedCollection<[Preparation.Type]> = preparations.reversed()
         for preparation in preparations {
             if let migration = try migration(for: preparation) {
                 try preparation.revert(self)
@@ -25,6 +26,7 @@ extension Database {
         try prepareMetadata()
         let batch = try latestBatch()
         var toBeReverted: [Preparation.Type] = []
+        let preparations: ReversedCollection<[Preparation.Type]> = preparations.reversed()
         for preparation in preparations {
             if let migration = try migration(for: preparation), migration.batch == batch {
                 toBeReverted.append(preparation)
@@ -37,6 +39,7 @@ extension Database {
     public func revertBatch(_ preparations: [Preparation.Type]) throws {
         try prepareMetadata()
         let batch = try latestBatch()
+        let preparations: ReversedCollection<[Preparation.Type]> = preparations.reversed()
         for preparation in preparations {
             if let migration = try migration(for: preparation), migration.batch == batch {
                 try preparation.revert(self)

--- a/Sources/Fluent/Preparation/Database+Preparation.swift
+++ b/Sources/Fluent/Preparation/Database+Preparation.swift
@@ -13,7 +13,7 @@ extension Database {
     
     public func revertAll(_ preparations: [Preparation.Type]) throws {
         try prepareMetadata()
-        let preparations: ReversedCollection<[Preparation.Type]> = preparations.reversed()
+        let preparations = preparations.reversed()
         for preparation in preparations {
             if let migration = try migration(for: preparation) {
                 try preparation.revert(self)
@@ -26,7 +26,7 @@ extension Database {
         try prepareMetadata()
         let batch = try latestBatch()
         var toBeReverted: [Preparation.Type] = []
-        let preparations: ReversedCollection<[Preparation.Type]> = preparations.reversed()
+        let preparations = preparations.reversed()
         for preparation in preparations {
             if let migration = try migration(for: preparation), migration.batch == batch {
                 toBeReverted.append(preparation)
@@ -39,7 +39,7 @@ extension Database {
     public func revertBatch(_ preparations: [Preparation.Type]) throws {
         try prepareMetadata()
         let batch = try latestBatch()
-        let preparations: ReversedCollection<[Preparation.Type]> = preparations.reversed()
+        let preparations = preparations.reversed()
         for preparation in preparations {
             if let migration = try migration(for: preparation), migration.batch == batch {
                 try preparation.revert(self)


### PR DESCRIPTION
This needs to ensure the correct order for tables deletion to avoid breaking the foreign key constraints.
This does not work with a double linked foreign key that MUST be removed manually before dropping the interested table.