### PR TITLE
Use valid UUID for insert-and-fix

### DIFF
--- a/Sources/FluentTester/Tester+InsertAndFind.swift
+++ b/Sources/FluentTester/Tester+InsertAndFind.swift
@@ -6,14 +6,15 @@ extension Tester {
             try! Atom.revert(database)
         }
 
-        let hydrogen = Atom(id: "asdf", name: "Hydrogen", protons: 1, weight: 1.007)
+        let uuid = UUID()
+        let hydrogen = Atom(id: Identifier(uuid.uuidString), name: "Hydrogen", protons: 1, weight: 1.007)
 
         guard hydrogen.exists == false else {
             throw Error.failed("Exists should be false since not yet saved.")
         }
         try hydrogen.save()
         
-        guard hydrogen.id?.string == "asdf" else {
+        guard hydrogen.id?.string?.lowercased() == uuid.uuidString.lowercased() else {
             throw Error.failed("Saved ID not equal to set id.")
         }
         
@@ -44,6 +45,5 @@ extension Tester {
         guard hydrogen.weight == found.weight else {
             throw Error.failed("Weight retrieved different than what was saved.")
         }
-        
     }
 }


### PR DESCRIPTION
Postgres – unlike MySQL – actually validates the UUIDs sent as values, so the tests of postgresql-driver were silently broken by the Fluent 2.0.1 release. This commit fixes the test by using a valid UUID instead of just `"asdf"`.

I noticed that PG returns UUID fields as all lowercase, so I changed the comparison to be case insensitive. (It shouldn't be a problem as we're talking about the string representation of an otherwise fixed binary entity and the hex numbers still match.)

---

Despite what we discussed in Slack, I didn't change Atom's initializer, as it would be a breaking change. (And no one likes unexpected breaking changes to their project.)