### PR TITLE
Commenting out ambiguous operators

### DIFF
--- a/Sources/Fluent/Query/Filter/Comparison.swift
+++ b/Sources/Fluent/Query/Filter/Comparison.swift
@@ -16,13 +16,14 @@ extension Encodable {
 /// MARK: .equals
 
 /// Model.field == value
-public func == <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
-    where Model: Fluent.Model, Value: Encodable & Equatable
-{
-    return try ModelFilterMethod<Model>(
-        method: .compare(lhs.makeQueryField(), .equality(.equals), .value(rhs))
-    )
-}
+/// FIXME: conditional conformance
+//public func == <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
+//    where Model: Fluent.Model, Value: Encodable & Equatable
+//{
+//    return try ModelFilterMethod<Model>(
+//        method: .compare(lhs.makeQueryField(), .equality(.equals), .value(rhs))
+//    )
+//}
 
 /// field == value
 public func == <
@@ -43,13 +44,14 @@ public func == <
 /// MARK: .notEquals
 
 /// Model.field != value
-public func != <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
-    where Model: Fluent.Model, Value: Encodable & Equatable
-{
-    return try ModelFilterMethod<Model>(
-        method: .compare(lhs.makeQueryField(), .equality(.notEquals), .value(rhs))
-    )
-}
+/// FIXME: conditional conformance
+//public func != <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
+//    where Model: Fluent.Model, Value: Encodable & Equatable
+//{
+//    return try ModelFilterMethod<Model>(
+//        method: .compare(lhs.makeQueryField(), .equality(.notEquals), .value(rhs))
+//    )
+//}
 
 /// field != value
 public func != <
@@ -103,13 +105,14 @@ public enum OrderedComparison {
 /// .greaterThan
 
 /// Model.field > value
-public func > <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
-    where Model: Fluent.Model, Value: Encodable & Equatable
-{
-    return try ModelFilterMethod<Model>(
-        method: .compare(lhs.makeQueryField(), .order(.greaterThan), .value(rhs))
-    )
-}
+/// FIXME: conditional conformance
+//public func > <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
+//    where Model: Fluent.Model, Value: Encodable & Equatable
+//{
+//    return try ModelFilterMethod<Model>(
+//        method: .compare(lhs.makeQueryField(), .order(.greaterThan), .value(rhs))
+//    )
+//}
 
 /// field > value
 public func > <
@@ -130,13 +133,14 @@ public func > <
 /// .lessThan
 
 /// Model.field > value
-public func < <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
-    where Model: Fluent.Model, Value: Encodable & Equatable
-{
-    return try ModelFilterMethod<Model>(
-        method: .compare(lhs.makeQueryField(), .order(.lessThan), .value(rhs))
-    )
-}
+/// FIXME: conditional conformance
+//public func < <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
+//    where Model: Fluent.Model, Value: Encodable & Equatable
+//{
+//    return try ModelFilterMethod<Model>(
+//        method: .compare(lhs.makeQueryField(), .order(.lessThan), .value(rhs))
+//    )
+//}
 
 /// field < value
 public func < <
@@ -157,13 +161,14 @@ public func < <
 /// .greaterThanOrEquals
 
 /// Model.field >= value
-public func >= <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
-    where Model: Fluent.Model, Value: Encodable & Equatable
-{
-    return try ModelFilterMethod<Model>(
-        method: .compare(lhs.makeQueryField(), .order(.greaterThanOrEquals), .value(rhs))
-    )
-}
+/// FIXME: conditional conformance
+//public func >= <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
+//    where Model: Fluent.Model, Value: Encodable & Equatable
+//{
+//    return try ModelFilterMethod<Model>(
+//        method: .compare(lhs.makeQueryField(), .order(.greaterThanOrEquals), .value(rhs))
+//    )
+//}
 
 /// field >= value
 public func >= <
@@ -184,13 +189,14 @@ public func >= <
 /// .lessThanOrEquals
 
 /// Model.field <= value
-public func <= <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
-    where Model: Fluent.Model, Value: Encodable & Equatable
-{
-    return try ModelFilterMethod<Model>(
-        method: .compare(lhs.makeQueryField(), .order(.lessThanOrEquals), .value(rhs))
-    )
-}
+/// FIXME: conditional conformance
+//public func <= <Model, Value>(lhs: ReferenceWritableKeyPath<Model, Value>, rhs: Value) throws -> ModelFilterMethod<Model>
+//    where Model: Fluent.Model, Value: Encodable & Equatable
+//{
+//    return try ModelFilterMethod<Model>(
+//        method: .compare(lhs.makeQueryField(), .order(.lessThanOrEquals), .value(rhs))
+//    )
+//}
 
 /// field <= value
 public func <= <

--- a/Tests/FluentTests/OperatorAmbiguityTests.swift
+++ b/Tests/FluentTests/OperatorAmbiguityTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Async
+import Fluent
+import FluentSQLite
+import SQLite
+import XCTest
+
+final class OperatorAmbiguityTests: XCTestCase {
+    let worker = DispatchEventLoop(label: "database-sqlite")
+    let database = SQLiteDatabase(storage: .memory)
+
+    func testQuery() throws {
+        do {
+            let connection = try database.makeConnection(on: worker).blockingAwait()
+            try TestModel.prepare(on: connection).blockingAwait()
+
+            let model = TestModel(testDate: Date() - 1000)
+            try model.save(on: connection).blockingAwait()
+
+            let fetchedModel: TestModel? = try TestModel.query(on: connection)
+                .filter(\TestModel.testDate < Date())
+                .first()
+                .blockingAwait()
+
+            guard let sameModel = fetchedModel else {
+                XCTFail("Unable to fetch a TestModel. Expected to get 1 entity, got none.")
+                return
+            }
+
+            XCTAssert(model.id == sameModel.id)
+            XCTAssert(model.testDate == sameModel.testDate)
+        } catch {
+            XCTFail("Unable to test TestModel's query. Error: \(error)")
+        }
+    }
+}
+
+fileprivate final class TestModel: Model, Migration {
+    typealias Database = SQLiteDatabase
+    typealias ID = UUID
+
+    static let idKey = \TestModel.id
+
+    var id: TestModel.ID?
+    var testDate: Date
+
+    init(testDate: Date) {
+        self.testDate = testDate
+    }
+
+    static func prepare(on connection: SQLiteDatabase.Connection) -> Future<Void> {
+        return connection.create(self) { builder in
+            try builder.field(for: \.id)
+            try builder.field(for: \.testDate)
+        }
+    }
+
+    static func revert(on connection: SQLiteDatabase.Connection) -> Future<Void> {
+        return connection.delete(self)
+    }
+}


### PR DESCRIPTION
Commenting out ambiguous operators adding FIXME to enable them back once Conditional Conformance ships into Swift.
Added a test case to check if it's working as expected.