### PR TITLE
Fix grouping several filters with `AND` instead of `OR`

### DIFF
--- a/Sources/Fluent/Query/Filter/GroupRelation.swift
+++ b/Sources/Fluent/Query/Filter/GroupRelation.swift
@@ -16,7 +16,7 @@ extension QueryBuilder {
         try closure(sub)
         let filter = QueryFilter(
             entity: Model.entity,
-            method: .group(.or, sub.query.filters)
+            method: .group(relation, sub.query.filters)
         )
         return addFilter(filter)
     }

--- a/Sources/FluentBenchmark/BenchmarkModels.swift
+++ b/Sources/FluentBenchmark/BenchmarkModels.swift
@@ -27,6 +27,17 @@ extension Benchmarker where Database: QuerySupporting {
             self.fail("b.bar should have been updated")
         }
 
+        // make sure that AND queries work as expected - this query should return exactly one result
+        let fetchedWithAndQuery = try test(Foo<Database>.query(on: conn)
+            .group(.and) { and in
+                and.filter(\Foo.bar == "asdf")
+                and.filter(\Foo.baz == 42)
+            }
+            .all())
+        if fetchedWithAndQuery.count != 1 {
+            self.fail("fetchedWithAndQuery.count = \(fetchedWithAndQuery.count), should be 1")
+        }
+
         let c = try test(b.delete(on: conn))
         if c.id != nil {
             self.fail("id should have been set to nil")

--- a/Sources/FluentBenchmark/BenchmarkModels.swift
+++ b/Sources/FluentBenchmark/BenchmarkModels.swift
@@ -38,6 +38,17 @@ extension Benchmarker where Database: QuerySupporting {
             self.fail("fetchedWithAndQuery.count = \(fetchedWithAndQuery.count), should be 1")
         }
 
+        // make sure that OR queries work as expected - this query should return exactly two results
+        let fetchedWithOrQuery = try test(Foo<Database>.query(on: conn)
+            .group(.or) { or in
+                or.filter(\Foo.bar == "asdf")
+                or.filter(\Foo.bar == "fdsa")
+            }
+            .all())
+        if fetchedWithOrQuery.count != 2 {
+            self.fail("fetchedWithOrQuery.count = \(fetchedWithOrQuery.count), should be 2")
+        }
+
         let c = try test(b.delete(on: conn))
         if c.id != nil {
             self.fail("id should have been set to nil")


### PR DESCRIPTION
This bug can have a severe impact — imagine a query like `userID = 123 AND string LIKE '%foo%'` returning **_every_** user's data instead of just the **_current_** user's! I think there should really be tests to spot issues like this.