### PR TITLE
add outer joins

### DIFF
--- a/Sources/Fluent/Query/Join.swift
+++ b/Sources/Fluent/Query/Join.swift
@@ -18,13 +18,15 @@ public struct Join {
     /// the base data
     public let joined: Entity.Type
     
+    /// An exhaustive list of 
+    /// possible join types.
     public enum Kind {
-        // returns only rows that
-        // appear in both sets
+        /// returns only rows that
+        /// appear in both sets
         case inner
-        // returns all matching rows
-        // from the queried table _and_
-        // all rows that appear in both sets
+        /// returns all matching rows
+        /// from the queried table _and_
+        /// all rows that appear in both sets
         case outer
     }
 

--- a/Sources/Fluent/Query/Join.swift
+++ b/Sources/Fluent/Query/Join.swift
@@ -17,7 +17,18 @@ public struct Join {
     /// Entity that will be joining
     /// the base data
     public let joined: Entity.Type
+    
+    public enum Kind {
+        // returns only rows that
+        // appear in both sets
+        case inner
+        // returns all matching rows
+        // from the queried table _and_
+        // all rows that appear in both sets
+        case outer
+    }
 
+    public let kind: Kind
 
     /// The key from the base table that will
     /// be compared to the key from the joined
@@ -39,11 +50,13 @@ public struct Join {
 
     /// Create a new Join
     public init<Base: Entity, Joined: Entity>(
+        kind: Kind,
         base: Base.Type,
         joined: Joined.Type,
         baseKey: String = Base.idKey,
         joinedKey: String = Base.foreignIdKey
     ) {
+        self.kind = kind
         self.base = base
         self.joined = joined
         self.baseKey = baseKey
@@ -56,11 +69,13 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
     /// See Join for more information.
     @discardableResult
     public func join<Joined: Entity>(
+        kind: Join.Kind = .inner,
         _ joined: Joined.Type,
         baseKey: String = E.idKey,
         joinedKey: String = E.foreignIdKey
     ) throws -> Query<Self.E> {
         let join = Join(
+            kind: kind,
             base: E.self,
             joined: joined,
             baseKey: baseKey,

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -710,7 +710,12 @@ open class GeneralSQLSerializer<E: Entity>: SQLSerializer {
     open func join(_ join: Join) -> String {
         var fragments: [String] = []
 
-        fragments += "JOIN"
+        switch join.kind {
+        case .inner:
+            fragments += "INNER JOIN"
+        case .outer:
+            fragments += "LEFT OUTER JOIN"
+        }
         fragments += escape(join.joined.entity)
         fragments += "ON"
 

--- a/Tests/FluentTests/RawTests.swift
+++ b/Tests/FluentTests/RawTests.swift
@@ -56,7 +56,7 @@ class RawTests: XCTestCase {
         
         let (statement, values) = serialize(query)
         
-        XCTAssertEqual(statement, "SELECT `compounds`.* FROM `compounds` JOIN `atoms` ON `compounds`.`#id` = `atoms`.`compound_#id` JOIN `foo` ON `users`.BAR !~ `foo`.🚀 WHERE `atoms`.`size` = ? AND `foo`.aGe ~~ ?")
+        XCTAssertEqual(statement, "SELECT `compounds`.* FROM `compounds` INNER JOIN `atoms` ON `compounds`.`#id` = `atoms`.`compound_#id` JOIN `foo` ON `users`.BAR !~ `foo`.🚀 WHERE `atoms`.`size` = ? AND `foo`.aGe ~~ ?")
         XCTAssertEqual(values.count, 2)
     }
     

--- a/Tests/FluentTests/SQLSerializerTests.swift
+++ b/Tests/FluentTests/SQLSerializerTests.swift
@@ -252,7 +252,7 @@ class SQLSerializerTests: XCTestCase {
         try query.delete()
         
         let (statement, values) = serialize(query)
-        XCTAssertEqual(statement, "DELETE `compounds` FROM `compounds` JOIN `atoms` ON `compounds`.`id` = `atoms`.`compound_id` WHERE `atoms`.`name` = ?")
+        XCTAssertEqual(statement, "DELETE `compounds` FROM `compounds` INNER JOIN `atoms` ON `compounds`.`id` = `atoms`.`compound_id` WHERE `atoms`.`name` = ?")
         XCTAssertEqual(values.count, 1)
     }
 


### PR DESCRIPTION
Allows for outer joins. Fixes #248. 

As for right joins, those don't make sense in the context of Fluent since the data from the query will ultimately be parsed by models from the Left table.

### Inner (Default)
![inner_join](https://cloud.githubusercontent.com/assets/1342803/25903518/8f9b1c74-3594-11e7-9d5c-aa2b1dc9de2b.gif)

### Outer (New)

![left_outer_join](https://cloud.githubusercontent.com/assets/1342803/25903524/9401fbca-3594-11e7-9614-c642a357b074.gif)
