### PR TITLE
Make `BenchmarkTimestampable` care more about fractional-second parts.

### DIFF
--- a/Sources/FluentBenchmark/BenchmarkTimestampable.swift
+++ b/Sources/FluentBenchmark/BenchmarkTimestampable.swift
@@ -13,15 +13,17 @@ extension Benchmarker where Database: QuerySupporting {
         }
 
         _ = try test(tanner.save(on: conn))
-        if tanner.createdAt?.isWithin(seconds: 1, of: Date()) != true {
+        if tanner.createdAt?.isWithin(seconds: 0.1, of: Date()) != true {
             self.fail("timestamps should be current")
         }
 
-        if tanner.updatedAt?.isWithin(seconds: 1, of: Date()) != true {
+        if tanner.updatedAt?.isWithin(seconds: 0.1, of: Date()) != true {
             self.fail("timestamps should be current")
         }
 
         let originalUpdatedAt = tanner.updatedAt!
+        // Ensure that there is a substantial difference between `originalUpdatedAt` and `updatedAt`.
+        Thread.sleep(forTimeInterval: 0.05)
         _ = try test(tanner.save(on: conn))
 
         if tanner.updatedAt! <= originalUpdatedAt {
@@ -34,9 +36,11 @@ extension Benchmarker where Database: QuerySupporting {
             return
         }
 
-        // microsecond rounding
-        if !fetched.createdAt!.isWithin(seconds: 2, of: tanner.createdAt!) && !fetched.updatedAt!.isWithin(seconds: 2, of: tanner.updatedAt!) {
-            self.fail("fetched timestamps are different")
+        if !fetched.createdAt!.isWithin(seconds: 0.002, of: tanner.createdAt!) {
+            self.fail("fetched createdAt timestamp \(fetched.createdAt!.timeIntervalSince1970) is more than 2ms different from expected value \(tanner.createdAt!.timeIntervalSince1970)")
+        }
+        if !fetched.updatedAt!.isWithin(seconds: 0.002, of: tanner.updatedAt!) {
+            self.fail("fetched updatedAt timestamp \(fetched.updatedAt!.timeIntervalSince1970) is more than 2ms different from expected value \(tanner.updatedAt!.timeIntervalSince1970)")
         }
     }
 
@@ -64,11 +68,7 @@ extension Benchmarker where Database: QuerySupporting & SchemaSupporting {
 
 extension Date {
     public func isWithin(seconds: Double, of other: Date) -> Bool {
-        var diff = other.timeIntervalSince1970 - self.timeIntervalSince1970
-        if diff < 0 {
-            diff = diff * -1.0
-        }
-        return diff <= seconds
+        return abs(other.timeIntervalSince1970 - self.timeIntervalSince1970) <= seconds
     }
 
     public var unix: Int {


### PR DESCRIPTION
See https://github.com/vapor/postgresql/pull/29.