### PR TITLE
One can now register lifecycle callbacks once globally for all entities

### DIFF
--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -47,6 +47,27 @@ public protocol Entity: class, RowConvertible, Storable {
     /// computed with every request for this type of entity.
     static var computedFields: [RawOr<ComputedField>] { get }
 
+    /// Called before any entity will be created.
+    /// Throwing will cancel the creation.
+    static func willCreate(entity: Entity) throws
+
+    /// Called after any entity has been created.
+    static func didCreate(entity: Entity)
+
+    /// Called before any entity will be updated.
+    /// Throwing will cancel the update.
+    static func willUpdate(entity: Entity) throws
+
+    /// Called after any entity has been updated.
+    static func didUpdate(entity: Entity)
+
+    /// Called before any entity will be deleted.
+    /// Throwing will cancel the deletion.
+    static func willDelete(entity: Entity) throws
+
+    /// Called after any entity has been deleted.
+    static func didDelete(entity: Entity)
+
     /// Called before the entity will be created.
     /// Throwing will cancel the creation.
     func willCreate() throws
@@ -107,6 +128,13 @@ extension Entity {
         return []
     }
     
+    public static func willCreate(entity: Entity) {}
+    public static func didCreate(entity: Entity) {}
+    public static func willUpdate(entity: Entity) {}
+    public static func didUpdate(entity: Entity) {}
+    public static func willDelete(entity: Entity) {}
+    public static func didDelete(entity: Entity) {}
+
     public func willCreate() {}
     public func didCreate() {}
     public func willUpdate() {}

--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -107,7 +107,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
 
         if let _ = entity.id, entity.exists {
             // update
-            try type(of: entity).willUpdate(entity: entity)
+            try E.willUpdate(entity: entity)
             try entity.willUpdate()
             var row = try entity.makeDirtyRow()
             try row.set(E.idKey, entity.id)

--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -135,7 +135,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
             }
 
             try modify(row)
-            type(of: entity).didUpdate(entity: entity)
+            E.didUpdate(entity: entity)
             entity.didUpdate()
         } else {
             // create
@@ -144,7 +144,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
                 // for models without them
                 entity.id = Identifier(UUID.random())
             }
-            try type(of: entity).willCreate(entity: entity)
+            try E.willCreate(entity: entity)
             try entity.willCreate()
             var row = try entity.makeRow()
             try row.set(E.idKey, entity.id)
@@ -166,7 +166,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
                 entity.id = id
             }
 
-            type(of: entity).didCreate(entity: entity)
+            E.didCreate(entity: entity)
             entity.didCreate()
         }
         entity.exists = true
@@ -207,10 +207,10 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
             // permenantly delete the model
             query.action = .delete
             try query.filter(E.idKey, id)
-            try type(of: entity).willDelete(entity: entity)
+            try E.willDelete(entity: entity)
             try entity.willDelete()
             try query.raw()
-            type(of: entity).didDelete(entity: entity)
+            E.didDelete(entity: entity)
             entity.didDelete()
             entity.exists = false
         }

--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -107,6 +107,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
 
         if let _ = entity.id, entity.exists {
             // update
+            try type(of: entity).willUpdate(entity: entity)
             try entity.willUpdate()
             var row = try entity.makeDirtyRow()
             try row.set(E.idKey, entity.id)
@@ -134,6 +135,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
             }
 
             try modify(row)
+            type(of: entity).didUpdate(entity: entity)
             entity.didUpdate()
         } else {
             // create
@@ -142,6 +144,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
                 // for models without them
                 entity.id = Identifier(UUID.random())
             }
+            try type(of: entity).willCreate(entity: entity)
             try entity.willCreate()
             var row = try entity.makeRow()
             try row.set(E.idKey, entity.id)
@@ -163,6 +166,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
                 entity.id = id
             }
 
+            type(of: entity).didCreate(entity: entity)
             entity.didCreate()
         }
         entity.exists = true
@@ -203,8 +207,10 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
             // permenantly delete the model
             query.action = .delete
             try query.filter(E.idKey, id)
+            try type(of: entity).willDelete(entity: entity)
             try entity.willDelete()
             try query.raw()
+            type(of: entity).didDelete(entity: entity)
             entity.didDelete()
             entity.exists = false
         }


### PR DESCRIPTION
I made this, because I sometimes want to be able to perform an action whenever any of my entities updates. With this feature I can do that simply by extending the `Entity` protocol. Without this feature I would have to track down all the places where I'm constructing a new entity and then register the `didUpdate()` callback there. It's easy to forget one place and get everything messed up.

This feature is purely additive so it shouldn't affect anyone in a negative way to merge this.