### PR TITLE
Add a test to ensure that `AND` queries actually do an `AND` query

### DIFF
--- a/Sources/FluentBenchmark/BenchmarkModels.swift
+++ b/Sources/FluentBenchmark/BenchmarkModels.swift
@@ -27,6 +27,17 @@ extension Benchmarker where Database: QuerySupporting {
             self.fail("b.bar should have been updated")
         }
 
+        // make sure that AND queries work as expected - this query should return exactly one result
+        let fetchedWithAndQuery = try test(Foo<Database>.query(on: conn)
+            .group(.and) { and in
+                and.filter(\Foo.bar == "asdf")
+                and.filter(\Foo.baz == 42)
+            }
+            .all())
+        if fetchedWithAndQuery.count != 1 {
+            self.fail("fetchedWithAndQuery.count = \(fetchedWithAndQuery.count), should be 1")
+        }
+
         let c = try test(b.delete(on: conn))
         if c.id != nil {
             self.fail("id should have been set to nil")


### PR DESCRIPTION
... and not an `OR` query. See https://github.com/vapor/fluent/pull/399 for context.