### PR TITLE
sqlite last insert id

### DIFF
--- a/Sources/FluentTester/Atom.swift
+++ b/Sources/FluentTester/Atom.swift
@@ -2,6 +2,7 @@ public final class Atom: Entity {
     public var name: String
     public var protons: Int
     public var weight: Double
+    public static let idType: IdentifierType = .uuid
 
     public let storage = Storage()
 

--- a/Sources/FluentTester/Tester+InsertAndFind.swift
+++ b/Sources/FluentTester/Tester+InsertAndFind.swift
@@ -6,12 +6,16 @@ extension Tester {
             try! Atom.revert(database)
         }
 
-        let hydrogen = Atom(id: nil, name: "Hydrogen", protons: 1, weight: 1.007)
+        let hydrogen = Atom(id: "asdf", name: "Hydrogen", protons: 1, weight: 1.007)
 
         guard hydrogen.exists == false else {
             throw Error.failed("Exists should be false since not yet saved.")
         }
         try hydrogen.save()
+        
+        guard hydrogen.id?.string == "asdf" else {
+            throw Error.failed("Saved ID not equal to set id.")
+        }
         
         guard hydrogen.exists == true else {
             throw Error.failed("Exists should be true since just saved.")


### PR DESCRIPTION
- Uses ID supplied in data instead of SQLite last id if idType is not `.int`
- Fixes https://github.com/vapor/fluent/issues/259