### PR TITLE
context fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ Packages
 .DS_Store
 *.xcodeproj
 Package.pins
+Package.resolved
 

--- a/Sources/Fluent/Query/QueryRepresentable.swift
+++ b/Sources/Fluent/Query/QueryRepresentable.swift
@@ -28,7 +28,7 @@ extension QueryRepresentable where Self: ExecutorRepresentable {
         var models: [E] = []
 
         for result in array {
-            let row = Row(node: result)
+            let row = Row(result.wrapped)
             let model = try E(row: row)
             model.id = try row.get(E.idKey)
             model.exists = true


### PR DESCRIPTION
Fixes a subtle bug in which Row objects passed to models fetched from `.all()` would not have a `RowContext`. This would cause `node.context.isRow` to return `false`, causing `RowConvertible` to be skipped for `Node.fuzzy`.