### PR TITLE
 add condition on ForeignKey name length (64 characters)

### DIFF
--- a/Sources/Fluent/Schema/ForeignKey.swift
+++ b/Sources/Fluent/Schema/ForeignKey.swift
@@ -36,7 +36,10 @@ public struct ForeignKey {
 		let e2 = String("\(foreignEntity.entity)".characters.prefix(12))
 		let f1 = String("\(field)".characters.prefix(12))
 		let f2 = String("\(foreignField)".characters.prefix(12))
-		self.name = name ?? "\(e1).\(f1)-\(e2).\(f2)"
+	
+		let timestamp = String(describing: ²Date().timeIntervalSince1970).suffix(12)
+
+		self.name = name ?? "\(timestamp)_\(e1).\(f1)-\(e2).\(f2)"
 	}
     }
 }

--- a/Sources/Fluent/Schema/ForeignKey.swift
+++ b/Sources/Fluent/Schema/ForeignKey.swift
@@ -37,7 +37,7 @@ public struct ForeignKey {
 		let f1 = String("\(field)".characters.prefix(12))
 		let f2 = String("\(foreignField)".characters.prefix(12))
 	
-		let timestamp = String(describing: ²Date().timeIntervalSince1970).suffix(12)
+		let timestamp = String(describing: Date().timeIntervalSince1970).suffix(12)
 
 		self.name = name ?? "\(timestamp)_\(e1).\(f1)-\(e2).\(f2)"
 	}

--- a/Sources/Fluent/Schema/ForeignKey.swift
+++ b/Sources/Fluent/Schema/ForeignKey.swift
@@ -24,19 +24,19 @@ public struct ForeignKey {
         self.field = field
         self.foreignField = foreignField
         self.foreignEntity = foreignEntity
-if  "_fluent_fk_\(entity.entity).\(field)-\(foreignEntity.entity).\(foreignField)".characters.count < 64{
-			self.name = name ?? "_fluent_fk_\(entity.entity).\(field)-\(foreignEntity.entity).\(foreignField)"
-		}else{
+        if  "_fluent_fk_\(entity.entity).\(field)-\(foreignEntity.entity).\(foreignField)".characters.count < 64{
+		self.name = name ?? "_fluent_fk_\(entity.entity).\(field)-\(foreignEntity.entity).\(foreignField)"
+	}else{
 			
-			/// we have "_fluent_fk_" + "." + "_" + "." = 14 characters
-			/// so the reset must be less then 50 characters long
-			/// 50 characters divided by 4 variables is 12 characters per variable
-			
-			let e1 = String("\(entity.entity)".characters.prefix(12))
-			let e2 = String("\(foreignEntity.entity)".characters.prefix(12))
-			let f1 = String("\(field)".characters.prefix(12))
-			let f2 = String("\(foreignField)".characters.prefix(12))
-			self.name = name ?? "\(e1).\(f1)-\(e2).\(f2)"
-		}
+		/// we have "_fluent_fk_" + "." + "_" + "." = 14 characters
+		/// so the reset must be less then 50 characters long
+		/// 50 characters divided by 4 variables is 12 characters per variable
+
+		let e1 = String("\(entity.entity)".characters.prefix(12))
+		let e2 = String("\(foreignEntity.entity)".characters.prefix(12))
+		let f1 = String("\(field)".characters.prefix(12))
+		let f2 = String("\(foreignField)".characters.prefix(12))
+		self.name = name ?? "\(e1).\(f1)-\(e2).\(f2)"
+	}
     }
 }

--- a/Sources/Fluent/Schema/ForeignKey.swift
+++ b/Sources/Fluent/Schema/ForeignKey.swift
@@ -24,6 +24,19 @@ public struct ForeignKey {
         self.field = field
         self.foreignField = foreignField
         self.foreignEntity = foreignEntity
-        self.name = name ?? "_fluent_fk_\(entity.entity).\(field)-\(foreignEntity.entity).\(foreignField)"
+if  "_fluent_fk_\(entity.entity).\(field)-\(foreignEntity.entity).\(foreignField)".characters.count < 64{
+			self.name = name ?? "_fluent_fk_\(entity.entity).\(field)-\(foreignEntity.entity).\(foreignField)"
+		}else{
+			
+			/// we have "_fluent_fk_" + "." + "_" + "." = 14 characters
+			/// so the reset must be less then 50 characters long
+			/// 50 characters divided by 4 variables is 12 characters per variable
+			
+			let e1 = String("\(entity.entity)".characters.prefix(12))
+			let e2 = String("\(foreignEntity.entity)".characters.prefix(12))
+			let f1 = String("\(field)".characters.prefix(12))
+			let f2 = String("\(foreignField)".characters.prefix(12))
+			self.name = name ?? "\(e1).\(f1)-\(e2).\(f2)"
+		}
     }
 }


### PR DESCRIPTION

add condition on ForeignKey name length (64 characters)  …
if ForeignKey name is longer then 64 characters, mysql throws an error of :
fatal error: Error raised at top level: MySQL Error: Identifier name 'FK_name' is too long
Identifier: MySQL.MySQLError.1059 (tooLongIdent)

so I added a condition on if ForeignKey name is longer I will cut it up

