### PR TITLE
Make Filter NodeConvertible

### DIFF
--- a/Sources/Fluent/Query/Filter/NodeUtilities/Comparison+String.swift
+++ b/Sources/Fluent/Query/Filter/NodeUtilities/Comparison+String.swift
@@ -1,0 +1,42 @@
+/// Filter.Comparison <-> String
+extension Filter.Comparison {
+    public var string: String {
+        switch(self) {
+        case .equals: return "equals"
+        case .greaterThan: return "greaterThan"
+        case .lessThan: return "lessThan"
+        case .greaterThanOrEquals: return "greaterThanOrEquals"
+        case .lessThanOrEquals: return "lessThanOrEquals"
+        case .notEquals: return "notEquals"
+        case .hasSuffix: return "hasSuffix"
+        case .hasPrefix: return "hasPrefix"
+        case .contains: return "contains"
+        case .custom(let s): return "custom(\(s))"
+        }
+    }
+
+    /// Returns Filter.Comparison.custom("X") from a string "custom(X)"
+    static func customFromString(_ string: String) throws -> Filter.Comparison {
+        guard string.hasPrefix("custom(") && string.hasSuffix(")") else {
+            throw FilterSerializationError.undefinedComparison(string)
+        }
+        let start = string.index(string.startIndex, offsetBy: 7)
+        let end = string.index(string.endIndex, offsetBy: -1)
+        return .custom(string.substring(with: start..<end))
+    }
+
+    public init(_ string: String) throws {
+        switch(string) {
+        case "equals": self = .equals
+        case "greaterThan": self = .greaterThan
+        case "lessThan": self = .lessThan
+        case "greaterThanOrEquals": self = .greaterThanOrEquals
+        case "lessThanOrEquals": self = .lessThanOrEquals
+        case "notEquals": self = .notEquals
+        case "hasSuffix": self = .hasSuffix
+        case "hasPrefix": self = .hasPrefix
+        case "contains": self = .contains
+        default: self = try .customFromString(string)
+        }
+    }
+}

--- a/Sources/Fluent/Query/Filter/NodeUtilities/Filter+Node.swift
+++ b/Sources/Fluent/Query/Filter/NodeUtilities/Filter+Node.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Node
 
 /// Conforms Filter to NodeRepresentable and adds a Node Initializer
 extension Filter: NodeConvertible {
@@ -15,7 +14,11 @@ extension Filter: NodeConvertible {
     }
 
     public func makeNode(in context: Context?) throws -> Node {
-        return try self.method.makeNode(in: context)
+        var node = Node([:])
+        let entityName = String(reflecting: entity).components(separatedBy: ".Type")[0]
+        try node.set("entity", entityName)
+        try node.set("method", try self.method.makeNode(in: context))
+        return node
     }
 }
 
@@ -26,3 +29,4 @@ enum FilterSerializationError: Error {
     case undefinedRelation(String)
     case undefinedMethodType(String)
 }
+

--- a/Sources/Fluent/Query/Filter/NodeUtilities/Filter+Node.swift
+++ b/Sources/Fluent/Query/Filter/NodeUtilities/Filter+Node.swift
@@ -28,5 +28,109 @@ enum FilterSerializationError: Error {
     case undefinedScope(String)
     case undefinedRelation(String)
     case undefinedMethodType(String)
+    case other(String)
 }
+
+extension FilterSerializationError: Debuggable {
+    public var identifier: String {
+        switch self {
+        case .undefinedEntity:
+            return "undefinedEntity"
+        case .undefinedComparison:
+            return "undefinedComparison"
+        case .undefinedScope:
+            return "undefinedScope"
+        case .undefinedRelation:
+            return "undefinedRelation"
+        case .undefinedMethodType:
+            return "undefinedMethodType"
+        case .other:
+            return "other"
+        }
+    }
+
+    public var reason: String {
+        switch self {
+        case .undefinedEntity(let s):
+            return "Entity not defined: \(s)"
+        case .undefinedComparison(let s):
+            return "Comparison not defined: \(s)"
+        case .undefinedScope(let s):
+            return "Scope not defined: \(s)"
+        case .undefinedRelation(let s):
+            return "Relation not defined: \(s)"
+        case .undefinedMethodType(let s):
+            return "Method type not defined: \(s))"
+        case .other(let s):
+            return "Other: \(s)"
+        }
+    }
+
+    public var possibleCauses: [String] {
+        switch self {
+        case .undefinedEntity:
+            return [
+                "There is a mistake in the provided entity",
+                "The entity is not defined or does not inherit from Fluent.Entity"
+            ]
+        case .undefinedComparison:
+            return [
+                "There is a mistake in the provided comparison",
+                "The provided comparison is not defined"
+            ]
+        case .undefinedScope:
+            return [
+                "There is a mistake in the provided scope",
+                "The provided scope is not defined"
+            ]
+        case .undefinedRelation:
+            return [
+                "There is a mistake in the provided relation",
+                "The provided relation is not defined"
+            ]
+        case .undefinedMethodType:
+            return [
+                "There is a mistake in the provided method type",
+                "The provided method type is not defined"
+            ]
+        case .other:
+            return [
+                "Something wrong happened"
+            ]
+        }
+    }
+
+    public var suggestedFixes: [String] {
+        switch self {
+        case .undefinedEntity:
+            return [
+                "Type the entity correctly: \"ModuleName.EntityName\"",
+                "Use a defined entity that inherits from Fluent.Entity"
+            ]
+        case .undefinedComparison:
+            return [
+                "Type the comparison correctly: \"equals\", \"notEquals\", \"greaterThan\", ...",
+                "Use one of the defined comparisons: see Fluent.Filter.Comparison"
+            ]
+        case .undefinedScope:
+            return [
+                "Type the scope correctly: \"in\", \"notIn\"",
+                "Use one of the defined comparisons: \"in\", \"notIn\""
+            ]
+        case .undefinedRelation:
+            return [
+                "Type the relation correctly: \"and\", \"or\"",
+                "Use one of the defined relations: \"and\", \"or\""
+            ]
+        case .undefinedMethodType:
+            return [
+                "Type the method type correctly: \"compare\", \"subset\", \"group\"",
+                "Use one of the defined methods type: \"compare\", \"subset\", \"group\""
+            ]
+        case .other:
+            return []
+        }
+    }
+}
+
 

--- a/Sources/Fluent/Query/Filter/NodeUtilities/Filter+Node.swift
+++ b/Sources/Fluent/Query/Filter/NodeUtilities/Filter+Node.swift
@@ -1,0 +1,20 @@
+import Node
+
+/// Conforms Filter to NodeRepresentable and adds a Node Initializer
+extension Filter: NodeRepresentable {
+    public init(_ entity: Entity.Type, _ node: Node) throws {
+        self.method = try Method(entity, node)
+        self.entity = entity
+    }
+
+    public func makeNode(in context: Context?) throws -> Node {
+        return try self.method.makeNode(in: context)
+    }
+}
+
+enum FilterSerializationError: Error {
+    case undefinedComparison(String)
+    case undefinedScope(String)
+    case undefinedRelation(String)
+    case undefinedMethodType(String)
+}

--- a/Sources/Fluent/Query/Filter/NodeUtilities/Filter+Node.swift
+++ b/Sources/Fluent/Query/Filter/NodeUtilities/Filter+Node.swift
@@ -1,10 +1,17 @@
+import Foundation
 import Node
 
 /// Conforms Filter to NodeRepresentable and adds a Node Initializer
-extension Filter: NodeRepresentable {
-    public init(_ entity: Entity.Type, _ node: Node) throws {
-        self.method = try Method(entity, node)
+extension Filter: NodeConvertible {
+    public init(node: Node) throws {
+        let entityName: String = try node.get("entity")
+        let entityClass: AnyClass? = NSClassFromString(entityName)
+        guard let entity = entityClass as? Entity.Type else {
+            throw FilterSerializationError.undefinedEntity(entityName)
+        }
+
         self.entity = entity
+        self.method = try Method(node: try node.get("method"))
     }
 
     public func makeNode(in context: Context?) throws -> Node {
@@ -13,6 +20,7 @@ extension Filter: NodeRepresentable {
 }
 
 enum FilterSerializationError: Error {
+    case undefinedEntity(String)
     case undefinedComparison(String)
     case undefinedScope(String)
     case undefinedRelation(String)

--- a/Sources/Fluent/Query/Filter/NodeUtilities/Filter+Node.swift
+++ b/Sources/Fluent/Query/Filter/NodeUtilities/Filter+Node.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-/// Conforms Filter to NodeRepresentable and adds a Node Initializer
 extension Filter: NodeConvertible {
     public init(node: Node) throws {
         let entityName: String = try node.get("entity")

--- a/Sources/Fluent/Query/Filter/NodeUtilities/Method+Node.swift
+++ b/Sources/Fluent/Query/Filter/NodeUtilities/Method+Node.swift
@@ -1,5 +1,5 @@
 /// Conforms Filter.Method to NodeRepresentable and adds a Node Initializer
-extension Filter.Method: NodeRepresentable {
+extension Filter.Method: NodeConvertible {
     var string: String {
         switch self {
         case .compare(_, _, _): return "compare"
@@ -8,7 +8,7 @@ extension Filter.Method: NodeRepresentable {
         }
     }
 
-    public init(_ entity: Entity.Type, _ node: Node) throws {
+    public init(node: Node) throws {
         let type: String = try node.get("type")
 
         if(type == "compare") {
@@ -30,7 +30,7 @@ extension Filter.Method: NodeRepresentable {
         if(type == "group") {
             let relation = try Filter.Relation(try node.get("relation"))
             let filters = try (try node.get("filters") as [Node]).map {
-                RawOr<Filter>.some(try Filter(entity, $0))
+                RawOr<Filter>.some(try Filter(node: $0))
             }
 
             self = .group(relation, filters); return

--- a/Sources/Fluent/Query/Filter/NodeUtilities/Method+Node.swift
+++ b/Sources/Fluent/Query/Filter/NodeUtilities/Method+Node.swift
@@ -1,0 +1,65 @@
+/// Conforms Filter.Method to NodeRepresentable and adds a Node Initializer
+extension Filter.Method: NodeRepresentable {
+    var string: String {
+        switch self {
+        case .compare(_, _, _): return "compare"
+        case .subset(_, _, _): return "subset"
+        case .group(_, _): return "group"
+        }
+    }
+
+    public init(_ entity: Entity.Type, _ node: Node) throws {
+        let type: String = try node.get("type")
+
+        if(type == "compare") {
+            let field: String = try node.get("field")
+            let comparison = try Filter.Comparison(try node.get("comparison"))
+            let value: Node = try node.get("value")
+
+            self = .compare(field, comparison, value); return
+        }
+
+        if(type == "subset") {
+            let field: String = try node.get("field")
+            let scope = try Filter.Scope(try node.get("scope"))
+            let values: [Node] = try node.get("values")
+            print(values)
+            self = .subset(field, scope, values); return
+        }
+
+        if(type == "group") {
+            let relation = try Filter.Relation(try node.get("relation"))
+            let filters = try (try node.get("filters") as [Node]).map {
+                RawOr<Filter>.some(try Filter(entity, $0))
+            }
+
+            self = .group(relation, filters); return
+        }
+
+        throw FilterSerializationError.undefinedMethodType(type)
+    }
+
+    public func makeNode(in context: Context?) throws -> Node {
+        var node = Node([:])
+        try node.set("type", self.string)
+
+        if case .compare(let field, let comparison, let value) = self {
+            try node.set("field", field)
+            try node.set("comparison", comparison.string)
+            try node.set("value", value)
+        }
+
+        if case .subset(let field, let scope, let values) = self {
+            try node.set("field", field)
+            try node.set("scope", scope.string)
+            try node.set("values", values)
+        }
+
+        if case .group(let relation, let filters) = self {
+            try node.set("relation", relation.string)
+            try node.set("filters", filters.map { $0.wrapped })
+        }
+        
+        return node
+    }
+}

--- a/Sources/Fluent/Query/Filter/NodeUtilities/Method+Node.swift
+++ b/Sources/Fluent/Query/Filter/NodeUtilities/Method+Node.swift
@@ -1,4 +1,3 @@
-/// Conforms Filter.Method to NodeRepresentable and adds a Node Initializer
 extension Filter.Method: NodeConvertible {
     var string: String {
         switch self {

--- a/Sources/Fluent/Query/Filter/NodeUtilities/Relation+String.swift
+++ b/Sources/Fluent/Query/Filter/NodeUtilities/Relation+String.swift
@@ -1,0 +1,17 @@
+/// Filter.Relation <-> String
+extension Filter.Relation {
+    public var string: String {
+        switch(self) {
+        case .and: return "and"
+        case .or: return "or"
+        }
+    }
+
+    public init(_ string: String) throws {
+        switch(string) {
+        case Filter.Relation.and.string: self = .and
+        case Filter.Relation.or.string: self = .or
+        default: throw FilterSerializationError.undefinedRelation(string)
+        }
+    }
+}

--- a/Sources/Fluent/Query/Filter/NodeUtilities/Scope+String.swift
+++ b/Sources/Fluent/Query/Filter/NodeUtilities/Scope+String.swift
@@ -1,0 +1,17 @@
+/// Filter.Scope <-> String
+extension Filter.Scope {
+    public var string: String {
+        switch(self) {
+        case .`in`: return "in"
+        case .notIn: return "notIn"
+        }
+    }
+
+    public init(_ string: String) throws {
+        switch(string) {
+        case "in": self = .`in`
+        case "notIn": self = .notIn
+        default: throw FilterSerializationError.undefinedScope(string)
+        }
+    }
+}

--- a/Tests/FluentTests/FilterNodeConvertibleTests.swift
+++ b/Tests/FluentTests/FilterNodeConvertibleTests.swift
@@ -3,8 +3,8 @@ import Node
 import XCTest
 @testable import Fluent
 
-class NodeConvertibleTestEntity: Entity {
-    static let fullClassName = "FluentTests.NodeConvertibleTestEntity"
+class FilterNodeConvertibleTestEntity: Entity {
+    static let fullClassName = "FluentTests.FilterNodeConvertibleTestEntity"
 
     let storage = Storage()
 
@@ -31,7 +31,7 @@ class NodeConvertibleTestEntity: Entity {
     }
 }
 
-class NodeConvertibleTests: XCTestCase {
+class FilterNodeConvertibleTests: XCTestCase {
 
     static var allTests = [
         ("testCompare", testCompare),
@@ -41,7 +41,7 @@ class NodeConvertibleTests: XCTestCase {
 
     static func makeCompare() throws -> Node {
         var compare = Node([:])
-        try compare.set("entity", NodeConvertibleTestEntity.fullClassName)
+        try compare.set("entity", FilterNodeConvertibleTestEntity.fullClassName)
         var method = Node([:])
         try method.set("type", "compare")
         try method.set("field", "string0")
@@ -53,7 +53,7 @@ class NodeConvertibleTests: XCTestCase {
 
     static func makeSubset() throws -> Node {
         var subset = Node([:])
-        try subset.set("entity", NodeConvertibleTestEntity.fullClassName)
+        try subset.set("entity", FilterNodeConvertibleTestEntity.fullClassName)
         var method = Node([:])
         try method.set("type", "subset")
         try method.set("field", "string0")
@@ -65,7 +65,7 @@ class NodeConvertibleTests: XCTestCase {
 
     static func makeGroup() throws -> Node {
         var group = Node([:])
-        try group.set("entity", NodeConvertibleTestEntity.fullClassName)
+        try group.set("entity", FilterNodeConvertibleTestEntity.fullClassName)
         var method = Node([:])
         try method.set("type", "group")
         try method.set("relation", "and")
@@ -75,7 +75,7 @@ class NodeConvertibleTests: XCTestCase {
     }
 
     func testCompare() throws {
-        let _compare = try NodeConvertibleTests.makeCompare()
+        let _compare = try FilterNodeConvertibleTests.makeCompare()
         let compare = try Filter(node: _compare)
         XCTAssert(try compare.makeNode(in: nil) == _compare)
 
@@ -90,7 +90,7 @@ class NodeConvertibleTests: XCTestCase {
     }
 
     func testSubset() throws {
-        let _subset = try NodeConvertibleTests.makeSubset()
+        let _subset = try FilterNodeConvertibleTests.makeSubset()
         let subset = try Filter(node: _subset)
 
         XCTAssert(try subset.makeNode(in: nil) == _subset)
@@ -106,13 +106,13 @@ class NodeConvertibleTests: XCTestCase {
     }
 
     func testGroup() throws {
-        let _group = try NodeConvertibleTests.makeGroup()
+        let _group = try FilterNodeConvertibleTests.makeGroup()
         let group = try Filter(node: _group)
 
         XCTAssert(try group.makeNode(in: nil) == _group)
 
-        let _compare = try NodeConvertibleTests.makeCompare()
-        let _subset = try NodeConvertibleTests.makeSubset()
+        let _compare = try FilterNodeConvertibleTests.makeCompare()
+        let _subset = try FilterNodeConvertibleTests.makeSubset()
 
         switch(group.method) {
         case .group(let relation, let filters):

--- a/Tests/FluentTests/NodeConvertibleTests.swift
+++ b/Tests/FluentTests/NodeConvertibleTests.swift
@@ -1,0 +1,129 @@
+import Node
+
+import XCTest
+@testable import Fluent
+
+class NodeConvertibleTestEntity: Entity {
+    static let fullClassName = "FluentTests.NodeConvertibleTestEntity"
+
+    let storage = Storage()
+
+    var string0 = "field0"
+    var string1 = "field1"
+    var int0 = 0
+    var int1 = 1
+
+    required init(row: Row) throws {
+        string0 = try row.get("string0")
+        string1 = try row.get("string1")
+        int0 = try row.get("int0")
+        int1 = try row.get("int1")
+    }
+
+    func makeRow() throws -> Row {
+        var row = Row()
+        try row.set("id", self.id)
+        try row.set("string0", string0)
+        try row.set("string1", string1)
+        try row.set("int0", int0)
+        try row.set("int1", int1)
+        return row
+    }
+}
+
+class NodeConvertibleTests: XCTestCase {
+
+    static var allTests = [
+        ("testCompare", testCompare),
+        ("testSubset", testSubset),
+        ("testCustomFromString", testCustomFromString)
+    ]
+
+    static func makeCompare() throws -> Node {
+        var compare = Node([:])
+        try compare.set("entity", NodeConvertibleTestEntity.fullClassName)
+        var method = Node([:])
+        try method.set("type", "compare")
+        try method.set("field", "string0")
+        try method.set("comparison", "equals")
+        try method.set("value", "string0")
+        try compare.set("method", method)
+        return compare
+    }
+
+    static func makeSubset() throws -> Node {
+        var subset = Node([:])
+        try subset.set("entity", NodeConvertibleTestEntity.fullClassName)
+        var method = Node([:])
+        try method.set("type", "subset")
+        try method.set("field", "string0")
+        try method.set("scope", "in")
+        try method.set("values", ["string0", "string1"])
+        try subset.set("method", method)
+        return subset
+    }
+
+    static func makeGroup() throws -> Node {
+        var group = Node([:])
+        try group.set("entity", NodeConvertibleTestEntity.fullClassName)
+        var method = Node([:])
+        try method.set("type", "group")
+        try method.set("relation", "and")
+        try method.set("filters", [makeCompare(), makeSubset()])
+        try group.set("method", method)
+        return group
+    }
+
+    func testCompare() throws {
+        let _compare = try NodeConvertibleTests.makeCompare()
+        let compare = try Filter(node: _compare)
+        XCTAssert(try compare.makeNode(in: nil) == _compare)
+
+        switch(compare.method) {
+        case .compare(let field, let comparison, let value):
+            XCTAssert(field == "string0")
+            XCTAssert(comparison == .equals)
+            XCTAssert(value.string == "string0")
+        default:
+            XCTFail()
+        }
+    }
+
+    func testSubset() throws {
+        let _subset = try NodeConvertibleTests.makeSubset()
+        let subset = try Filter(node: _subset)
+
+        XCTAssert(try subset.makeNode(in: nil) == _subset)
+
+        switch(subset.method) {
+        case .subset(let field, let scope, let values):
+            XCTAssert(field == "string0")
+            XCTAssert(scope == .in)
+            XCTAssert(values == ["string0", "string1"])
+        default:
+            XCTFail()
+        }
+    }
+
+    func testGroup() throws {
+        let _group = try NodeConvertibleTests.makeGroup()
+        let group = try Filter(node: _group)
+
+        XCTAssert(try group.makeNode(in: nil) == _group)
+
+        let _compare = try NodeConvertibleTests.makeCompare()
+        let _subset = try NodeConvertibleTests.makeSubset()
+
+        switch(group.method) {
+        case .group(let relation, let filters):
+            XCTAssert(relation == .and)
+            XCTAssert(try filters.map { $0.wrapped! }.map { try $0.makeNode(in: nil) } == [_compare, _subset])
+        default:
+            XCTFail()
+        }
+    }
+
+    func testCustomFromString() throws {
+        XCTAssert(try Filter.Comparison.customFromString("custom(test)") == .custom("test"))
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -15,7 +15,8 @@ XCTMain([
     testCase(SQLSerializerTests.allTests),
     testCase(JoinTests.allTests),
     testCase(MemoryBenchmarkTests.allTests),
-    testCase(SQLiteTests.allTests)
+    testCase(SQLiteTests.allTests),
+    testCase(FilterNodeConvertibleTests.allTests)
 ])
 
 #endif


### PR DESCRIPTION
## Make Filter NodeConvertible
See related issue for motivation:  #295

### Example:

#### route
```swift
/// [GET] @ /users
/// Returns all users, optionally filtered by the request data.
func index(_ req: Request) throws -> ResponseRepresentable {
    if let filterString = req.query?["filter"]?.string {
        let filterJSON = try JSON(bytes: filterString.data(using: .utf8)?.makeBytes() ?? [])
        let filter = try Filter(node: Node(filterJSON))
        return try User.makeQuery().filter(filter).all().makeJSON()
    }
    
    return try User.all().makeJSON()
}
```

#### request
```json
[GET]  /users?filter={"entity":"StalkrCloud.User","method":{"type":"compare","comparison":"equals", "field":"username","value":"admin"}}
```

#### response
```json
[
  {
    "id": 1,
    "username": "admin",
    "password": "123456"
  }
]
```

### TODO:
#### 1. Tests:
I've made some tests [here](https://github.com/cardoso/fluent-extended/blob/master/Tests/FluentExtendedTests/Query/Filter/Filter%2BNode.swift), but i chose not to include them yet. Do you guys have any specific guidelines for tests?

cheers ❤️👍
