### PR TITLE
Fixes an id issue after creation

### DIFF
--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -159,7 +159,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
             }
 
             let id = try query.create(row)
-            if id != nil, id != .null, id != 0 {
+            if case .int = E.idType, id != nil, id != .null, id != 0 {
                 entity.id = id
             }
 


### PR DESCRIPTION
Currently an entity's `id` gets updated post creation by the retuned identifier for `query.create` [if not `.null` and non zero](https://github.com/vapor/fluent/blob/master/Sources/Fluent/Query/QueryRepresentable.swift#L162). 

If a database uses entities only with `idType == .uuid` then `LAST_INSERT_ID()` will always returns `0` thus never updating the entity's `id` post creation - and behaving as expected. 

However, in an hybrid configuration (some tables may use `.uuid` whilst other use `.id` as their `idType`), a model using `.uuid` will see his identifier updated by a previously created instance (of a entity having an `idType == .id`).

Example:

```swift
final class User: Entity {

  static let idType = .uuid
}

final class Update: Entity {

  static let idType = .int
}

let update = try Update().save()
let user = try User().save()

precondition(user.id != update.id) // fails
```

Proposed fix: only update the entity's `id` if its `idType` is `.int`. This seems to work well in my testing (using the `MySQL` driver, at the very least) but I wonder if the approach isn't too simplistic - I'm guessing some drivers may / could potentially return the actual created `UUID` - in which case this would break.

A more advanced / correct approach could involve comparing the returned `StructuredData` type by `create` to the `idType` and only update it if it "matches".

Suggestions welcome as I'm not particularly knowledgeable in different database behaviours 👍 