### PR TITLE
Generate Custom Model IDs

### DIFF
--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -67,8 +67,6 @@ public protocol Entity: class, RowConvertible, Storable {
 
     /// Called after the entity has been deleted.
     func didDelete()
-    
-    func generateId(`for` custom: String) throws -> Identifier?
 }
 
 extension Entity {
@@ -115,10 +113,6 @@ extension Entity {
     public func didUpdate() {}
     public func willDelete() {}
     public func didDelete() {}
-    
-    public func generateId(`for` custom: String) throws -> Identifier? {
-        return nil
-    }
 }
 
 // MARK: CRUD

--- a/Sources/Fluent/Entity/Entity.swift
+++ b/Sources/Fluent/Entity/Entity.swift
@@ -67,6 +67,8 @@ public protocol Entity: class, RowConvertible, Storable {
 
     /// Called after the entity has been deleted.
     func didDelete()
+    
+    func generateId(`for` custom: String) throws -> Identifier?
 }
 
 extension Entity {
@@ -113,6 +115,10 @@ extension Entity {
     public func didUpdate() {}
     public func willDelete() {}
     public func didDelete() {}
+    
+    public func generateId(`for` custom: String) throws -> Identifier? {
+        return nil
+    }
 }
 
 // MARK: CRUD

--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -137,10 +137,18 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
             entity.didUpdate()
         } else {
             // create
-            if entity.id == nil, case .uuid = E.idType {
-                // automatically generates uuids
-                // for models without them
-                entity.id = Identifier(UUID.random())
+            if entity.id == nil {
+                switch E.idType {
+                case .uuid:
+                    // automatically generates uuids
+                    // for models without them
+                    entity.id = Identifier(UUID.random())
+                case .custom(let custom):
+                    // generate a custom id
+                    // for models without them
+                    entity.id = try entity.generateId(for: custom)
+                default: ()
+                }
             }
             try entity.willCreate()
             var row = try entity.makeRow()

--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -143,11 +143,11 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
                     // automatically generates uuids
                     // for models without them
                     entity.id = Identifier(UUID.random())
-                case .custom(let custom):
+                case .string(let closure), .custom(_, let closure):
                     // generate a custom id
                     // for models without them
-                    entity.id = try entity.generateId(for: custom)
-                default: ()
+                    entity.id = try closure()
+                case .int: ()
                 }
             }
             try entity.willCreate()

--- a/Sources/Fluent/SQL/GeneralSQLSerializer.swift
+++ b/Sources/Fluent/SQL/GeneralSQLSerializer.swift
@@ -436,9 +436,9 @@ open class GeneralSQLSerializer<E: Entity>: SQLSerializer {
             switch type {
             case .int:
                 typeString = "INTEGER"
-            case .uuid:
+            case .uuid, .string:
                 typeString = "STRING"
-            case .custom(let dataType):
+            case .custom(let dataType, _):
                 typeString = dataType
             }
             if primaryKey {

--- a/Sources/Fluent/SQLite/SQLiteDriver.swift
+++ b/Sources/Fluent/SQLite/SQLiteDriver.swift
@@ -83,7 +83,7 @@
                         if let id = database.lastId {
                             return Node(id)
                         }
-                    case .uuid, .custom:
+                    case .uuid, .string, .custom:
                         // sqlite annoyingly doesn't support anything
                         // besides integers for getting last ID.
                         // so we must manually pull the id from the data

--- a/Sources/Fluent/SQLite/SQLiteSerializer.swift
+++ b/Sources/Fluent/SQLite/SQLiteSerializer.swift
@@ -24,9 +24,9 @@
                 switch idType {
                 case .int:
                     string = "INTEGER"
-                case .uuid:
+                case .uuid, .string:
                     string = "TEXT"
-                case .custom(let custom):
+                case .custom(let custom, _):
                     string = custom
                 }
                 if primaryKey {

--- a/Sources/Fluent/Schema/Field.swift
+++ b/Sources/Fluent/Schema/Field.swift
@@ -98,9 +98,10 @@ extension IdentifierType: Equatable {
     public static func ==(lhs: IdentifierType, rhs: IdentifierType) -> Bool {
         switch (lhs, rhs) {
         case (.int, .int),
-             (.uuid, .uuid):
+             (.uuid, .uuid),
+             (.string, .string):
             return true
-        case (.custom(let a), .custom(let b)):
+        case (.custom(let a, _), .custom(let b, _)):
             return a == b
         default:
             return false

--- a/Sources/Fluent/Schema/IdentifierType.swift
+++ b/Sources/Fluent/Schema/IdentifierType.swift
@@ -3,5 +3,8 @@
 public enum IdentifierType {
     case int
     case uuid
-    case custom(String)
+    /// For string IDs, provide a closure to be called for new IDs
+    case string((() throws -> Identifier?))
+    /// For custom IDs, provide the type to be stored in the database and a closure to be called for new IDs
+    case custom(String, (() throws -> Identifier?))
 }


### PR DESCRIPTION
Hey Guys,

I ran into a situation where I have a model, like an invite, that I wanted to generate a custom token for. I then wanted to use that custom token as the model's ID, similar to using a UUID. I saw there is a `custom` type for `IdentifierType` but saw now way to specify a value for an ID, perhaps I missed it...

Here's a bit of what my model looks like with this new `generateId` function I added:

```swift
final class Invite: Model {
    static let idType = IdentifierType.custom("TEXT")
    ...
    func generateId(for custom: String) throws -> Identifier? {
        let token = try URandom.bytes(count: 5).hexString
        return Identifier(token)
    }
    ...
}
```

This then allows me to look up an `Invite` with all the standard resources and auto parameter magic in vapor: `:id`.

This fork is not meant to be merged in as is, I slammed this together to prove it out in my own app's unit tests, works there. If this solution looks good to others I'll refine the code and add unit tests.

Lemme know!