### PR TITLE
Created QueryBuilder.set method

### DIFF
--- a/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
@@ -47,6 +47,16 @@ extension QueryBuilder where Model.ID: KeyStringDecodable {
         }
     }
 
+    /// Updates a a given row in the model.
+    /// This requires that the models ID is set.
+    func set<Value>(_ key: KeyPath<Model, Value>, to value: Value) -> Future<Void> where Value: Encodable & KeyStringDecodable {
+        self.query.data = [
+            key.makeQueryField().name: value
+        ]
+        self.query.action = .update
+        return self.execute()
+    }
+    
     /// Updates the model. This requires that
     /// the model has its ID set.
     public func update(_ model: Model, originalID: Model.ID? = nil) -> Future<Model> {

--- a/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
@@ -49,7 +49,7 @@ extension QueryBuilder where Model.ID: KeyStringDecodable {
 
     /// Updates a a given row in the model.
     /// This requires that the models ID is set.
-    func set<Value>(_ key: KeyPath<Model, Value>, to value: Value) -> Future<Void> where Value: Encodable & KeyStringDecodable {
+    public func set<Value>(_ key: KeyPath<Model, Value>, to value: Value) -> Future<Void> where Value: Encodable & KeyStringDecodable {
         self.query.data = [
             key.makeQueryField().name: value
         ]

--- a/Sources/FluentBenchmark/BenchmarkModels.swift
+++ b/Sources/FluentBenchmark/BenchmarkModels.swift
@@ -20,6 +20,7 @@ extension Benchmarker where Database: QuerySupporting {
         // update
         b.bar = "fdsa"
         _ = try test(b.save(on: conn))
+        _ = try test(Foo.query(on: conn).filter(\.id == a.id).set(\Foo<Database>.baz, to: 314))
 
         // read
         let fetched = try test(Foo<Database>.find(b.requireID(), on: conn))
@@ -27,6 +28,14 @@ extension Benchmarker where Database: QuerySupporting {
             self.fail("b.bar should have been updated")
         }
 
+        let fetchedA = try test(Foo<Database>.find(a.requireID(), on: conn))
+        if fetchedA?.baz != 314 {
+            self.fail("a.baz should equal 314")
+        }
+        if fetched?.baz == 314 {
+            self.fail("b.baz should not equal 314")
+        }
+        
         let c = try test(b.delete(on: conn))
         if c.id != nil {
             self.fail("id should have been set to nil")


### PR DESCRIPTION
This PR adds a `.set(_:to:)` method to the `QueryBuilder` type, allowing you to run `SET` queries on a model.

Example:

```swift
Player.query(on: request).filter(\.points == 10_000).set(\.rank, to: 10)
```