### PR TITLE
Fix case mismatch in the custom keys test

### DIFF
--- a/Sources/FluentTester/Tester+CustomKeys.swift
+++ b/Sources/FluentTester/Tester+CustomKeys.swift
@@ -122,7 +122,7 @@ final class Bloguser: Entity, Preparation {
     }
     
     var updatedPosts: Children<Bloguser, Blogpost> {
-        return children(foreignIdKey: "updatedby")
+        return children(foreignIdKey: "updatedBy")
     }
     
     var followers: Siblings<Bloguser, Bloguser, BloguserFollowersPivot> {


### PR DESCRIPTION
Other parts of the test use proper camelCase, this single occurrence was in all lowercase.
This PR resolves that discrepancy.

(This might not be a problem in MySQL, but it makes Postgres barf.)