### PR TITLE
fixes issues with softdeletable

### DIFF
--- a/Sources/Fluent/Model/SoftDeletable.swift
+++ b/Sources/Fluent/Model/SoftDeletable.swift
@@ -32,9 +32,10 @@ extension Model where Self: SoftDeletable, Database: QuerySupporting, ID: KeyStr
     }
 
     /// Restores a soft deleted model.
-    public mutating func restore(on connection: DatabaseConnectable) -> Future<Self> {
-        fluentDeletedAt = nil
-        return update(on: connection)
+    public func restore(on connection: DatabaseConnectable) -> Future<Self> {
+        var copy = self
+        copy.fluentDeletedAt = nil
+        return query(on: connection).withSoftDeleted().update(copy)
     }
 }
 
@@ -50,8 +51,9 @@ extension DatabaseQuery {
 
 extension QueryBuilder where Model: SoftDeletable {
     /// Includes soft deleted models in the results.
-    public func withSoftDeleted() {
+    public func withSoftDeleted() -> Self {
         query.withSoftDeleted = true
+        return self
     }
 }
 

--- a/Sources/Fluent/Model/SoftDeletable.swift
+++ b/Sources/Fluent/Model/SoftDeletable.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Has create and update timestamps.
 public protocol SoftDeletable: Model, AnySoftDeletable {
     /// Key referencing deleted at property.
-    typealias DeletedAtKey = ReferenceWritableKeyPath<Self, Date?>
+    typealias DeletedAtKey = WritableKeyPath<Self, Date?>
 
     /// The date at which this model was deleted.
     /// nil if the model has not been deleted yet.

--- a/Sources/Fluent/Query/Builder/QueryBuilder.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder.swift
@@ -31,7 +31,7 @@ public final class QueryBuilder<Model> where Model: Fluent.Model, Model.Database
                 let type = Model.self as? AnySoftDeletable.Type,
                 !self.query.withSoftDeleted
             {
-                try! self.group(.or) { or in
+                self.group(.or) { or in
                     let notDeleted = QueryFilter<Model.Database>(
                         entity: type.entity,
                         method: .compare(type.deletedAtField, .equality(.equals), .null)

--- a/Sources/Fluent/Query/Builder/QueryBuilder.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder.swift
@@ -24,25 +24,30 @@ public final class QueryBuilder<Model> where Model: Fluent.Model, Model.Database
     public func run<D>(decoding type: D.Type) -> QueryResultStream<D, Model.Database> where D: Decodable {
         /// if the model is soft deletable, and soft deleted
         /// models were not requested, then exclude them
-        if
-            let type = Model.self as? AnySoftDeletable.Type,
-            !self.query.withSoftDeleted
-        {
-            try! self.group(.or) { or in
-                let notDeleted = QueryFilter<Model.Database>(
-                    entity: type.entity,
-                    method: .compare(type.deletedAtField, .equality(.equals), .value(Date.null))
-                )
-                or.addFilter(notDeleted)
+        switch query.action {
+        case .create: break // no soft delete filters needed for create
+        case .aggregate, .read, .update, .delete:
+            if
+                let type = Model.self as? AnySoftDeletable.Type,
+                !self.query.withSoftDeleted
+            {
+                try! self.group(.or) { or in
+                    let notDeleted = QueryFilter<Model.Database>(
+                        entity: type.entity,
+                        method: .compare(type.deletedAtField, .equality(.equals), .null)
+                    )
+                    or.addFilter(notDeleted)
 
-                let notYetDeleted = QueryFilter<Model.Database>(
-                    entity: type.entity,
-                    method: .compare(type.deletedAtField, .order(.greaterThan), .value(Date()))
-                )
-                or.addFilter(notYetDeleted)
+                    let notYetDeleted = QueryFilter<Model.Database>(
+                        entity: type.entity,
+                        method: .compare(type.deletedAtField, .order(.greaterThan), .value(Date()))
+                    )
+                    or.addFilter(notYetDeleted)
+                }
             }
         }
 
+        /// Create the result stream
         return QueryResultStream(query: query, on: connection)
     }
 

--- a/Sources/Fluent/Query/Filter/Comparison.swift
+++ b/Sources/Fluent/Query/Filter/Comparison.swift
@@ -7,13 +7,6 @@ public enum EqualityComparison {
     case notEquals
 }
 
-extension Encodable {
-    /// Null
-    public static var null: Optional<Self> {
-        return nil
-    }
-}
-
 /// MARK: .equals
 
 /// Model.field == value
@@ -26,11 +19,11 @@ public func == <Model, Value>(lhs: KeyPath<Model, Value>, rhs: Value) -> ModelFi
 }
 
 /// Model.field? == value
-public func == <Model, Value>(lhs: KeyPath<Model, Value?>, rhs: Value) -> ModelFilterMethod<Model>
+public func == <Model, Value>(lhs: KeyPath<Model, Value?>, rhs: Value?) -> ModelFilterMethod<Model>
     where Model: Fluent.Model, Value: Encodable & Equatable & KeyStringDecodable
 {
     return ModelFilterMethod<Model>(
-        method: .compare(lhs.makeQueryField(), .equality(.equals), .value(rhs))
+        method: .compare(lhs.makeQueryField(), .equality(.equals), rhs == nil ? .null : .value(rhs))
     )
 }
 
@@ -42,6 +35,15 @@ public func != <Model, Value>(lhs: KeyPath<Model, Value>, rhs: Value) -> ModelFi
 {
     return ModelFilterMethod<Model>(
         method: .compare(lhs.makeQueryField(), .equality(.notEquals), .value(rhs))
+    )
+}
+
+/// Model.field? != value
+public func != <Model, Value>(lhs: KeyPath<Model, Value?>, rhs: Value?) -> ModelFilterMethod<Model>
+    where Model: Fluent.Model, Value: Encodable & Equatable & KeyStringDecodable
+{
+    return ModelFilterMethod<Model>(
+        method: .compare(lhs.makeQueryField(), .equality(.notEquals), rhs == nil ? .null : .value(rhs))
     )
 }
 
@@ -66,6 +68,15 @@ public func ~= <Model, Value>(lhs: KeyPath<Model, Value>, rhs: Value) -> ModelFi
     )
 }
 
+/// Model.field? ~= value
+public func ~= <Model, Value>(lhs: KeyPath<Model, Value?>, rhs: Value?) -> ModelFilterMethod<Model>
+    where Model: Fluent.Model, Value: Encodable & Equatable & KeyStringDecodable
+{
+    return ModelFilterMethod<Model>(
+        method: .compare(lhs.makeQueryField(), .sequence(.hasSuffix), rhs == nil ? .null : .value(rhs))
+    )
+}
+
 /// Model.field =~ value
 infix operator =~
 public func =~ <Model, Value>(lhs: KeyPath<Model, Value>, rhs: Value) -> ModelFilterMethod<Model>
@@ -76,6 +87,15 @@ public func =~ <Model, Value>(lhs: KeyPath<Model, Value>, rhs: Value) -> ModelFi
     )
 }
 
+/// Model.field? =~ value
+public func =~ <Model, Value>(lhs: KeyPath<Model, Value?>, rhs: Value?) -> ModelFilterMethod<Model>
+    where Model: Fluent.Model, Value: Encodable & Equatable & KeyStringDecodable
+{
+    return ModelFilterMethod<Model>(
+        method: .compare(lhs.makeQueryField(), .sequence(.hasPrefix), rhs == nil ? .null : .value(rhs))
+    )
+}
+
 /// Model.field ~~ value
 infix operator ~~
 public func ~~ <Model, Value>(lhs: KeyPath<Model, Value>, rhs: Value) -> ModelFilterMethod<Model>
@@ -83,6 +103,14 @@ public func ~~ <Model, Value>(lhs: KeyPath<Model, Value>, rhs: Value) -> ModelFi
 {
     return ModelFilterMethod<Model>(
         method: .compare(lhs.makeQueryField(), .sequence(.contains), .value(rhs))
+    )
+}
+/// Model.field ~~ value
+public func ~~ <Model, Value>(lhs: KeyPath<Model, Value?>, rhs: Value?) -> ModelFilterMethod<Model>
+    where Model: Fluent.Model, Value: Encodable & Equatable, Value: KeyStringDecodable
+{
+    return ModelFilterMethod<Model>(
+        method: .compare(lhs.makeQueryField(), .sequence(.contains), rhs == nil ? .null : .value(rhs))
     )
 }
 
@@ -106,6 +134,14 @@ public func > <Model, Value>(lhs: KeyPath<Model, Value>, rhs: Value) -> ModelFil
         method: .compare(lhs.makeQueryField(), .order(.greaterThan), .value(rhs))
     )
 }
+/// Model.field? > value
+public func > <Model, Value>(lhs: KeyPath<Model, Value?>, rhs: Value?) -> ModelFilterMethod<Model>
+    where Model: Fluent.Model, Value: Encodable & Equatable & KeyStringDecodable
+{
+    return ModelFilterMethod<Model>(
+        method: .compare(lhs.makeQueryField(), .order(.greaterThan), rhs == nil ? .null : .value(rhs))
+    )
+}
 
 /// .lessThan
 
@@ -115,6 +151,14 @@ public func < <Model, Value>(lhs: KeyPath<Model, Value>, rhs: Value) -> ModelFil
 {
     return ModelFilterMethod<Model>(
         method: .compare(lhs.makeQueryField(), .order(.lessThan), .value(rhs))
+    )
+}
+/// Model.field? > value
+public func < <Model, Value>(lhs: KeyPath<Model, Value?>, rhs: Value?) -> ModelFilterMethod<Model>
+    where Model: Fluent.Model, Value: Encodable & Equatable & KeyStringDecodable
+{
+    return ModelFilterMethod<Model>(
+        method: .compare(lhs.makeQueryField(), .order(.lessThan), rhs == nil ? .null : .value(rhs))
     )
 }
 
@@ -128,6 +172,14 @@ public func >= <Model, Value>(lhs: KeyPath<Model, Value>, rhs: Value) throws -> 
         method: .compare(lhs.makeQueryField(), .order(.greaterThanOrEquals), .value(rhs))
     )
 }
+/// Model.field? >= value
+public func >= <Model, Value>(lhs: KeyPath<Model, Value?>, rhs: Value?) throws -> ModelFilterMethod<Model>
+    where Model: Fluent.Model, Value: Encodable & Equatable & KeyStringDecodable
+{
+    return ModelFilterMethod<Model>(
+        method: .compare(lhs.makeQueryField(), .order(.greaterThanOrEquals), rhs == nil ? .null : .value(rhs))
+    )
+}
 
 /// .lessThanOrEquals
 
@@ -137,5 +189,13 @@ public func <= <Model, Value>(lhs: KeyPath<Model, Value>, rhs: Value) -> ModelFi
 {
     return ModelFilterMethod<Model>(
         method: .compare(lhs.makeQueryField(), .order(.lessThanOrEquals), .value(rhs))
+    )
+}
+/// Model.field? <= value
+public func <= <Model, Value>(lhs: KeyPath<Model, Value?>, rhs: Value?) -> ModelFilterMethod<Model>
+    where Model: Fluent.Model, Value: Encodable & Equatable & KeyStringDecodable
+{
+    return ModelFilterMethod<Model>(
+        method: .compare(lhs.makeQueryField(), .order(.lessThanOrEquals), rhs == nil ? .null : .value(rhs))
     )
 }

--- a/Sources/Fluent/Query/Filter/FilterMethod.swift
+++ b/Sources/Fluent/Query/Filter/FilterMethod.swift
@@ -12,6 +12,7 @@ public enum QueryComparison {
 }
 
 public enum QueryComparisonValue {
+    case null
     case value(Encodable)
     case field(QueryField)
 }

--- a/Sources/Fluent/Query/Filter/GroupRelation.swift
+++ b/Sources/Fluent/Query/Filter/GroupRelation.swift
@@ -11,7 +11,7 @@ extension QueryBuilder {
     public func group(
         _ relation: QueryGroupRelation,
         closure: @escaping GroupClosure
-    ) throws -> Self {
+    ) rethrows -> Self {
         let sub = copy()
         try closure(sub)
         let filter = QueryFilter(

--- a/Sources/FluentBenchmark/Bar.swift
+++ b/Sources/FluentBenchmark/Bar.swift
@@ -1,0 +1,39 @@
+import Async
+import Fluent
+import Foundation
+
+internal final class Bar<D>: Model, SoftDeletable where D: QuerySupporting {
+    /// See Model.Database
+    typealias Database = D
+
+    /// See Model.ID
+    typealias ID = UUID
+
+    /// See Model.name
+    static var name: String { return "bar" }
+
+    /// See Model.idKey
+    static var idKey: IDKey { return \.id }
+
+    /// See SoftDeletable.deletedAtKey
+    static var deletedAtKey: DeletedAtKey {
+        return \.deletedAt
+    }
+
+    /// Foo's identifier
+    var id: UUID?
+
+    /// Test integer
+    var baz: Int
+
+    /// See `SoftDeletable.deletedAt`
+    var deletedAt: Date?
+
+    /// Create a new foo
+    init(id: ID? = nil, baz: Int) {
+        self.id = id
+        self.baz = baz
+    }
+}
+
+extension Bar: Migration where D: SchemaSupporting { }

--- a/Sources/FluentBenchmark/Bar.swift
+++ b/Sources/FluentBenchmark/Bar.swift
@@ -2,7 +2,7 @@ import Async
 import Fluent
 import Foundation
 
-internal final class Bar<D>: Model, SoftDeletable where D: QuerySupporting {
+struct Bar<D>: Model, SoftDeletable where D: QuerySupporting {
     /// See Model.Database
     typealias Database = D
 

--- a/Sources/FluentBenchmark/BenchmarkSoftDeletable.swift
+++ b/Sources/FluentBenchmark/BenchmarkSoftDeletable.swift
@@ -1,0 +1,77 @@
+//
+//  BenchmarkSoftDeletable.swift
+//  FluentBenchmark
+//
+//  Created by Tanner Nelson on 2/12/18.
+//
+
+import Foundation
+import Async
+import Dispatch
+import Fluent
+import Foundation
+
+extension Benchmarker where Database: QuerySupporting & TransactionSupporting {
+    /// The actual benchmark.
+    fileprivate func _benchmark(on conn: Database.Connection) throws {
+        // create
+        var bar = Bar<Database>(baz: 1)
+
+        if try test(Bar<Database>.query(on: conn).count()) != 0 {
+            fail("count should have been 0")
+        }
+
+        bar = try test(bar.save(on: conn))
+        if try test(Bar<Database>.query(on: conn).count()) != 1 {
+            fail("count should have been 1")
+        }
+        if try test(Bar<Database>.query(on: conn).withSoftDeleted().count()) != 1 {
+            fail("count should have been 1")
+        }
+
+        bar = try test(bar.delete(on: conn))
+        if try test(Bar<Database>.query(on: conn).count()) != 0 {
+            fail("count should have been 0")
+        }
+        if try test(Bar<Database>.query(on: conn).withSoftDeleted().count()) != 1 {
+            fail("count should have been 1")
+        }
+
+        bar = try test(bar.restore(on: conn))
+        if try test(Bar<Database>.query(on: conn).count()) != 1 {
+            fail("count should have been 1")
+        }
+        if try test(Bar<Database>.query(on: conn).withSoftDeleted().count()) != 1 {
+            fail("count should have been 1")
+        }
+
+        bar = try test(bar.forceDelete(on: conn))
+        if try test(Bar<Database>.query(on: conn).count()) != 0 {
+            fail("count should have been 0")
+        }
+        if try test(Bar<Database>.query(on: conn).withSoftDeleted().count()) != 0 {
+            fail("count should have been 0")
+        }
+    }
+
+    /// Benchmark fluent transactions.
+    public func benchmarkSoftDeletable() throws {
+        let conn = try test(pool.requestConnection())
+        try self._benchmark(on: conn)
+        pool.releaseConnection(conn)
+    }
+}
+
+extension Benchmarker where Database: QuerySupporting & TransactionSupporting & SchemaSupporting {
+    /// Benchmark fluent transactions.
+    /// The schema will be prepared first.
+    public func benchmarkSoftDeletable_withSchema() throws {
+        let conn = try test(pool.requestConnection())
+        try test(Bar<Database>.prepare(on: conn))
+        try self._benchmark(on: conn)
+        try test(Bar<Database>.revert(on: conn))
+        pool.releaseConnection(conn)
+    }
+}
+
+

--- a/Sources/FluentBenchmark/Foo.swift
+++ b/Sources/FluentBenchmark/Foo.swift
@@ -15,11 +15,6 @@ internal final class Foo<D>: Model where D: QuerySupporting {
     /// See Model.idKey
     static var idKey: IDKey { return \.id }
 
-    /// See Model.database
-    public static var database: DatabaseIdentifier<D> {
-        return .init("test")
-    }
-
     /// Foo's identifier
     var id: UUID?
 

--- a/Sources/FluentSQL/QueryComparison.swift
+++ b/Sources/FluentSQL/QueryComparison.swift
@@ -3,9 +3,13 @@ import SQL
 
 extension QueryComparison {
     /// Convert query comparison to sql predicate comparison.
-    internal func makeDataPredicateComparison() -> DataPredicateComparison {
+    internal func makeDataPredicateComparison(for value: QueryComparisonValue) -> DataPredicateComparison {
         switch self {
-        case .equality(let eq): return eq.makeDataPredicateComparison()
+        case .equality(let eq):
+            switch value {
+            case .null: return .null
+            default: return eq.makeDataPredicateComparison()
+            }
         case .order(let or): return or.makeDataPredicateComparison()
         case .sequence(let seq): return seq.makeDataPredicateComparison()
         }
@@ -16,10 +20,9 @@ extension QueryComparisonValue {
     /// Convert query comparison value to sql data predicate value.
     internal func makeDataPredicateValue() -> DataPredicateValue {
         switch self {
-        case .field(let field):
-            return .column(field.makeDataColumn())
-        case .value:
-            return .placeholder
+        case .null: return .none
+        case .field(let field): return .column(field.makeDataColumn())
+        case .value: return .placeholder
         }
     }
 }

--- a/Sources/FluentSQL/QueryFilter.swift
+++ b/Sources/FluentSQL/QueryFilter.swift
@@ -11,7 +11,7 @@ extension QueryFilter {
         case .compare(let field, let comp, let value):
             let predicate = DataPredicate(
                 column: field.makeDataColumn(),
-                comparison: comp.makeDataPredicateComparison(),
+                comparison: comp.makeDataPredicateComparison(for: value),
                 value: value.makeDataPredicateValue()
             )
 

--- a/Sources/FluentSQLite/SQLiteDatabase+Query.swift
+++ b/Sources/FluentSQLite/SQLiteDatabase+Query.swift
@@ -23,8 +23,9 @@ extension SQLiteDatabase: QuerySupporting {
             // bind model columns to sql query
             if let model = query.data {
                 try model.encode(to: rowEncoder)
-                dataQuery.columns += rowEncoder.row.fields.keys.map {
-                    DataColumn(table: query.entity, name: $0.name)
+                rowEncoder.row.fields.forEach { key, val in
+                    let col = DataColumn(table: query.entity, name: key.name)
+                    dataQuery.columns.append(col)
                 }
             }
 

--- a/Tests/FluentTests/SQLiteBenchmarkTests.swift
+++ b/Tests/FluentTests/SQLiteBenchmarkTests.swift
@@ -52,6 +52,10 @@ final class SQLiteBenchmarkTests: XCTestCase {
         try benchmarker.benchmarkJoins_withSchema()
     }
 
+    func testSoftDeletable() throws {
+        try benchmarker.benchmarkSoftDeletable_withSchema()
+    }
+
     static let allTests = [
         ("testSchema", testSchema),
         ("testModels", testModels),
@@ -61,5 +65,6 @@ final class SQLiteBenchmarkTests: XCTestCase {
         ("testChunking", testChunking),
         ("testAutoincrement", testAutoincrement),
         ("testCache", testCache),
+        ("testSoftDeletable", testSoftDeletable)
     ]
 }


### PR DESCRIPTION
Fixes https://github.com/vapor/fluent/pull/335

This PR addresses a number of issues surrounding `SoftDeletable`:
- [x] Most importantly, adds a benchmarker test.
- [x] `builder.withSoftDeleted()` now properly returns `self` for chaining
- [x] Soft delete filtering is no longer incorrectly applied to create (`INSERT`) queries
- [x] QueryComparisonValue now supports `null`
- [x] Adds optional overloads for all operators (currently only `==` exists)