### PR TITLE
fixing join mapping - take 1

### DIFF
--- a/Sources/Fluent/Query/Builder/QueryBuilder.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder.swift
@@ -19,7 +19,7 @@ public final class QueryBuilder<Model, Result> where Model: Fluent.Model, Model.
         query: DatabaseQuery<Model.Database>,
         on connection: Future<Model.Database.Connection>,
         resultTransformer: @escaping ([QueryField: Model.Database.QueryData], Model.Database.Connection) -> Future<Result>
-    ) {
+        ) {
         self.query = query
         self.connection = connection
         self.resultTransformer = resultTransformer
@@ -69,7 +69,7 @@ public final class QueryBuilder<Model, Result> where Model: Fluent.Model, Model.
     static func make(
         on connection: Future<Model.Database.Connection>,
         with transformer: @escaping ([QueryField: Model.Database.QueryData], Model.Database.Connection) -> Future<Result>
-    ) -> QueryBuilder<Model, Result> {
+        ) -> QueryBuilder<Model, Result> {
         return QueryBuilder(query: DatabaseQuery(entity: Model.entity), on: connection, resultTransformer: { row, conn in
             return transformer(row, conn)
         })
@@ -78,7 +78,7 @@ public final class QueryBuilder<Model, Result> where Model: Fluent.Model, Model.
     /// Replaces the query result handler with the supplied closure.
     func changeResult<NewResult>(
         with transformer: @escaping ([QueryField: Model.Database.QueryData], Model.Database.Connection) -> Future<NewResult>
-    ) -> QueryBuilder<Model, NewResult> {
+        ) -> QueryBuilder<Model, NewResult> {
         return QueryBuilder<Model, NewResult>(query: self.query, on: self.connection, resultTransformer: { row, conn in
             return transformer(row, conn)
         })
@@ -87,7 +87,7 @@ public final class QueryBuilder<Model, Result> where Model: Fluent.Model, Model.
     /// Transforms the previous query result to a new result using the supplied closure.
     func transformResult<NewResult>(
         with transformer: @escaping ([QueryField: Model.Database.QueryData], Model.Database.Connection, Result) -> Future<NewResult>
-    ) -> QueryBuilder<Model, NewResult> {
+        ) -> QueryBuilder<Model, NewResult> {
         return QueryBuilder<Model, NewResult>(query: self.query, on: self.connection, resultTransformer: { row, conn in
             return self.resultTransformer(row, conn).flatMap(to: NewResult.self) { result in
                 return transformer(row, conn, result)
@@ -97,7 +97,7 @@ public final class QueryBuilder<Model, Result> where Model: Fluent.Model, Model.
 
     /// Sets the query to decode type `D` when run.
     public func decode<D>(_ type: D.Type, entity: String = Model.entity) -> QueryBuilder<Model, D> where D: Decodable {
-        let decoder = QueryDataDecoder(Model.Database.self)
+        let decoder = QueryDataDecoder(Model.self)
         return changeResult { row, conn in
             let row = row.onlyValues(forEntity: entity)
             return Future.map(on: conn) {
@@ -109,7 +109,7 @@ public final class QueryBuilder<Model, Result> where Model: Fluent.Model, Model.
     /// Adds an additional type `D` to be decoded when run.
     /// The new result for this query will be a tuple containing the previous result and this new result.
     public func alsoDecode<D>(_ type: D.Type, entity: String) -> QueryBuilder<Model, (Result, D)> where D: Decodable {
-        let decoder = QueryDataDecoder(Model.Database.self)
+        let decoder = QueryDataDecoder(Model.self)
         return transformResult { row, conn, result in
             let row = row.onlyValues(forEntity: entity)
             return Future.map(on: conn) {
@@ -131,7 +131,7 @@ extension Model where Database: QuerySupporting {
     static func query<D>(decoding type: D.Type, on connection: Future<Self.Database.Connection>) -> QueryBuilder<Self, D> where D: Decodable {
         return QueryBuilder<Self, D>.make(on: connection) { row, conn in
             return Future.map(on: conn) {
-                let decoder = QueryDataDecoder(Self.Database.self)
+                let decoder = QueryDataDecoder(Self.self)
                 return try decoder.decode(D.self, from: row)
             }
         }
@@ -146,3 +146,4 @@ extension Model where Database: QuerySupporting {
         }
     }
 }
+

--- a/Sources/Fluent/Query/Codable/QueryDataDecoder.swift
+++ b/Sources/Fluent/Query/Codable/QueryDataDecoder.swift
@@ -1,6 +1,8 @@
 final class QueryDataDecoder<Database> where Database: QuerySupporting {
     var entity: String?
-    init(_ database: Database.Type, entity: String? = nil) { }
+    init(_ database: Database.Type, entity: String? = nil) {
+        self.entity = entity
+    }
     func decode<D>(_ type: D.Type, from data: [QueryField: Database.QueryData]) throws -> D where D: Decodable {
         let decoder = _QueryDataDecoder<Database>(data: data, entity: entity)
         return try D.init(from: decoder)
@@ -54,10 +56,11 @@ fileprivate struct _QueryDataKeyedDecoder<K, Database>: KeyedDecodingContainerPr
     }
 
     func _value(forEntity entity: String?, atField field: String) -> Database.QueryData? {
+        print("Entity is: \(entity ?? "unknown")")
         guard let entity = entity else {
             return decoder.data.firstValue(forField: field)
         }
-        return decoder.data.value(forEntity: entity, atField: field)
+        return decoder.data.value(forEntity: entity, atField: field) ?? decoder.data.firstValue(forField: field)
     }
 
     func _parse<T>(_ type: T.Type, forKey key: K) throws -> T? {

--- a/Sources/Fluent/Query/Codable/QueryDataDecoder.swift
+++ b/Sources/Fluent/Query/Codable/QueryDataDecoder.swift
@@ -1,23 +1,23 @@
-final class QueryDataDecoder<Database> where Database: QuerySupporting {
-    init(_ database: Database.Type) { }
-    func decode<D>(_ type: D.Type, from data: [QueryField: Database.QueryData]) throws -> D where D: Decodable {
-        let decoder = _QueryDataDecoder<Database>(data: data)
+final class QueryDataDecoder<M> where M: Model, M.Database: QuerySupporting {
+    init(_ model: M.Type) { }
+    func decode<D>(_ type: D.Type, from data: [QueryField: M.Database.QueryData]) throws -> D where D: Decodable {
+        let decoder = _QueryDataDecoder<M>(data: data)
         return try D.init(from: decoder)
     }
 }
 
 /// MARK: Private
 
-fileprivate final class _QueryDataDecoder<Database>: Decoder where Database: QuerySupporting {
+fileprivate final class _QueryDataDecoder<M>: Decoder where M: Model, M.Database: QuerySupporting {
     var codingPath: [CodingKey] { return [] }
     var userInfo: [CodingUserInfoKey: Any] { return [:] }
-    var data: [QueryField: Database.QueryData]
-    init(data: [QueryField: Database.QueryData]) {
+    var data: [QueryField: M.Database.QueryData]
+    init(data: [QueryField: M.Database.QueryData]) {
         self.data = data
     }
 
     func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
-        return KeyedDecodingContainer(_QueryDataKeyedDecoder<Key, Database>(decoder: self))
+        return KeyedDecodingContainer(_QueryDataKeyedDecoder<Key, M>(decoder: self))
     }
 
     func unkeyedContainer() throws -> UnkeyedDecodingContainer { throw unsupported() }
@@ -36,28 +36,28 @@ private func unsupported() -> FluentError {
 }
 
 
-fileprivate struct _QueryDataKeyedDecoder<K, Database>: KeyedDecodingContainerProtocol
-    where K: CodingKey, Database: QuerySupporting
+fileprivate struct _QueryDataKeyedDecoder<K, M>: KeyedDecodingContainerProtocol
+    where K: CodingKey, M: Model, M.Database: QuerySupporting
 {
     var allKeys: [K] {
         return decoder.data.keys.compactMap { K(stringValue: $0.name) }
     }
     var codingPath: [CodingKey] { return [] }
-    let decoder: _QueryDataDecoder<Database>
-    init(decoder: _QueryDataDecoder<Database>) {
+    let decoder: _QueryDataDecoder<M>
+    init(decoder: _QueryDataDecoder<M>) {
         self.decoder = decoder
     }
 
     func _parse<T>(_ type: T.Type, forKey key: K) throws -> T? {
-        guard let data = decoder.data.firstValue(forField: key.stringValue) else {
+        guard let data = decoder.data.firstValue(forField: key.stringValue, on: M.entity) else {
             return nil
         }
 
-        return try Database.queryDataParse(T.self, from: data)
+        return try M.Database.queryDataParse(T.self, from: data)
     }
 
     func contains(_ key: K) -> Bool { return decoder.data.keys.contains { $0.name == key.stringValue } }
-    func decodeNil(forKey key: K) throws -> Bool { return decoder.data.firstValue(forField: key.stringValue) == nil }
+    func decodeNil(forKey key: K) throws -> Bool { return decoder.data.firstValue(forField: key.stringValue, on: M.entity) == nil }
     func decodeIfPresent(_ type: Int.Type, forKey key: K) throws -> Int? { return try _parse(Int.self, forKey: key) }
     func decodeIfPresent(_ type: Int8.Type, forKey key: K) throws -> Int8? { return try _parse(Int8.self, forKey: key) }
     func decodeIfPresent(_ type: Int16.Type, forKey key: K) throws -> Int16? { return try _parse(Int16.self, forKey: key) }
@@ -86,3 +86,4 @@ fileprivate struct _QueryDataKeyedDecoder<K, Database>: KeyedDecodingContainerPr
     func superDecoder() throws -> Decoder { return decoder }
     func superDecoder(forKey key: K) throws -> Decoder { return decoder }
 }
+

--- a/Sources/Fluent/Query/QueryField.swift
+++ b/Sources/Fluent/Query/QueryField.swift
@@ -163,4 +163,3 @@ public struct QueryFieldEncodingContainer<Model: Fluent.Model> {
         try container.encode(value, forKey: field)
     }
 }
-

--- a/Sources/Fluent/Query/QueryField.swift
+++ b/Sources/Fluent/Query/QueryField.swift
@@ -43,24 +43,12 @@ extension QueryField: ExpressibleByStringLiteral {
 
 extension Dictionary where Key == QueryField {
     /// Accesses the _first_ value from this dictionary with a matching field name.
-    public func firstValue(forField fieldName: String, on entity: String) -> Value? {
-        print("\n\n\nLooking for: \(entity).\(fieldName) in:")
-        for (field, _) in self {
-            print("\t\(field.entity ?? "unknown").\(field.name)")
-        }
-        for (field, value) in self {
-            if field.name == fieldName && field.entity == entity {
-                print("\n\tFound exact match: \(field.entity ?? "unknown").\(field.name)\n\n\n")
-                return value
-            }
-        }
+    public func firstValue(forField fieldName: String) -> Value? {
         for (field, value) in self {
             if field.name == fieldName {
-                print("\n\tFound match: \(field.entity ?? "unknown").\(field.name)\n\n\n")
                 return value
             }
         }
-        print("\tNot found\n\n\n")
         return nil
     }
 

--- a/Sources/Fluent/Query/QueryField.swift
+++ b/Sources/Fluent/Query/QueryField.swift
@@ -43,12 +43,24 @@ extension QueryField: ExpressibleByStringLiteral {
 
 extension Dictionary where Key == QueryField {
     /// Accesses the _first_ value from this dictionary with a matching field name.
-    public func firstValue(forField fieldName: String) -> Value? {
+    public func firstValue(forField fieldName: String, on entity: String) -> Value? {
+        print("\n\n\nLooking for: \(entity).\(fieldName) in:")
+        for (field, _) in self {
+            print("\t\(field.entity ?? "unknown").\(field.name)")
+        }
         for (field, value) in self {
-            if field.name == fieldName {
+            if field.name == fieldName && field.entity == entity {
+                print("\n\tFound exact match: \(field.entity ?? "unknown").\(field.name)\n\n\n")
                 return value
             }
         }
+        for (field, value) in self {
+            if field.name == fieldName {
+                print("\n\tFound match: \(field.entity ?? "unknown").\(field.name)\n\n\n")
+                return value
+            }
+        }
+        print("\tNot found\n\n\n")
         return nil
     }
 
@@ -140,7 +152,7 @@ extension Model where ID: KeyStringDecodable {
 public struct QueryFieldDecodingContainer<Model> where Model: Fluent.Model {
     /// The underlying container.
     public var container: KeyedDecodingContainer<QueryField>
-    
+
     /// Decodes a model key path to a type.
     public func decode<T: Decodable>(key: KeyPath<Model, T>) throws -> T where T: KeyStringDecodable {
         let field = try key.makeQueryField()
@@ -163,3 +175,4 @@ public struct QueryFieldEncodingContainer<Model: Fluent.Model> {
         try container.encode(value, forKey: field)
     }
 }
+

--- a/Sources/Fluent/Query/QueryField.swift
+++ b/Sources/Fluent/Query/QueryField.swift
@@ -140,7 +140,7 @@ extension Model where ID: KeyStringDecodable {
 public struct QueryFieldDecodingContainer<Model> where Model: Fluent.Model {
     /// The underlying container.
     public var container: KeyedDecodingContainer<QueryField>
-
+    
     /// Decodes a model key path to a type.
     public func decode<T: Decodable>(key: KeyPath<Model, T>) throws -> T where T: KeyStringDecodable {
         let field = try key.makeQueryField()


### PR DESCRIPTION
I had to pass the info about the model down the generics chain ...

In the `firstValue` method I now first try to check for the "main" id and then have a fallback onto any "foreign" keys to the model. Obvious downside to this is that you won't be able to get a join field with the same name as you may have in the "main" table but its still an improvement me thinks ...

Sorry for the whitespaces, stupid copy/paste from my projects dependencies ... will remove if you confirm I am on the right path ...