### PR TITLE
Remove occurrences of requesting .max

### DIFF
--- a/Sources/Fluent/Query/Builder/QueryBuilder+Execute.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder+Execute.swift
@@ -17,6 +17,7 @@ extension QueryBuilder {
         // drain the stream of results
         let drain = stream.drain { row, upstream in
             rows.append(row)
+            upstream.request()
         }.catch { error in
             promise.fail(error)
         }.finally {
@@ -24,7 +25,7 @@ extension QueryBuilder {
         }
 
         stream.execute()
-        drain.upstream?.request(count: .max)
+        drain.upstream?.request()
 
         return promise.future
     }
@@ -47,8 +48,9 @@ extension QueryBuilder {
 
         let stream = run()
 
-        let drain = stream.drain { model, upstream in
+        let drain = stream.drain { _, upstream in
             // ignore output
+            upstream.request()
         }.catch { err in
             promise.fail(err)
         }.finally {
@@ -56,7 +58,7 @@ extension QueryBuilder {
         }
 
         stream.execute()
-        drain.upstream?.request(count: .max)
+        drain.upstream?.request()
 
         return promise.future
     }
@@ -95,6 +97,7 @@ extension QueryBuilder {
                 try closure(partial)
                 partial = []
             }
+            upstream.request()
         }.catch { error in
             promise.fail(error)
         }.finally {
@@ -109,7 +112,7 @@ extension QueryBuilder {
         }
 
         stream.execute()
-        drain.upstream?.request(count: .max)
+        drain.upstream?.request()
 
         return promise.future
     }

--- a/Sources/Fluent/Query/QueryAggregate.swift
+++ b/Sources/Fluent/Query/QueryAggregate.swift
@@ -71,6 +71,7 @@ extension QueryBuilder {
 
         let drain = stream.drain { res, upstream in
             result = res.fluentAggregate
+            upstream.request()
         }.catch { err in
             promise.fail(err)
         }.finally {
@@ -82,7 +83,7 @@ extension QueryBuilder {
         }
 
         stream.execute()
-        drain.upstream?.request(count: .max)
+        drain.upstream?.request()
 
         return promise.future
     }

--- a/Sources/SQLite/Query/SQLiteResultStream.swift
+++ b/Sources/SQLite/Query/SQLiteResultStream.swift
@@ -69,13 +69,14 @@ extension OutputStream {
         // drain the stream of results
         let drain = self.drain { row, upstream in
             rows.append(row)
+            upstream.request()
         }.catch { error in
             promise.fail(error)
         }.finally {
             promise.complete(rows)
         }
 
-        drain.upstream!.request(count: .max)
+        drain.upstream?.request()
 
         return promise.future
     }


### PR DESCRIPTION
Some drivers (specifically MySQL) don't work with .max because the internal state is kept after execution rather than from the point of starting the query.

In addition, this .max model goes against reactiveness