### PR TITLE
Removed unnecessary print() statement

### DIFF
--- a/Sources/Fluent/Pivot/PivotProtocol.swift
+++ b/Sources/Fluent/Pivot/PivotProtocol.swift
@@ -51,7 +51,6 @@ extension PivotProtocol where Self: Entity {
         try row.set(leftIdKey, leftId)
         try row.set(rightIdKey, rightId)
 
-        print(row)
         let pivot = try self.init(row: row)
         try pivot.save()
 


### PR DESCRIPTION
This went to release version. I believe we can get rid of it?