### PR TITLE
operation pipelining

### DIFF
--- a/Sources/Fluent/Database/DatabaseConnection.swift
+++ b/Sources/Fluent/Database/DatabaseConnection.swift
@@ -9,3 +9,60 @@ extension DatabaseConnection {
         return M.query(on: Future.map(on: self) { self })
     }
 }
+
+fileprivate final class PipelineCache {
+    var storage: [ObjectIdentifier: Future<Void>]
+    init() { storage = [:] }
+}
+
+fileprivate var pipelineCache: ThreadSpecificVariable<PipelineCache> = .init()
+
+extension DatabaseConnection {
+    fileprivate var pipeline: Future<Void> {
+        get {
+            let cache: PipelineCache
+            if let existing = pipelineCache.currentValue {
+                cache = existing
+            } else {
+                cache = .init()
+                pipelineCache.currentValue = cache
+            }
+
+            let pipeline: Future<Void>
+            if let existing = cache.storage[.init(self)] {
+                pipeline = existing
+            } else {
+                pipeline = Future.map(on: self) { }
+                cache.storage[.init(self)] = pipeline
+            }
+            return pipeline
+        }
+        set {
+            let cache: PipelineCache
+            if let existing = pipelineCache.currentValue {
+                cache = existing
+            } else {
+                cache = .init()
+                pipelineCache.currentValue = cache
+            }
+            cache.storage[.init(self)] = newValue
+        }
+    }
+
+    /// Enqueues a Fluent operation.
+    internal func fluentOperation<T>(_ work: @escaping () -> Future<T>) -> Future<T> {
+        /// perform this work when the current pipeline future is completed
+        let new = pipeline.flatMap(to: T.self) {
+            work()
+        }
+
+        /// append this work to the pipeline, discarding errors as the pipeline
+        /// does not care about them
+        pipeline = new.transform(to: ()).catchMap { err in
+            return ()
+        }
+
+        /// return the newly enqueued work's future result
+        return new
+    }
+}

--- a/Sources/Fluent/Migration/Migration.swift
+++ b/Sources/Fluent/Migration/Migration.swift
@@ -1,4 +1,4 @@
-import CodableKit
+import Core
 import Async
 
 /// Declares a database migration.
@@ -24,19 +24,29 @@ public protocol Migration {
 extension Model where Database: SchemaSupporting {
     /// Automatically adds `SchemaField`s for each of this `Model`s properties.
     public static func addProperties(to builder: SchemaCreator<Self>) throws {
-        let idCodingPath = try Self.codingPath(forKey: idKey)
-        let properties = try Self.properties()
+        let idProperty = try Self.reflectProperty(forKey: idKey)
+        let properties = try Self.reflectProperties()
 
         for property in properties {
-            guard property.codingPath.count == 1 else {
+            guard property.path.count == 1 else {
                 continue
             }
 
+            let type: Any.Type
+            let isOptional: Bool
+            if let o = property.type as? AnyOptionalType.Type {
+                type = o.anyWrappedType
+                isOptional = true
+            } else {
+                type = property.type
+                isOptional = false
+            }
+
             let field = try SchemaField<Database>(
-                name: property.codingPath[0].stringValue,
-                type: Database.fieldType(for: property.type),
-                isOptional: property.isOptional,
-                isIdentifier: property.codingPath.equals(idCodingPath)
+                name: property.path.first ?? "",
+                type: Database.fieldType(for: type),
+                isOptional: isOptional,
+                isIdentifier: property.path == idProperty.path
             )
             builder.schema.addFields.append(field)
         }

--- a/Sources/Fluent/Model/ID.swift
+++ b/Sources/Fluent/Model/ID.swift
@@ -8,28 +8,3 @@ public protocol ID: Codable, Equatable, KeyStringDecodable { }
 extension Int: ID { }
 extension String: ID { }
 extension UUID: ID { }
-
-
-/// MARK: String
-
-extension Int: StringDecodable {
-    /// See StringDecodable.decode
-    public static func decode(from string: String) -> Int? {
-        return Int(string)
-    }
-}
-
-extension UUID: StringDecodable {
-    /// See StringDecodable.decode
-    public static func decode(from string: String) -> UUID? {
-        return UUID(uuidString: string)
-    }
-}
-
-extension String: StringDecodable {
-    /// See StringDecodable.decode
-    public static func decode(from string: String) -> String? {
-        return string
-    }
-}
-

--- a/Sources/Fluent/Model/Model.swift
+++ b/Sources/Fluent/Model/Model.swift
@@ -1,13 +1,14 @@
 import Async
-import CodableKit
+import Core
 import Service
+import CodableKit
 
 /// Fluent database models. These types can be fetched
 /// from a database connection using a query.
 ///
 /// Types conforming to this protocol provide the basis
 /// fetching and saving data to/from Fluent.
-public protocol Model: AnyModel {
+public protocol Model: AnyModel, Reflectable {
     /// The type of database this model can be queried on.
     associatedtype Database: Fluent.Database
 

--- a/Sources/Fluent/Model/SoftDeletable.swift
+++ b/Sources/Fluent/Model/SoftDeletable.swift
@@ -1,4 +1,4 @@
-import CodableKit
+import Core
 import Async
 import Foundation
 
@@ -90,7 +90,7 @@ extension SoftDeletable {
     public static func deletedAtField() throws -> QueryField {
         return QueryField(
             entity: entity,
-            name: try Self.codingPath(forKey: deletedAtKey)[0].stringValue
+            name: try Self.reflectProperty(forKey: deletedAtKey).path.first ?? ""
         )
     }
 }

--- a/Sources/FluentBenchmark/BenchmarkBugs.swift
+++ b/Sources/FluentBenchmark/BenchmarkBugs.swift
@@ -37,13 +37,16 @@ extension Benchmarker where Database: QuerySupporting {
     fileprivate func _benchmark(on conn: Database.Connection) throws {
         let one = BasicUser<Database>(name: "one")
         let two = BasicUser<Database>(name: "two")
+        let three = BasicUser<Database>(name: "three")
 
-        let res = try test([
+        _ = try test([
             one.save(on: conn),
-            two.save(on: conn)
+            two.save(on: conn),
+            three.save(on: conn),
         ].flatten(on: conn))
-        print(one.id)
-        print(two.id)
+        if one.id == two.id || one.id == three.id || two.id == three.id {
+            fail("ids are equal")
+        }
     }
 
     /// Benchmark the Timestampable protocol
@@ -59,7 +62,6 @@ extension Benchmarker where Database: QuerySupporting & SchemaSupporting {
     /// The schema will be prepared first.
     public func benchmarkBugs_withSchema() throws {
         let conn = try test(pool.requestConnection())
-        try? test(BasicUser<Database>.revert(on: conn))
         try test(BasicUser<Database>.prepare(on: conn))
         defer { try? test(BasicUser<Database>.revert(on: conn)) }
         try self._benchmark(on: conn)

--- a/Sources/FluentBenchmark/BenchmarkBugs.swift
+++ b/Sources/FluentBenchmark/BenchmarkBugs.swift
@@ -1,0 +1,68 @@
+import Async
+import Service
+import Dispatch
+import Fluent
+import Foundation
+
+
+final class BasicUser<D>:  Model where D: QuerySupporting {
+    /// See Model.Database
+    typealias Database = D
+
+    /// See Model.ID
+    typealias ID = Int
+
+    /// See Model.idKey
+    static var idKey: IDKey { return \.id }
+
+    static var entity: String { return "b_users" }
+
+    /// Foo's identifier
+    var id: Int?
+
+    /// Name string
+    var name: String
+
+    /// Creates a new `BasicUser`
+    init(id: Int? = nil, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+extension BasicUser: Migration where D: SchemaSupporting { }
+
+extension Benchmarker where Database: QuerySupporting {
+    /// The actual benchmark.
+    fileprivate func _benchmark(on conn: Database.Connection) throws {
+        let one = BasicUser<Database>(name: "one")
+        let two = BasicUser<Database>(name: "two")
+
+        let res = try test([
+            one.save(on: conn),
+            two.save(on: conn)
+        ].flatten(on: conn))
+        print(one.id)
+        print(two.id)
+    }
+
+    /// Benchmark the Timestampable protocol
+    public func benchmarkBugs() throws {
+        let conn = try test(pool.requestConnection())
+        try self._benchmark(on: conn)
+        pool.releaseConnection(conn)
+    }
+}
+
+extension Benchmarker where Database: QuerySupporting & SchemaSupporting {
+    /// Benchmark the Timestampable protocol
+    /// The schema will be prepared first.
+    public func benchmarkBugs_withSchema() throws {
+        let conn = try test(pool.requestConnection())
+        try? test(BasicUser<Database>.revert(on: conn))
+        try test(BasicUser<Database>.prepare(on: conn))
+        defer { try? test(BasicUser<Database>.revert(on: conn)) }
+        try self._benchmark(on: conn)
+        pool.releaseConnection(conn)
+    }
+}

--- a/circle.yml
+++ b/circle.yml
@@ -32,8 +32,8 @@ jobs:
       - image: codevapor/swift:4.1
       - image: circleci/postgres:latest
         environment:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
+          POSTGRES_USER: vapor_username
+          POSTGRES_DB: vapor_database
           POSTGRES_PASSWORD: ""
     steps:
       - run:


### PR DESCRIPTION
Some fluent operations may span multiple database queries. These operations must be pipelined correctly to avoid incorrect query results. This PR adds a new `fluentOperation` method to all fluent `DatabaseConnection`s that allows Fluent to express operations that must happen as one unit. 

- [x] Fixes #411.