### PR TITLE
schema refs + cleanup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/console.git", .exact("3.0.0-beta.1")),
 
         // Core services for creating database integrations.
-        .package(url: "https://github.com/vapor/database-kit.git", .branch("is-null")),
+        .package(url: "https://github.com/vapor/database-kit.git", .exact("1.0.0-beta.2")),
 
         // Service container and configuration system.
         .package(url: "https://github.com/vapor/service.git", .exact("1.0.0-beta.1")),

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/console.git", .exact("3.0.0-beta.1")),
 
         // Core services for creating database integrations.
-        .package(url: "https://github.com/vapor/database-kit.git", .branch("beta")),
+        .package(url: "https://github.com/vapor/database-kit.git", .branch("is-null")),
 
         // Service container and configuration system.
         .package(url: "https://github.com/vapor/service.git", .exact("1.0.0-beta.1")),

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/console.git", .exact("3.0.0-beta.1")),
 
         // Core services for creating database integrations.
-        .package(url: "https://github.com/vapor/database-kit.git", .exact("1.0.0-beta.1")),
+        .package(url: "https://github.com/vapor/database-kit.git", .branch("beta")),
 
         // Service container and configuration system.
         .package(url: "https://github.com/vapor/service.git", .exact("1.0.0-beta.1")),

--- a/Sources/Fluent/Model/Model.swift
+++ b/Sources/Fluent/Model/Model.swift
@@ -156,8 +156,8 @@ extension Model where Database: QuerySupporting {
 
     /// Updates the model. This requires that
     /// the model has its ID set.
-    public func update(on conn: DatabaseConnectable) -> Future<Self> {
-        return query(on: conn).update(self)
+    public func update(on conn: DatabaseConnectable, originalID: ID? = nil) -> Future<Self> {
+        return query(on: conn).update(self, originalID: originalID)
     }
 
     /// Saves this model to the supplied query executor.

--- a/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
@@ -49,7 +49,7 @@ extension QueryBuilder where Model.ID: KeyStringDecodable {
 
     /// Updates the model. This requires that
     /// the model has its ID set.
-    public func update(_ model: Model) -> Future<Model> {
+    public func update(_ model: Model, originalID: Model.ID? = nil) -> Future<Model> {
         // set timestamps
         let copy: Model
         if var timestampable = model as? AnyTimestampable {
@@ -60,7 +60,7 @@ extension QueryBuilder where Model.ID: KeyStringDecodable {
         }
 
         return connection.flatMap(to: Model.self) { conn in
-            guard let id = model.fluentID else {
+            guard let id = originalID ?? model.fluentID else {
                 throw FluentError(
                     identifier: "idRequired",
                     reason: "No ID was set on updated model, it is required for updating."

--- a/Sources/Fluent/Query/QueryJoin.swift
+++ b/Sources/Fluent/Query/QueryJoin.swift
@@ -78,7 +78,7 @@ extension DatabaseQuery {
     }
 }
 
-// MARK: Query Builder
+// MARK: Join on Model.ID
 
 extension QueryBuilder where Model.Database: JoinSupporting {
     /// Join another model to this query builder.
@@ -90,7 +90,7 @@ extension QueryBuilder where Model.Database: JoinSupporting {
     ) -> Self where Joined: Fluent.Model {
         let join = QueryJoin(
             method: method,
-            base:  Model.idKey.makeQueryField(),
+            base:  baseKey.makeQueryField(),
             joined: joinedKey.makeQueryField()
         )
         query.joins.append(join)
@@ -106,7 +106,7 @@ extension QueryBuilder where Model.Database: JoinSupporting {
     ) -> Self where Joined: Fluent.Model {
         let join = QueryJoin(
             method: method,
-            base:  Model.idKey.makeQueryField(),
+            base:  baseKey.makeQueryField(),
             joined: joinedKey.makeQueryField()
         )
         query.joins.append(join)
@@ -116,13 +116,13 @@ extension QueryBuilder where Model.Database: JoinSupporting {
     /// Join another model to this query builder.
     public func join<Joined>(
         _ joinedType: Joined.Type = Joined.self,
-        field joinedKey: KeyPath<Joined, Joined.ID?>,
-        to baseKey: KeyPath<Model, Joined.ID>,
+        field joinedKey: KeyPath<Joined, Model.ID?>,
+        to baseKey: KeyPath<Model, Model.ID>,
         method: QueryJoinMethod = .inner
     ) -> Self where Joined: Fluent.Model {
         let join = QueryJoin(
             method: method,
-            base: baseKey.makeQueryField(),
+            base:  baseKey.makeQueryField(),
             joined: joinedKey.makeQueryField()
         )
         query.joins.append(join)
@@ -132,13 +132,13 @@ extension QueryBuilder where Model.Database: JoinSupporting {
     /// Join another model to this query builder.
     public func join<Joined>(
         _ joinedType: Joined.Type = Joined.self,
-        field joinedKey: KeyPath<Joined, Joined.ID?>,
-        to baseKey: KeyPath<Model, Joined.ID?>,
+        field joinedKey: KeyPath<Joined, Model.ID>,
+        to baseKey: KeyPath<Model, Model.ID>,
         method: QueryJoinMethod = .inner
     ) -> Self where Joined: Fluent.Model {
         let join = QueryJoin(
             method: method,
-            base: baseKey.makeQueryField(),
+            base:  baseKey.makeQueryField(),
             joined: joinedKey.makeQueryField()
         )
         query.joins.append(join)

--- a/Sources/Fluent/Query/QueryJoin.swift
+++ b/Sources/Fluent/Query/QueryJoin.swift
@@ -90,7 +90,7 @@ extension QueryBuilder where Model.Database: JoinSupporting {
     ) -> Self where Joined: Fluent.Model {
         let join = QueryJoin(
             method: method,
-            base:  baseKey.makeQueryField(),
+            base: baseKey.makeQueryField(),
             joined: joinedKey.makeQueryField()
         )
         query.joins.append(join)
@@ -106,7 +106,7 @@ extension QueryBuilder where Model.Database: JoinSupporting {
     ) -> Self where Joined: Fluent.Model {
         let join = QueryJoin(
             method: method,
-            base:  baseKey.makeQueryField(),
+            base: baseKey.makeQueryField(),
             joined: joinedKey.makeQueryField()
         )
         query.joins.append(join)
@@ -122,7 +122,7 @@ extension QueryBuilder where Model.Database: JoinSupporting {
     ) -> Self where Joined: Fluent.Model {
         let join = QueryJoin(
             method: method,
-            base:  baseKey.makeQueryField(),
+            base: baseKey.makeQueryField(),
             joined: joinedKey.makeQueryField()
         )
         query.joins.append(join)
@@ -138,7 +138,7 @@ extension QueryBuilder where Model.Database: JoinSupporting {
     ) -> Self where Joined: Fluent.Model {
         let join = QueryJoin(
             method: method,
-            base:  baseKey.makeQueryField(),
+            base: baseKey.makeQueryField(),
             joined: joinedKey.makeQueryField()
         )
         query.joins.append(join)

--- a/Sources/Fluent/Schema/SchemaBuilder.swift
+++ b/Sources/Fluent/Schema/SchemaBuilder.swift
@@ -1,16 +1,12 @@
 import Async
 
-/// FIXME: move to protocol when swift fixes demangle bug
-
 /// Helps you create and execute a database schema.
-public class SchemaBuilder<Model>
-    where Model: Fluent.Model, Model.Database: SchemaSupporting
-{
+public protocol SchemaBuilder: class {
+    associatedtype Model: Fluent.Model where Model.Database: SchemaSupporting
+
     /// The schema being built.
-    public var schema: DatabaseSchema<Model.Database>
+    var schema: DatabaseSchema<Model.Database> { get set }
 
     /// Create a new schema creator.
-    public init(_ type: Model.Type = Model.self) {
-        schema = DatabaseSchema(entity: Model.entity)
-    }
+    init(_ type: Model.Type)
 }

--- a/Sources/Fluent/Schema/SchemaCreator.swift
+++ b/Sources/Fluent/Schema/SchemaCreator.swift
@@ -2,6 +2,14 @@ import Async
 
 /// A schema builder specifically for creating
 /// new tables and collections.
-public final class SchemaCreator<Model>: SchemaBuilder<Model>
+public final class SchemaCreator<Model>: SchemaBuilder
     where Model: Fluent.Model, Model.Database: SchemaSupporting
-{ }
+{
+    /// See `SchemaBuilder.schema`
+    public var schema: DatabaseSchema<Model.Database>
+
+    /// See `SchemaBuilder.init(type:)`
+    public init(_ type: Model.Type = Model.self) {
+        schema = DatabaseSchema(entity: Model.entity)
+    }
+}

--- a/Sources/Fluent/Schema/SchemaReference.swift
+++ b/Sources/Fluent/Schema/SchemaReference.swift
@@ -45,19 +45,28 @@ public struct SchemaReference<Database> where Database: ReferenceSupporting & Sc
 
 public struct ReferentialActions {
     /// Action to take if referenced entities are updated.
-    public var update: ReferentialAction
+    public var update: ReferentialAction?
 
     /// Action to take if referenced entities are deleted.
-    public var delete: ReferentialAction
+    public var delete: ReferentialAction?
 
     /// Creates a new `ReferentialActions`
-    public init(update: ReferentialAction, delete: ReferentialAction) {
+    public init(update: ReferentialAction? = nil, delete: ReferentialAction? = nil) {
         self.update = update
         self.delete = delete
     }
 
     /// The default `ReferentialActions`
-    public static let `default`: ReferentialActions = .init(update: .default, delete: .default)
+    public static let `default`: ReferentialActions = .init(update: nil, delete: nil)
+
+    /// The default `ReferentialActions`
+    public static let prevent: ReferentialActions = .init(update: .prevent, delete: .prevent)
+
+    /// The default `ReferentialActions`
+    public static let nullify: ReferentialActions = .init(update: .nullify, delete: .nullify)
+
+    /// The default `ReferentialActions`
+    public static let update: ReferentialActions = .init(update: .update, delete: .update)
 }
 
 /// Supported referential actions.
@@ -139,13 +148,13 @@ extension SchemaBuilder where Model.Database: ReferenceSupporting, Model.ID: Key
 
     /// Adds a reference.
     public func addReference<T, Other>(
-        for key: KeyPath<Model, T>,
-        referencing: KeyPath<Other, T>,
+        from base: KeyPath<Model, T>,
+        to referenced: KeyPath<Other, T>,
         actions: ReferentialActions = .default
     ) throws where Other: Fluent.Model, T: KeyStringDecodable {
         let reference = SchemaReference<Model.Database>(
-            base: key.makeQueryField(),
-            referenced: referencing.makeQueryField(),
+            base: base.makeQueryField(),
+            referenced: referenced.makeQueryField(),
             actions: actions
         )
         schema.addReferences.append(reference)
@@ -153,13 +162,13 @@ extension SchemaBuilder where Model.Database: ReferenceSupporting, Model.ID: Key
 
     /// Adds a reference.
     public func addReference<T, Other>(
-        for key: KeyPath<Model, T?>,
-        referencing: KeyPath<Other, T>,
+        from base: KeyPath<Model, T?>,
+        to referenced: KeyPath<Other, T>,
         actions: ReferentialActions = .default
     ) throws where Other: Fluent.Model, T: KeyStringDecodable {
         let reference = SchemaReference<Model.Database>(
-            base: key.makeQueryField(),
-            referenced: referencing.makeQueryField(),
+            base: base.makeQueryField(),
+            referenced: referenced.makeQueryField(),
             actions: actions
         )
         schema.addReferences.append(reference)
@@ -167,13 +176,13 @@ extension SchemaBuilder where Model.Database: ReferenceSupporting, Model.ID: Key
 
     /// Adds a reference.
     public func addReference<T, Other>(
-        for key: KeyPath<Model, T>,
-        referencing: KeyPath<Other, T?>,
+        from base: KeyPath<Model, T>,
+        to referenced: KeyPath<Other, T?>,
         actions: ReferentialActions = .default
     ) throws where Other: Fluent.Model, T: KeyStringDecodable {
         let reference = SchemaReference<Model.Database>(
-            base: key.makeQueryField(),
-            referenced: referencing.makeQueryField(),
+            base: base.makeQueryField(),
+            referenced: referenced.makeQueryField(),
             actions: actions
         )
         schema.addReferences.append(reference)
@@ -181,13 +190,13 @@ extension SchemaBuilder where Model.Database: ReferenceSupporting, Model.ID: Key
 
     /// Adds a reference.
     public func addReference<T, Other>(
-        for key: KeyPath<Model, T?>,
-        referencing: KeyPath<Other, T?>,
+        from base: KeyPath<Model, T?>,
+        to referenced: KeyPath<Other, T?>,
         actions: ReferentialActions = .default
     ) throws where Other: Fluent.Model, T: KeyStringDecodable {
         let reference = SchemaReference<Model.Database>(
-            base: key.makeQueryField(),
-            referenced: referencing.makeQueryField(),
+            base: base.makeQueryField(),
+            referenced: referenced.makeQueryField(),
             actions: actions
         )
         schema.addReferences.append(reference)

--- a/Sources/Fluent/Schema/SchemaUpdater.swift
+++ b/Sources/Fluent/Schema/SchemaUpdater.swift
@@ -1,9 +1,17 @@
 import Async
 
 /// Updates schemas, capable of deleting fields.
-public final class SchemaUpdater<Model>: SchemaBuilder<Model>
+public final class SchemaUpdater<Model>: SchemaBuilder
     where Model: Fluent.Model, Model.Database: SchemaSupporting
 {
+    /// See `SchemaBuilder.schema`
+    public var schema: DatabaseSchema<Model.Database>
+
+    /// See `SchemaBuilder.init(type:)`
+    public init(_ type: Model.Type = Model.self) {
+        schema = DatabaseSchema(entity: Model.entity)
+    }
+
     /// Deletes the field with the supplied name.
     public func delete(_ name: String) {
         schema.removeFields.append(name)

--- a/Sources/FluentBenchmark/BenchmarkJoins.swift
+++ b/Sources/FluentBenchmark/BenchmarkJoins.swift
@@ -41,11 +41,11 @@ extension Benchmarker where Database: SchemaSupporting & JoinSupporting & Refere
         try test(Database.enableReferences(on: conn))
 
         try test(UserMigration<Database>.prepare(on: conn))
-        try test(PetMigration<Database>.prepare(on: conn))
+        try test(Pet<Database>.prepare(on: conn))
 
         try self._benchmark(on: conn)
 
-        try test(PetMigration<Database>.revert(on: conn))
+        try test(Pet<Database>.revert(on: conn))
         try test(UserMigration<Database>.revert(on: conn))
 
         self.pool.releaseConnection(conn)

--- a/Sources/FluentBenchmark/BenchmarkReferentialActions.swift
+++ b/Sources/FluentBenchmark/BenchmarkReferentialActions.swift
@@ -13,17 +13,10 @@ extension Benchmarker where Database: JoinSupporting & ReferenceSupporting & Que
         var ziz = try Pet<Database>(name: "Ziz", ownerID: tanner.requireID())
         ziz = try test(ziz.save(on: conn))
 
-        let foo = Pet<Database>(name: "Foo", ownerID: UUID())
-        do {
-            _ = try foo.save(on: conn).await(on: eventLoop)
-            fail("save should have failed")
-        } catch {
-            // pass
-        }
 
         var count = try test(tanner.pets.query(on: conn).count())
         if count != 1 {
-            self.fail("count should have been 1")
+            self.fail("invalid count \(count) != 1")
         }
 
         guard let ownerRelation = ziz.owner else {
@@ -36,42 +29,41 @@ extension Benchmarker where Database: JoinSupporting & ReferenceSupporting & Que
             self.fail("pet owner's name wrong")
         }
 
-        var plasticBag = Toy<Database>(name: "Plastic Bag")
-        plasticBag = try test(plasticBag.save(on: conn))
+        let originalID = tanner.id
+        tanner.id = UUID() // change id
+        tanner = try test(tanner.update(on: conn, originalID: originalID))
 
-        var oldBologna = Toy<Database>(name: "Old Bologna")
-        oldBologna = try test(oldBologna.save(on: conn))
-
-        _ = try test(ziz.toys.attach(plasticBag, on: conn))
-        _ = try test(oldBologna.pets.attach(ziz, on: conn))
-
-        count = try test(ziz.toys.query(on: conn).count())
-        if count != 2 {
-            self.fail("count \(count) != 2")
-        }
-
-        count = try test(oldBologna.pets.query(on: conn).count())
+        count = try test(tanner.pets.query(on: conn).count())
         if count != 1 {
-            self.fail("count should have been 1")
+            self.fail("invalid count \(count) != 1")
         }
 
-        count = try test(plasticBag.pets.query(on: conn).count())
-        if count != 1 {
-            self.fail("count should have been 1")
+        do {
+            guard let zizFetch = try test(Pet<Database>.query(on: conn).first()) else {
+                fail("could not fetch pet")
+                return
+            }
+
+            if zizFetch.ownerID == nil {
+                fail("owner id was nil")
+            }
         }
 
-        if try !test(ziz.toys.isAttached(plasticBag, on: conn)) {
-            self.fail("should be attached")
-        }
-        try test(ziz.toys.detach(plasticBag, on: conn))
+        tanner = try test(tanner.delete(on: conn))
+        do {
+            guard let zizFetch = try test(Pet<Database>.query(on: conn).first()) else {
+                fail("could not fetch pet")
+                return
+            }
 
-        if try test(ziz.toys.isAttached(plasticBag, on: conn)) {
-            self.fail("should not be attached")
+            if zizFetch.ownerID != nil {
+                fail("owner id did not get nullified")
+            }
         }
     }
 
     /// Benchmark fluent relations.
-    public func benchmarkRelations() throws {
+    public func benchmarkReferentialActions() throws {
         let conn = try test(pool.requestConnection())
         try test(Database.enableReferences(on: conn))
         try self._benchmark(on: conn)
@@ -82,23 +74,16 @@ extension Benchmarker where Database: JoinSupporting & ReferenceSupporting & Que
 extension Benchmarker where Database: SchemaSupporting & JoinSupporting & ReferenceSupporting & QuerySupporting {
     /// Benchmark fluent relations.
     /// The schema will be prepared first.
-    public func benchmarkRelations_withSchema() throws {
+    public func benchmarkReferentialActions_withSchema() throws {
         let conn = try test(pool.requestConnection())
         try test(Database.enableReferences(on: conn))
-
         try test(UserMigration<Database>.prepare(on: conn))
         try test(Pet<Database>.prepare(on: conn))
-        try test(ToyMigration<Database>.prepare(on: conn))
-        try test(PetToyMigration<Database>.prepare(on: conn))
-
         try self._benchmark(on: conn)
-
-        try test(PetToyMigration<Database>.revert(on: conn))
-        try test(ToyMigration<Database>.revert(on: conn))
         try test(Pet<Database>.revert(on: conn))
         try test(UserMigration<Database>.revert(on: conn))
-
         self.pool.releaseConnection(conn)
     }
 }
+
 

--- a/Sources/FluentBenchmark/BenchmarkRelations.swift
+++ b/Sources/FluentBenchmark/BenchmarkRelations.swift
@@ -82,7 +82,7 @@ extension Benchmarker where Database: SchemaSupporting & JoinSupporting & Refere
         try test(Database.enableReferences(on: conn))
 
         try test(UserMigration<Database>.prepare(on: conn))
-        try test(PetMigration<Database>.prepare(on: conn))
+        try test(Pet<Database>.prepare(on: conn))
         try test(ToyMigration<Database>.prepare(on: conn))
         try test(PetToyMigration<Database>.prepare(on: conn))
 
@@ -90,7 +90,7 @@ extension Benchmarker where Database: SchemaSupporting & JoinSupporting & Refere
 
         try test(PetToyMigration<Database>.revert(on: conn))
         try test(ToyMigration<Database>.revert(on: conn))
-        try test(PetMigration<Database>.revert(on: conn))
+        try test(Pet<Database>.revert(on: conn))
         try test(UserMigration<Database>.revert(on: conn))
 
         self.pool.releaseConnection(conn)

--- a/Sources/FluentBenchmark/Pet.swift
+++ b/Sources/FluentBenchmark/Pet.swift
@@ -29,15 +29,15 @@ public final class Pet<D>: Model where D: QuerySupporting {
     var name: String
 
     /// Age int
-    var ownerID: User<Database>.ID
+    var ownerID: User<Database>.ID?
 
-    /// Create a new foo
-    init(id: ID? = nil, name: String, ownerID: User<Database>.ID) {
+    /// Creates a new `Pet`
+    init(id: ID? = nil, name: String, ownerID: User<Database>.ID?) {
         self.id = id
         self.name = name
         self.ownerID = ownerID
     }
-
+    
     /// See Encodable.encode
     public func encode(to encoder: Encoder) throws {
         var container = encodingContainer(for: encoder)
@@ -51,7 +51,7 @@ public final class Pet<D>: Model where D: QuerySupporting {
 
 extension Pet {
     /// A relation to this pet's owner.
-    var owner: Parent<Pet, User<Database>> {
+    var owner: Parent<Pet, User<Database>>? {
         return parent(\.ownerID)
     }
 }
@@ -70,7 +70,7 @@ extension Pet: Migration where D: SchemaSupporting & ReferenceSupporting {
     public static func prepare(on connection: Database.Connection) -> Future<Void> {
         return Database.create(self, on: connection) { builder in
             try addProperties(to: builder)
-            try builder.addReference(for: \.ownerID, referencing: \User<D>.id)
+            try builder.addReference(from: \.ownerID, to: \User<D>.id, actions: .init(update: .update, delete: .nullify))
         }
     }
 }

--- a/Sources/FluentSQL/SchemaReference.swift
+++ b/Sources/FluentSQL/SchemaReference.swift
@@ -19,7 +19,20 @@ extension SchemaReference {
         return SchemaForeignKey(
             name: "",
             local: DataColumn(table: nil, name: base.name),
-            foreign: referenced.makeDataColumn()
+            foreign: referenced.makeDataColumn(),
+            onUpdate: actions.update?.makeForeignKeyAction(),
+            onDelete: actions.delete?.makeForeignKeyAction()
         )
+    }
+}
+
+extension ReferentialAction {
+    /// Converts a `ReferentialAction` to `SchemaForeignKeyAction`
+    fileprivate func makeForeignKeyAction() -> SchemaForeignKeyAction {
+        switch self {
+        case .nullify: return .setNull
+        case .prevent: return .restrict
+        case .update: return .cascade
+        }
     }
 }

--- a/Tests/FluentTests/SQLiteBenchmarkTests.swift
+++ b/Tests/FluentTests/SQLiteBenchmarkTests.swift
@@ -56,6 +56,10 @@ final class SQLiteBenchmarkTests: XCTestCase {
         try benchmarker.benchmarkSoftDeletable_withSchema()
     }
 
+    func testReferentialActions() throws {
+        try benchmarker.benchmarkReferentialActions_withSchema()
+    }
+
     static let allTests = [
         ("testSchema", testSchema),
         ("testModels", testModels),
@@ -65,6 +69,7 @@ final class SQLiteBenchmarkTests: XCTestCase {
         ("testChunking", testChunking),
         ("testAutoincrement", testAutoincrement),
         ("testCache", testCache),
-        ("testSoftDeletable", testSoftDeletable)
+        ("testSoftDeletable", testSoftDeletable),
+        ("testReferentialActions", testReferentialActions),
     ]
 }


### PR DESCRIPTION
- [x] adds referential actions to Fluent (long awaited feature!)

```swift
try builder.addReference(from: \.ownerID, to: \User.id)
try builder.addReference(from: \.ownerID, to: \User.id, actions: .update)
try builder.addReference(from: \.ownerID, to: \User<D>.id, actions: ReferentialActions(update: .nullify))
try builder.addReference(from: \.ownerID, to: \User<D>.id, actions: ReferentialActions(update: .update, delete: .prevent))
```

- [x] adds a new way to opt-in to auto-migrations, while still getting access to the schema creator `Model.addProperties(to:)`

```swift
extension Pet: Migration {
    /// See `Migration.prepare(on:)`
    public static func prepare(on connection: Database.Connection) -> Future<Void> {
        return Database.create(self, on: connection) { builder in
            try addProperties(to: builder)
            try builder.addReference(from: \.ownerID, to: \User.id)
        }
    }
}
```

This should be a great way to add references to fields (and any other custom stuff) without needing to implement the entire migration.

- [x] adds overloads for `addReference` and `removeReference` on the schema builder.
- [x] moves `SchemaBuilder` back to being a protocol instead of a base class (Swift mangling issue has been fixed)
- [x] adds `testReferentialActions` test suite
- [x] allows optionals for `Children` and `Parent` relations
- [x] cleans up `join` overloads.