### PR TITLE
Fluent 3 - Fix saving a new SoftDeletable Model.

### DIFF
--- a/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
@@ -19,6 +19,10 @@ extension QueryBuilder {
     public func create(_ model: Model) -> Future<Void> {
         query.data = model
         query.action = .create
+
+        // This feels very hacky.
+        query.withSoftDeleted = true
+
         return connection.flatMap(to: Void.self) { conn in
             if model.fluentID == nil {
                 // generate an id


### PR DESCRIPTION
It was adding ```WHERE ((`users`.`deletedAt` > ? OR `users`.`deletedAt` = ?))``` at the end of the `INSERT` statement.

Although, this solution feels very hacky. I would like to get it reviewed or improved somehow.
Maybe we should consider having a `query.ignoreSoftDeleted`.