### PR TITLE
Fix compiler errors

### DIFF
--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -84,7 +84,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
         let query = try makeQuery()
 
         query.action = .create
-        try row.makeNode(in: query.context).rawOrObject?.forEach { (key, value) in
+        row?.makeNode(in: query.context).rawOrObject?.forEach { (key, value) in
             query.data[key] = value
         }
 
@@ -219,7 +219,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
         let query = try makeQuery()
 
         query.action = .modify
-        try row.makeNode(in: query.context).rawOrObject?.forEach { (key, value) in
+        row?.makeNode(in: query.context).rawOrObject?.forEach { (key, value) in
             query.data[key] = value
         }
 

--- a/Sources/Fluent/Utilities/Exports.swift
+++ b/Sources/Fluent/Utilities/Exports.swift
@@ -2,5 +2,6 @@
     @_exported import NodeCocoapods
 #else
     @_exported import Node
+	@_exported import NodeFuzzy
 #endif
 

--- a/Tests/FluentTests/Utilities/LastQueryDriver.swift
+++ b/Tests/FluentTests/Utilities/LastQueryDriver.swift
@@ -1,4 +1,5 @@
 import Fluent
+import NodeFuzzy
 
 class LastQueryDriver: Driver {
     var keyNamingConvention: KeyNamingConvention = .snake_case


### PR DESCRIPTION
`MemoryBenchmarkTests` still fails at the moment. May be something due to `SoftDeletable`:

```
/fluent/Tests/FluentTesterTests/MemoryBenchmarkTests.swift:24: error: -[FluentTesterTests.MemoryBenchmarkTests testSuite] : failed - failed("Pagination failed: Node Error: No value found at path \'deleted_at\', expected \'Date, formatted time string, or timestamp\'\n\nIdentifier: Node.NodeError.unableToConvert\n\nHere are some possible causes: \n- typo in key path\n- underlying type is not convertible\n- unexpected \'.\' being interpreted as path instead of key\n\nThese suggestions could address the issue: \n- called `get(...)` on a key or key path that does not exist in the data\n- the data being parsed is missing required values or is incorrectly formatted\n- found unconvertible data, e.g., got a string of letters when an integer is required\n- if you have keys containing a \'.\' that shouldn\'t be interpreted as a path, use \'DotKey(\"actual.key\")\'")
```