### PR TITLE
Adds the ability to soft delete entities from a query

### DIFF
--- a/Sources/Fluent/Entity/SoftDeletable.swift
+++ b/Sources/Fluent/Entity/SoftDeletable.swift
@@ -91,6 +91,12 @@ extension QueryRepresentable where E: SoftDeletable, Self: ExecutorRepresentable
         query.includeSoftDeleted = true
         return query
     }
+
+    public func forceDelete() throws -> Query<E> {
+        let query = try makeQuery()
+        query.action = .delete
+        return query
+    }
 }
 
 // MARK: Entity

--- a/Sources/Fluent/Entity/SoftDeletable.swift
+++ b/Sources/Fluent/Entity/SoftDeletable.swift
@@ -93,7 +93,7 @@ extension QueryRepresentable where E: SoftDeletable, Self: ExecutorRepresentable
     }
 
     public func forceDelete() throws {
-        let query = try makeQuery()
+        let query = try makeQuery().withSoftDeleted()
         query.action = .delete
         try query.raw()
     }

--- a/Sources/Fluent/Entity/SoftDeletable.swift
+++ b/Sources/Fluent/Entity/SoftDeletable.swift
@@ -92,10 +92,10 @@ extension QueryRepresentable where E: SoftDeletable, Self: ExecutorRepresentable
         return query
     }
 
-    public func forceDelete() throws -> Query<E> {
+    public func forceDelete() throws {
         let query = try makeQuery()
         query.action = .delete
-        return query
+        try query.raw()
     }
 }
 

--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -173,14 +173,11 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
 extension QueryRepresentable where Self: ExecutorRepresentable {
     /// Attempts to delete all entities
     /// in the model's collection.
-    public func delete(shouldForceDelete: Bool = true) throws {
+    public func delete() throws {
         let query = try makeQuery()
         if let entity = query.entity {
-            if let softDeletbleEntity = entity as? SoftDeletable {
-                softDeletbleEntity.shouldForceDelete = shouldForceDelete
-            }
             try query.delete(entity)
-        } else if let S = E.self as? SoftDeletable.Type, shouldForceDelete == false {
+        } else if let S = E.self as? SoftDeletable.Type {
             let deletedAtKey = S.deletedAtKey
             var row = Row()
             try row.set(deletedAtKey, Date())

--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -180,8 +180,8 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
                 softDeletbleEntity.shouldForceDelete = shouldForceDelete
             }
             try query.delete(entity)
-        } else if let softDeletableEntityType = E.self as? SoftDeletable, shouldForceDelete == false {
-            let deletedAtKey = type(of: softDeletableEntityType).deletedAtKey
+        } else if let S = E.self as? SoftDeletable.Type, shouldForceDelete == false {
+            let deletedAtKey = S.deletedAtKey
             var row = Row()
             try row.set(deletedAtKey, Date())
             try query.modify(row)

--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -173,14 +173,14 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
 extension QueryRepresentable where Self: ExecutorRepresentable {
     /// Attempts to delete all entities
     /// in the model's collection.
-    public func delete(forceDeleteIfSoftDeletable: Bool = true) throws {
+    public func delete(shouldForceDelete: Bool = true) throws {
         let query = try makeQuery()
         if let entity = query.entity {
             if let softDeletbleEntity = entity as? SoftDeletable {
-                softDeletbleEntity.shouldForceDelete = forceDeleteIfSoftDeletable
+                softDeletbleEntity.shouldForceDelete = shouldForceDelete
             }
             try query.delete(entity)
-        } else if let softDeletableEntityType = E.self as? SoftDeletable, forceDeleteIfSoftDeletable == false {
+        } else if let softDeletableEntityType = E.self as? SoftDeletable, shouldForceDelete == false {
             let deletedAtKey = type(of: softDeletableEntityType).deletedAtKey
             var row = Row()
             try row.set(deletedAtKey, Date())

--- a/Sources/FluentTester/Tester+SoftDelete.swift
+++ b/Sources/FluentTester/Tester+SoftDelete.swift
@@ -59,17 +59,17 @@ extension Tester {
         try Compound.makeQuery().delete()
 
         guard try Compound.count() == 0 else {
-          throw Error.failed("Compound count did not equal 0 after delete.")
+            throw Error.failed("Compound count did not equal 0 after delete.")
         }
 
         guard try Compound.withSoftDeleted().count() == 3 else {
-          throw Error.failed("Water was not soft deleted")
+            throw Error.failed("Water was not soft deleted")
         }
 
         try Compound.makeQuery().forceDelete()
 
         guard try Compound.withSoftDeleted().count() == 0 else {
-          throw Error.failed("Water was not force deleted")
+            throw Error.failed("Water was not force deleted")
         }
     }
 }

--- a/Sources/FluentTester/Tester+SoftDelete.swift
+++ b/Sources/FluentTester/Tester+SoftDelete.swift
@@ -55,6 +55,30 @@ extension Tester {
         guard try Compound.withSoftDeleted().find(water.id) == nil else {
             throw Error.failed("Water was not forced deleted")
         }
+
+        try ethanol.save()
+
+        guard try Compound.count() == 1 else {
+          throw Error.failed("Compound count did not equal 4.")
+        }
+
+        try Compound.makeQuery().delete()
+
+        guard try Compound.count() == 0 else {
+          throw Error.failed("Compound count did not equal 0 after delete.")
+        }
+
+        guard try Compound.withSoftDeleted().count() == 1 else {
+          throw Error.failed("Water was not soft deleted")
+        }
+
+        try water.restore()
+
+        try Compound.makeQuery().forceDelete()
+
+        guard try Compound.withSoftDeleted().count() == 0 else {
+          throw Error.failed("Water was not force deleted")
+        }
     }
 }
 

--- a/Sources/FluentTester/Tester+SoftDelete.swift
+++ b/Sources/FluentTester/Tester+SoftDelete.swift
@@ -56,23 +56,15 @@ extension Tester {
             throw Error.failed("Water was not forced deleted")
         }
 
-        try ethanol.save()
-
-        guard try Compound.count() == 1 else {
-          throw Error.failed("Compound count did not equal 4.")
-        }
-
         try Compound.makeQuery().delete()
 
         guard try Compound.count() == 0 else {
           throw Error.failed("Compound count did not equal 0 after delete.")
         }
 
-        guard try Compound.withSoftDeleted().count() == 1 else {
+        guard try Compound.withSoftDeleted().count() == 3 else {
           throw Error.failed("Water was not soft deleted")
         }
-
-        try water.restore()
 
         try Compound.makeQuery().forceDelete()
 


### PR DESCRIPTION
Previously there was no way to soft delete a batch of un-fetched entities from a query.

This PR adds the ability to do so - if desired. It will default to the previous behaviour - which I think is a shame and probably unexpected. I initially assumed (maybe wrongly) that calling `delete` on a query of a `SoftDeletable` entity would behave the same as calling `delete` on each of these `SoftDeletable` entities themselves - but after looking through the sources I realised this behaviour was missing.

I'm not 100% satisfied of the `shouldForceDelete` parameter, and if anything I would be of the opinion that it should default to `false` - but that would change the existing behaviour that many people may rely on.