### PR TITLE
Various enhancements to relations

### DIFF
--- a/Sources/Fluent/Pivot/DoublePivot.swift
+++ b/Sources/Fluent/Pivot/DoublePivot.swift
@@ -16,9 +16,9 @@ extension PivotProtocol where Left: PivotProtocol, Self: Entity {
         let result = try Left
             .makeQuery()
             .join(self)
-            .filter(Left.self, Left.Left.foreignIdKey == leftId)
-            .filter(Left.self, Left.Right.foreignIdKey, middleId)
-            .filter(self, Right.foreignIdKey, rightId)
+            .filter(Left.self, pivotLeftIdKey == leftId)
+            .filter(Left.self, pivotRightIdKey, middleId)
+            .filter(self, pivotRightIdKey, rightId)
             .first()
 
         return result != nil
@@ -40,9 +40,9 @@ extension PivotProtocol where Right: PivotProtocol, Self: Entity {
         let result = try Right
             .makeQuery()
             .join(self)
-            .filter(self, Left.foreignIdKey, leftId)
-            .filter(Right.self, Right.Left.foreignIdKey, middleId)
-            .filter(Right.self, Right.Right.foreignIdKey, rightId)
+            .filter(self, pivotLeftIdKey, leftId)
+            .filter(Right.self, pivotLeftIdKey, middleId)
+            .filter(Right.self, pivotRightIdKey, rightId)
             .first()
 
         return result != nil

--- a/Sources/Fluent/Pivot/Pivot.swift
+++ b/Sources/Fluent/Pivot/Pivot.swift
@@ -54,8 +54,8 @@ public final class Pivot<
     }
 
     public init(row: Row) throws {
-        leftId = try row.get(Left.foreignIdKey)
-        rightId = try row.get(Right.foreignIdKey)
+        leftId = try row.get(pivotLeftIdKey)
+        rightId = try row.get(pivotRightIdKey)
 
         id = try row.get(idKey)
     }
@@ -63,8 +63,8 @@ public final class Pivot<
     public func makeRow() throws -> Row {
         var row = Row()
         try row.set(idKey, id)
-        try row.set(Left.foreignIdKey, leftId)
-        try row.set(Right.foreignIdKey, rightId)
+        try row.set(pivotLeftIdKey, leftId)
+        try row.set(pivotRightIdKey, rightId)
         return row
     }
 }
@@ -73,8 +73,8 @@ extension Pivot: Preparation {
     public static func prepare(_ database: Database) throws {
         try database.create(self) { builder in
             builder.id()
-            builder.foreignId(for: Left.self)
-            builder.foreignId(for: Right.self)
+            builder.foreignId(pivotLeftIdKey, for: Left.self)
+            builder.foreignId(pivotRightIdKey, for: Right.self)
         }
     }
 

--- a/Sources/Fluent/Pivot/PivotProtocol.swift
+++ b/Sources/Fluent/Pivot/PivotProtocol.swift
@@ -7,7 +7,7 @@
 public protocol PivotProtocol {
     associatedtype Left: Entity
     associatedtype Right: Entity
-
+    
     /// Returns true if the two entities are related
     static func related(_ left: Left, _ right: Right) throws -> Bool
 
@@ -30,8 +30,8 @@ extension PivotProtocol where Self: Entity {
         let rightId = try right.assertExists()
 
         let results = try makeQuery()
-            .filter(type(of: left).foreignIdKey, leftId)
-            .filter(type(of: right).foreignIdKey, rightId)
+            .filter(pivotLeftIdKey, leftId)
+            .filter(pivotRightIdKey, rightId)
             .first()
 
         return results != nil
@@ -44,8 +44,8 @@ extension PivotProtocol where Self: Entity {
         let rightId = try right.assertExists()
 
         var row = Row()
-        try row.set(Left.foreignIdKey, leftId)
-        try row.set(Right.foreignIdKey, rightId)
+        try row.set(pivotLeftIdKey, leftId)
+        try row.set(pivotRightIdKey, rightId)
 
         let pivot = try self.init(row: row)
         try pivot.save()
@@ -59,8 +59,11 @@ extension PivotProtocol where Self: Entity {
         let rightId = try right.assertExists()
 
         try makeQuery()
-            .filter(Left.foreignIdKey, leftId)
-            .filter(Right.foreignIdKey, rightId)
+            .filter(pivotLeftIdKey, leftId)
+            .filter(pivotRightIdKey, rightId)
             .delete()
     }
 }
+
+public var pivotLeftIdKey: String = "left_id"
+public var pivotRightIdKey: String = "right_id"

--- a/Sources/Fluent/Relations/RelationError.swift
+++ b/Sources/Fluent/Relations/RelationError.swift
@@ -3,6 +3,7 @@
 /// Ex: Children, Parent, Siblings
 public enum RelationError {
     case idRequired(Entity)
+    case oneToOneConstraint(Entity, Entity.Type, Int)
     case unspecified(Error)
 }
 
@@ -11,6 +12,8 @@ extension RelationError: Debuggable {
         switch self {
         case .idRequired:
             return "idRequired"
+        case .oneToOneConstraint(_, _, _):
+            return "oneToOneConstraint"
         case .unspecified:
             return "unspecified"
         }
@@ -20,6 +23,8 @@ extension RelationError: Debuggable {
         switch self {
         case .idRequired(let entity):
             return "Required identifier is missing for entity \(entity)"
+        case let .oneToOneConstraint(parent, child, count):
+            return "One-to-one relationship broken. Too many (\(count)) \(child.name) on \(parent)"
         case .unspecified(let error):
             return "An unspecified error was received \(error)"
         }
@@ -33,6 +38,10 @@ extension RelationError: Debuggable {
                 "object wasn't properly fetched from database before using",
                 "database is corrupt or has unexpected values",
                 "manually loaded object without setting id"
+            ]
+        case .oneToOneConstraint(_, _, _):
+            return [
+                "too many childs inserted under the same parent",
             ]
         case .unspecified:
             return [
@@ -48,6 +57,11 @@ extension RelationError: Debuggable {
                 "ensure the object is loading properly on database fetch",
                 "verify database tables are as expected",
                 "if loading object manually, make sure that id is appropriately set",
+            ]
+        case .oneToOneConstraint(_, _, _):
+            return [
+                "take care of your business logic",
+                "remove the extra child",
             ]
         case .unspecified:
             return [

--- a/Sources/Fluent/Relations/Siblings.swift
+++ b/Sources/Fluent/Relations/Siblings.swift
@@ -51,7 +51,7 @@ extension Siblings: QueryRepresentable {
         let query = try Foreign.makeQuery()
 
         try query.join(Through.self)
-        try query.filter(Through.self, Local.foreignIdKey, localId)
+        try query.filter(Through.self, pivotLeftIdKey, localId)
 
         return query
     }

--- a/Sources/Fluent/Schema/Builder.swift
+++ b/Sources/Fluent/Schema/Builder.swift
@@ -5,6 +5,28 @@ public protocol Builder: class {
     var foreignKeys: [RawOr<ForeignKey>] { get set }
 }
 
+/// Represents the way to create a foreign key constraint 
+/// inside a foreign id field definition
+public enum ForeignKeyCreation {
+    /// The default behavior: created only if autoForeignKeys == true
+    /// with an automatic name assigned
+    case auto
+    
+    /// Created only if autoForeignKeys == true with custom name
+    case autoWithName(String)
+    
+    /// The foreign key constraint is never created
+    case none
+    
+    /// The foreign key created regardeless to autoForeignKeys,
+    /// with an automatic name assigned
+    case force
+
+    /// The foreign key created regardeless to autoForeignKeys,
+    /// with a custom name assigned
+    case forceWithName(String)
+}
+
 extension Builder {
     public func field(_ field: Field) {
         fields.append(.some(field))
@@ -20,23 +42,47 @@ extension Builder {
     }
 
     public func foreignId<E: Entity>(
+        _ name: String = E.foreignIdKey,
         for entityType: E.Type,
         optional: Bool = false,
-        unique: Bool = false
-    ) {
+        unique: Bool = false,
+        constraint fkCreation: ForeignKeyCreation = .auto
+        ) {
         let field = Field(
-            name: E.foreignIdKey,
+            name: name,
             type: .id(type: E.idType),
             optional: optional,
             unique: unique
         )
         self.field(field)
         
-        if autoForeignKeys {
-            self.foreignKey(for: E.self)
+        switch fkCreation {
+            
+        case .auto:
+            if autoForeignKeys {
+                self.foreignKey(name, references: E.idKey, on: E.self)
+            }
+            
+        case .autoWithName(let fkName):
+            if autoForeignKeys {
+                self.foreignKey(name, references: E.idKey, on: E.self, name: fkName)
+            }
+            
+        case .none:
+            // Avoid the creation of the foreign key constraint
+            break
+            
+        case .force:
+            // Always creates the foreign key constraint, using the default name
+            self.foreignKey(name, references: E.idKey, on: E.self)
+
+        case .forceWithName(let fkName):
+            // Always creates the foreign key constraint, using a custom name
+            self.foreignKey(name, references: E.idKey, on: E.self, name: fkName)
+            
         }
     }
-
+    
     public func int(
         _ name: String,
         optional: Bool = false,
@@ -154,14 +200,66 @@ extension Builder {
     // MARK: Relations
 
     public func parent<E: Entity>(
+        field name: String = E.foreignIdKey,
         _ entity: E.Type = E.self,
         optional: Bool = false,
-        unique: Bool = false
+        unique: Bool = false,
+        constraint fkCreation: ForeignKeyCreation = .auto
     ) {
         foreignId(
+            name,
             for: E.self,
             optional: optional,
-            unique: unique
+            unique: unique,
+            constraint: fkCreation
+        )
+    }
+    
+    public func owner<E: Entity>(
+        _ name: String = E.foreignIdKey,
+        of entity: E.Type = E.self,
+        optional: Bool = false,
+        unique: Bool = false,
+        constraint fkCreation: ForeignKeyCreation = .auto
+        ) {
+        foreignId(
+            name,
+            for: entity,
+            optional: optional,
+            unique: unique,
+            constraint: fkCreation
+        )
+    }
+    
+    public func lookup<E: Entity>(
+        _ name: String = E.foreignIdKey,
+        on entity: E.Type = E.self,
+        optional: Bool = false,
+        unique: Bool = false,
+        constraint fkCreation: ForeignKeyCreation = .auto
+        ) {
+        foreignId(
+            name,
+            for: entity,
+            optional: optional,
+            unique: unique,
+            constraint: fkCreation
+        )
+    }
+    
+    public func subclass<E: Entity>(
+        _ name: String = E.foreignIdKey,
+        of entity: E.Type = E.self,
+        optional: Bool = false,
+        unique: Bool = false,
+        constraint fkCreation: ForeignKeyCreation = .auto
+        ) {
+        foreignId(
+            name,
+            for: entity,
+            optional: optional,
+            unique: unique,
+            constraint: fkCreation
         )
     }
     
@@ -201,6 +299,21 @@ extension Builder {
         )
     }
 
+    /// Adds a foreign key constraint from a local
+    /// column to a column on the foreign entity with
+    /// a custom name
+    public func foreignKey<E: Entity>(
+        for: E.Type = E.self,
+        idKey: String = E.foreignIdKey,
+        name: String? = nil
+        ) {
+        self.foreignKey(
+            idKey,
+            references: E.idKey,
+            on: E.self,
+            name: name
+        )
+    }
     // MARK: Raw
 
     public func raw(_ string: String) {


### PR DESCRIPTION
I've made some modification to expand the possibilities of relations.
Related to #236 and #242.

**WARNING! Not everything is tested yet!**

## Pivot
Instead of using the foreign id names provided by the linked entities, I've used two fixed names (now `left_id` and `right_id`). This allows for example to generate a Pivot table that connects entities of the same types.

## Foreign key names
The possibilities to add a foreign key is extended by the enum parameter ForeignKeyCreator. To enable this some functions on the Builder have been modified but kept retro-compatible.

## Custom foreign id names
Parent/children relations have been extended with the possibility to have custom foreign id names.

## Descriptive query functions
Even if almost every relation can be reduced to a parent/children, I find very useful to have functions that describe the type of the relation we need, like for example `owner/owned`, `lookup`, `ancestor/subclass`, etc. Functions with descriptive names were added on Entity extension.
A new RelationError was added to signal an expected one-to-one relation that is effectively a one-to-many.