### PR TITLE
Make Blob usable by adding public accessors

### DIFF
--- a/Sources/Fluent/Schema/Blob.swift
+++ b/Sources/Fluent/Schema/Blob.swift
@@ -1,6 +1,10 @@
 /// Box struct, use this type for blob columns in Models
 public struct Blob {
-    var bytes: [UInt8]
+    public var bytes: [UInt8]
+
+    public init(bytes: [UInt8]) {
+        self.bytes = bytes
+    }
 }
 
 extension Blob: NodeRepresentable {


### PR DESCRIPTION
I forgot to add public keywords to make Blob usable outside of the module.