### PR TITLE
fluent cache

### DIFF
--- a/Sources/Fluent/Cache/FluentCache.swift
+++ b/Sources/Fluent/Cache/FluentCache.swift
@@ -1,0 +1,58 @@
+import Async
+import Foundation
+
+public final class FluentCache<Database>: KeyedCache
+    where Database: QuerySupporting
+{
+    private let pool: DatabaseConnectionPool<Database>
+
+    public init(pool: DatabaseConnectionPool<Database>) {
+        self.pool = pool
+    }
+
+    public func get<D>(_ type: D.Type, forKey key: String) throws -> Future<D?> where D : Decodable {
+        return pool.requestConnection().flatMap(to: D?.self) { conn in
+            return FluentCacheEntry<Database>.find(key, on: conn).map(to: D?.self) { found in
+                guard let entry = found else {
+                    return nil
+                }
+                self.pool.releaseConnection(conn)
+                return try JSONDecoder().decode(D.self, from: entry.data)
+            }
+        }
+    }
+
+    public func set<E>(_ entity: E, forKey key: String) throws -> Future<Void> where E : Encodable {
+        return pool.requestConnection().flatMap(to: Void.self) { conn in
+            let data = try JSONEncoder().encode(entity)
+            return FluentCacheEntry<Database>(key: key, data: data).save(on: conn).map(to: Void.self) { entry in
+                self.pool.releaseConnection(conn)
+            }
+        }
+    }
+
+    public func remove(_ key: String) throws -> Future<Void> {
+        return pool.requestConnection().flatMap(to: Void.self) { conn in
+            return FluentCacheEntry<Database>.query(on: conn).filter(\.key == key).delete().map(to: Void.self) {
+                self.pool.releaseConnection(conn)
+            }
+        }
+    }
+
+
+}
+
+
+public final class FluentCacheEntry<D>: Model
+    where D: QuerySupporting
+{
+    public static var idKey: IDKey { return \.key }
+    public typealias ID = String
+    public typealias Database = D
+    public var key: ID?
+    public var data: Data
+    public init(key: String, data: Data) {
+        self.key = key
+        self.data = data
+    }
+}

--- a/Sources/Fluent/Cache/FluentCache.swift
+++ b/Sources/Fluent/Cache/FluentCache.swift
@@ -1,9 +1,10 @@
 import Async
 import Foundation
+import Service
 
 /// A Fluent-based keyed cache implementation.
 /// Requires a database prepared for querying `FluentCacheEntry` models.
-public final class FluentCache<Database>: KeyedCache
+public final class FluentCache<Database>: KeyedCache, Service
     where Database: QuerySupporting
 {
     /// Used to request a connection for each get/set/remove

--- a/Sources/Fluent/Cache/FluentCache.swift
+++ b/Sources/Fluent/Cache/FluentCache.swift
@@ -31,7 +31,7 @@ public final class FluentCache<Database>: KeyedCache
     public func set<E>(_ entity: E, forKey key: String) throws -> Future<Void> where E : Encodable {
         return pool.requestConnection().flatMap(to: Void.self) { conn in
             let data = try JSONEncoder().encode(entity)
-            return FluentCacheEntry<Database>(key: key, data: data).save(on: conn).map(to: Void.self) { entry in
+            return FluentCacheEntry<Database>(key: key, data: data).create(on: conn).map(to: Void.self) { entry in
                 self.pool.releaseConnection(conn)
             }
         }

--- a/Sources/Fluent/Cache/FluentCache.swift
+++ b/Sources/Fluent/Cache/FluentCache.swift
@@ -1,15 +1,20 @@
 import Async
 import Foundation
 
+/// A Fluent-based keyed cache implementation.
+/// Requires a database prepared for querying `FluentCacheEntry` models.
 public final class FluentCache<Database>: KeyedCache
     where Database: QuerySupporting
 {
+    /// Used to request a connection for each get/set/remove
     private let pool: DatabaseConnectionPool<Database>
 
+    /// Creates a new `FluentCache` with the supplied connection pool.
     public init(pool: DatabaseConnectionPool<Database>) {
         self.pool = pool
     }
 
+    /// See `KeyedCache.get(_:forKey:)`
     public func get<D>(_ type: D.Type, forKey key: String) throws -> Future<D?> where D : Decodable {
         return pool.requestConnection().flatMap(to: D?.self) { conn in
             return FluentCacheEntry<Database>.find(key, on: conn).map(to: D?.self) { found in
@@ -22,6 +27,7 @@ public final class FluentCache<Database>: KeyedCache
         }
     }
 
+    /// See `KeyedCache.set(_:forKey:)`
     public func set<E>(_ entity: E, forKey key: String) throws -> Future<Void> where E : Encodable {
         return pool.requestConnection().flatMap(to: Void.self) { conn in
             let data = try JSONEncoder().encode(entity)
@@ -31,28 +37,12 @@ public final class FluentCache<Database>: KeyedCache
         }
     }
 
+    /// See `KeyedCache.remove(key:)`
     public func remove(_ key: String) throws -> Future<Void> {
         return pool.requestConnection().flatMap(to: Void.self) { conn in
             return FluentCacheEntry<Database>.query(on: conn).filter(\.key == key).delete().map(to: Void.self) {
                 self.pool.releaseConnection(conn)
             }
         }
-    }
-
-
-}
-
-
-public final class FluentCacheEntry<D>: Model
-    where D: QuerySupporting
-{
-    public static var idKey: IDKey { return \.key }
-    public typealias ID = String
-    public typealias Database = D
-    public var key: ID?
-    public var data: Data
-    public init(key: String, data: Data) {
-        self.key = key
-        self.data = data
     }
 }

--- a/Sources/Fluent/Cache/FluentCacheEntry.swift
+++ b/Sources/Fluent/Cache/FluentCacheEntry.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Internal Fluent model powering `FluentCache`.
+internal final class FluentCacheEntry<D>: Model
+    where D: QuerySupporting
+{
+    /// See `Model.name`
+    internal static var name: String { return "fluentcache" }
+
+    /// See `Model.idKey`
+    internal static var idKey: IDKey { return \.key }
+
+    /// See `Model.ID`
+    internal typealias ID = String
+
+    /// See `Model.Database`
+    internal typealias Database = D
+
+    /// The cache entry's unique key.
+    internal var key: ID?
+
+    /// The cache entry's JSON encoded data.
+    internal var data: Data
+
+    /// Creates a new `CacheEntry`
+    internal init(key: String, data: Data) {
+        self.key = key
+        self.data = data
+    }
+}

--- a/Sources/Fluent/Cache/FluentCacheMigration.swift
+++ b/Sources/Fluent/Cache/FluentCacheMigration.swift
@@ -19,3 +19,13 @@ public final class FluentCacheMigration<D>: Migration where D: QuerySupporting, 
         return Database.delete(FluentCacheEntry<D>.self, on: connection)
     }
 }
+
+
+extension MigrationConfig {
+    /// Prepares the supplied `SchemaSupporting` database for `FluentCache` use.
+    public mutating func prepareCache<D>(for database: DatabaseIdentifier<D>)
+        where D: QuerySupporting, D: SchemaSupporting
+    {
+        self.add(migration: FluentCacheMigration<D>.self, database: database)
+    }
+}

--- a/Sources/Fluent/Cache/FluentCacheMigration.swift
+++ b/Sources/Fluent/Cache/FluentCacheMigration.swift
@@ -1,0 +1,21 @@
+import Async
+
+/// Prepares a `SchemaSupporting` database for use with `FluentCache`.
+public final class FluentCacheMigration<D>: Migration where D: QuerySupporting, D: SchemaSupporting {
+    /// See `Migration.Database`
+    public typealias Database = D
+
+    /// See `Migration.prepare(on:)`
+    public static func prepare(on connection: D.Connection) -> Future<Void> {
+        return Database.create(FluentCacheEntry<D>.self, on: connection) { builder in
+            try builder.field(for: \.key)
+            try builder.field(for: \.data)
+        }
+    }
+
+
+    /// See `Migration.revert(on:)`
+    public static func revert(on connection: D.Connection) -> Future<Void> {
+        return Database.delete(FluentCacheEntry<D>.self, on: connection)
+    }
+}

--- a/Sources/Fluent/Model/SoftDeletable.swift
+++ b/Sources/Fluent/Model/SoftDeletable.swift
@@ -54,17 +54,22 @@ extension QueryBuilder where Model: SoftDeletable {
     }
 }
 
-// MARK: Hack
-
-/// Unfortunately we need this hack.
+/// Unfortunately we need this hack until we have existentials.
 /// note: do not rely on this exterally.
 public protocol AnySoftDeletable: AnyModel {
-    /// Pointer to type erased key path
-    static var anyDeletedAtKey: AnyKeyPath { get }
+    /// Pointer to type erased key string
+    static var deletedAtField: QueryField { get }
+
+    /// Access the deleted at property.
+    var fluentDeletedAt: Date? { get set }
 }
 
 extension SoftDeletable {
-    public static var anyDeletedAtKey: AnyKeyPath {
-        return deletedAtKey
+    /// See `AnySoftDeletable.deletedAtField`
+    public static var deletedAtField: QueryField {
+        return QueryField(
+            entity: entity,
+            name: Self.codingPath(forKey: deletedAtKey)[0].stringValue
+        )
     }
 }

--- a/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
@@ -80,12 +80,8 @@ extension QueryBuilder {
     /// Deletes the supplied model.
     /// Throws an error if the mdoel did not have an id.
     internal func delete(_ model: Model) -> Future<Void> {
-        if let type = Model.self as? AnySoftDeletable.Type
-        {
-            /// model is soft deletable
-            let path = type.anyDeletedAtKey
-                as! ReferenceWritableKeyPath<Model, Date?>
-            model[keyPath: path] = Date()
+        if let softDeletable = model as? AnySoftDeletable {
+            softDeletable.fluentDeletedAt = Date()
             return update(model)
         } else {
             return _delete(model)

--- a/Sources/Fluent/Query/Builder/QueryBuilder.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder.swift
@@ -28,19 +28,16 @@ public final class QueryBuilder<Model> where Model: Fluent.Model, Model.Database
             let type = Model.self as? AnySoftDeletable.Type,
             !self.query.withSoftDeleted
         {
-            let deletedAtKey = D.unsafeCodingPath(forKey: type.anyDeletedAtKey)
-            let deletedAtField = QueryField(entity: type.entity, name: deletedAtKey[0].stringValue)
-
             try! self.group(.or) { or in
                 let notDeleted = QueryFilter<Model.Database>(
                     entity: type.entity,
-                    method: .compare(deletedAtField, .equality(.equals), .value(Date.null))
+                    method: .compare(type.deletedAtField, .equality(.equals), .value(Date.null))
                 )
                 or.addFilter(notDeleted)
 
                 let notYetDeleted = QueryFilter<Model.Database>(
                     entity: type.entity,
-                    method: .compare(deletedAtField, .order(.greaterThan), .value(Date()))
+                    method: .compare(type.deletedAtField, .order(.greaterThan), .value(Date()))
                 )
                 or.addFilter(notYetDeleted)
             }

--- a/Sources/Fluent/Query/QueryField.swift
+++ b/Sources/Fluent/Query/QueryField.swift
@@ -20,7 +20,7 @@ public struct QueryField {
 extension KeyPath where Root: Model {
     /// See QueryFieldRepresentable.makeQueryField()
     public func makeQueryField() -> QueryField {
-        let key = Root.unsafeCodingPath(forKey: self)
+        let key = Root.codingPath(forKey: self)
         return QueryField(entity: Root.entity, name: key[0].stringValue)
     }
 }

--- a/Sources/FluentBenchmark/BenchmarkCache.swift
+++ b/Sources/FluentBenchmark/BenchmarkCache.swift
@@ -1,0 +1,62 @@
+import Async
+import Dispatch
+import Fluent
+import Foundation
+
+extension Benchmarker where Database: QuerySupporting & TransactionSupporting {
+    /// The actual benchmark.
+    fileprivate func _benchmark(on conn: Database.Connection) throws {
+        let cache = FluentCache<Database>(pool: pool)
+
+        // get empty
+        let first = try test(cache.get(FooCache.self, forKey: "hello"))
+        if first != nil {
+            fail("cache was not empty")
+        }
+
+        // save
+        let example = FooCache(bar: "swift rulez", baz: 42)
+        try test(cache.set(example, forKey: "hello"))
+
+        // fetch saved
+        let fetched = try test(cache.get(FooCache.self, forKey: "hello"))
+        if let foo = fetched {
+            if foo.bar != "swift rulez" { fail("invalid bar") }
+            if foo.baz != 42 { fail("invalid baz") }
+        } else {
+            fail("fetched was nil")
+        }
+
+        // delete
+        try test(cache.remove("hello"))
+
+        let failed = try test(cache.get(FooCache.self, forKey: "hello"))
+        if failed != nil {
+            fail("delete failed")
+        }
+    }
+
+    /// Benchmark fluent transactions.
+    public func benchmarkCache() throws {
+        let conn = try test(pool.requestConnection())
+        try self._benchmark(on: conn)
+        pool.releaseConnection(conn)
+    }
+}
+
+struct FooCache: Codable {
+    var bar: String
+    var baz: Int
+}
+
+extension Benchmarker where Database: QuerySupporting & TransactionSupporting & SchemaSupporting {
+    /// Benchmark fluent transactions.
+    /// The schema will be prepared first.
+    public func benchmarkCache_withSchema() throws {
+        let conn = try test(pool.requestConnection())
+        try test(FluentCacheMigration<Database>.prepare(on: conn))
+        try self._benchmark(on: conn)
+        try test(FluentCacheMigration<Database>.revert(on: conn))
+        pool.releaseConnection(conn)
+    }
+}

--- a/Sources/FluentSQLite/SQLiteDatabase+Query.swift
+++ b/Sources/FluentSQLite/SQLiteDatabase+Query.swift
@@ -92,7 +92,6 @@ extension SQLiteDatabase: QuerySupporting {
     }
 }
 
-
 extension SQLiteDataEncoder {
     /// Converts a SQL bind value into SQLite data.
     /// This method applies wildcards if necessary.

--- a/Sources/FluentSQLite/SQLiteProvider.swift
+++ b/Sources/FluentSQLite/SQLiteProvider.swift
@@ -22,6 +22,10 @@ public final class FluentSQLiteProvider: Provider {
             let storage = try container.make(SQLiteStorage.self, for: FluentSQLiteProvider.self)
             return try SQLiteDatabase(storage: storage)
         }
+        services.register(KeyedCache.self) { container -> FluentCache<SQLiteDatabase> in
+            let pool = try container.connectionPool(to: .sqlite)
+            return .init(pool: pool)
+        }
     }
 
     /// See Provider.boot

--- a/Sources/FluentSQLite/SQLiteProvider.swift
+++ b/Sources/FluentSQLite/SQLiteProvider.swift
@@ -22,7 +22,7 @@ public final class FluentSQLiteProvider: Provider {
             let storage = try container.make(SQLiteStorage.self, for: FluentSQLiteProvider.self)
             return try SQLiteDatabase(storage: storage)
         }
-        services.register(KeyedCache.self) { container -> FluentCache<SQLiteDatabase> in
+        services.register(KeyedCache.self) { container -> SQLiteCache in
             let pool = try container.connectionPool(to: .sqlite)
             return .init(pool: pool)
         }
@@ -31,3 +31,5 @@ public final class FluentSQLiteProvider: Provider {
     /// See Provider.boot
     public func boot(_ container: Container) throws {}
 }
+
+public typealias SQLiteCache = FluentCache<SQLiteDatabase>

--- a/Sources/SQLite/Data/SQLiteData.swift
+++ b/Sources/SQLite/Data/SQLiteData.swift
@@ -78,3 +78,22 @@ extension SQLiteData: CustomStringConvertible {
         }
     }
 }
+
+public protocol SQLiteDataConvertible {
+    static func convertFromSQLiteData(_ data: SQLiteData) throws -> Self
+    func convertToSQLiteData() throws -> SQLiteData
+}
+
+
+extension Data: SQLiteDataConvertible {
+    public static func convertFromSQLiteData(_ data: SQLiteData) throws -> Data {
+        switch data {
+        case .blob(let data): return data
+        default: throw SQLiteError(problem: .warning, reason: "Could not convert to Data: \(data)")
+        }
+    }
+
+    public func convertToSQLiteData() throws -> SQLiteData {
+        return .blob(self)
+    }
+}

--- a/Sources/SQLite/Row/DecodingContainer.swift
+++ b/Sources/SQLite/Row/DecodingContainer.swift
@@ -115,8 +115,12 @@ internal final class DecodingContainer<K: CodingKey>:
             fatalError("no data at key")
         }
 
-        let d = SQLiteDataDecoder(data: data)
-        return try T(from: d)
+        if let convertible = T.self as? SQLiteDataConvertible.Type {
+            return try convertible.convertFromSQLiteData(data) as! T
+        } else {
+            let d = SQLiteDataDecoder(data: data)
+            return try T(from: d)
+        }
     }
 
     func nestedContainer<NestedKey: CodingKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> {

--- a/Sources/SQLite/Row/EncodingContainer.swift
+++ b/Sources/SQLite/Row/EncodingContainer.swift
@@ -31,9 +31,13 @@ internal final class RowEncodingContainer<K: CodingKey>: KeyedEncodingContainerP
     }
 
     func encode<T: Encodable>(_ value: T, forKey key: K) throws {
-        let d = SQLiteDataEncoder()
-        try value.encode(to: d)
-        encoder.row[key.stringValue] = d.data
+        if let convertible = value as? SQLiteDataConvertible {
+            encoder.row[key.stringValue] = try convertible.convertToSQLiteData()
+        } else {
+            let d = SQLiteDataEncoder()
+            try value.encode(to: d)
+            encoder.row[key.stringValue] = d.data
+        }
     }
 
     func encodeNil(forKey key: K) throws {

--- a/Tests/FluentTests/SQLiteBenchmarkTests.swift
+++ b/Tests/FluentTests/SQLiteBenchmarkTests.swift
@@ -44,6 +44,10 @@ final class SQLiteBenchmarkTests: XCTestCase {
         try benchmarker.benchmarkAutoincrement_withSchema()
     }
 
+    func testCache() throws {
+        try benchmarker.benchmarkCache_withSchema()
+    }
+
     static let allTests = [
         ("testSchema", testSchema),
         ("testModels", testModels),
@@ -52,5 +56,6 @@ final class SQLiteBenchmarkTests: XCTestCase {
         ("testTransactions", testTransactions),
         ("testChunking", testChunking),
         ("testAutoincrement", testAutoincrement),
+        ("testCache", testCache),
     ]
 }


### PR DESCRIPTION
Adds a `KeyedCache` implementation to Fluent.

```swift
var migrations = MigrationConfig()
migrations.prepareCache(for: .psql)
services.use(migrations)
```

```swift
let cache = try req.make(KeyedCache.self)
// use cache
```