### PR TITLE
Adds `.save(on:)` and `.delete(on:)` extensions to Future

### DIFF
--- a/Sources/Fluent/Extensions/Future.swift
+++ b/Sources/Fluent/Extensions/Future.swift
@@ -1,0 +1,15 @@
+import Async
+
+extension Future where T: Model, T.Database: QuerySupporting {
+    public func save(on connectable: DatabaseConnectable) -> Future<T> {
+        return self.flatMap(to: T.self) { (model) in
+            return model.save(on: connectable).transform(to: model)
+        }
+    }
+
+    public func delete(on connectable: DatabaseConnectable) -> Future<T> {
+        return self.flatMap(to: T.self) { (model) in
+            return model.delete(on: connectable).transform(to: model)
+        }
+    }
+}


### PR DESCRIPTION
Saving and deleting models are very common operations. This PR adds two convenience methods for doing just that.

Example usage:

```
return Reservation
    .query(on: databaseConnectable)
    .filter(\Reservation.user == userName)
    .first()
    .unwrap(or: Abort(.notFound, reason: "No reservations have been made"))
    .delete(on: databaseConnectable)
    .map(to: HTTPStatus.self) { _ in
        return .ok
    }
```