### PR TITLE
pivot and subset operator fixes

### DIFF
--- a/Sources/Fluent/Pivot/Pivot.swift
+++ b/Sources/Fluent/Pivot/Pivot.swift
@@ -1,3 +1,16 @@
+/// The string to use when connecting entity names for pivot tables.
+///
+/// A pivot name connector of `"_"` would derive the following name for a pivot on `Pet` and `User`.
+///
+///     pet_user
+///
+/// You can change the `pivotNameConnector` by updating the global variable.
+///
+///     Fluent.pivotNameConnector = "+"
+///
+/// Note: Changing the `pivotNameConnector` requires that you also update any pivot tables in your database.
+public var pivotNameConnector: String = "_"
+
 /// Capable of being a pivot between two
 /// models. Usually in a Siblings relation.
 /// note: special care must be taken when using pivots
@@ -40,9 +53,9 @@ extension Pivot {
     /// See Model.entity
     public static var name: String {
         if Left.name < Right.name {
-            return "\(Left.name)_\(Right.name)"
+            return Left.name + pivotNameConnector + Right.name
         } else {
-            return "\(Right.name)_\(Left.name)"
+            return Right.name + pivotNameConnector + Left.name
         }
     }
 

--- a/Sources/Fluent/Query/Filter/QueryFilter.swift
+++ b/Sources/Fluent/Query/Filter/QueryFilter.swift
@@ -78,6 +78,7 @@ public struct QueryFilterValue<Database> where Database: QuerySupporting {
         case data(Database.QueryData)
         case array([Database.QueryData])
         case subquery(DatabaseQuery<Database>)
+        case none
     }
 
     /// Internal storage.
@@ -119,6 +120,11 @@ public struct QueryFilterValue<Database> where Database: QuerySupporting {
     /// A sub query.
     public static func subquery(_ subquery: DatabaseQuery<Database>) -> QueryFilterValue<Database> {
         return .init(storage: .subquery(subquery))
+    }
+
+    /// No value.
+    public static func none() -> QueryFilterValue<Database> {
+        return .init(storage: .none)
     }
 }
 

--- a/Sources/FluentBenchmark/BenchmarkContains.swift
+++ b/Sources/FluentBenchmark/BenchmarkContains.swift
@@ -31,6 +31,16 @@ extension Benchmarker where Database: QuerySupporting, Database.QueryFilter: Dat
         if ns != 3 {
             fail("ns == \(tas)")
         }
+
+        let nertan = try test(User<Database>.query(on: conn).filter(\.name ~~ ["ner", "tan"]).count())
+        if nertan != 2 {
+            fail("nertan == \(tas)")
+        }
+
+        let notner = try test(User<Database>.query(on: conn).filter(\.name !~ ["ner"]).count())
+        if notner != 2 {
+            fail("nertan == \(tas)")
+        }
     }
 
     /// Benchmark fluent contains.

--- a/Sources/FluentSQL/QueryComparison.swift
+++ b/Sources/FluentSQL/QueryComparison.swift
@@ -113,7 +113,7 @@ private func _contains<M, V>(_ key: KeyPath<M, V>, _ comp: DataPredicateComparis
     let filter = try QueryFilter<M.Database>(
         field: key.makeQueryField(),
         type: .custom(.convertFromDataPredicateComparison(comp)),
-        value: .data(value)
+        value: value
     )
     return ModelFilter<M>(filter: filter)
 }

--- a/Sources/FluentSQL/QueryComparison.swift
+++ b/Sources/FluentSQL/QueryComparison.swift
@@ -94,7 +94,11 @@ public func ~~ <Model, Value>(lhs: KeyPath<Model, Value>, rhs: String) throws ->
 public func ~~ <Model, Value>(lhs: KeyPath<Model, Value>, rhs: [Value]) throws -> ModelFilter<Model>
     where Value: KeyStringDecodable, Model.Database.QueryFilter: DataPredicateComparisonConvertible
 {
-    return try _contains(lhs, .in, .array(rhs))
+    switch rhs.count {
+    case 0: return try _contains(lhs, .sql("false"), .none())
+    case 1: return try _contains(lhs, .equal, .data(rhs[0]))
+    default: return try _contains(lhs, .in, .array(rhs))
+    }
 }
 
 infix operator !~
@@ -103,7 +107,11 @@ infix operator !~
 public func !~ <Model, Value>(lhs: KeyPath<Model, Value>, rhs: [Value]) throws -> ModelFilter<Model>
     where Value: KeyStringDecodable, Model.Database.QueryFilter: DataPredicateComparisonConvertible
 {
-    return try _contains(lhs, .in, .array(rhs))
+    switch rhs.count {
+    case 0: return try _contains(lhs, .sql("true"), .none())
+    case 1: return try _contains(lhs, .notEqual, .data(rhs[0]))
+    default: return try _contains(lhs, .notIn, .array(rhs))
+    }
 }
 
 /// Operator helper func.

--- a/Sources/FluentSQL/QueryComparison.swift
+++ b/Sources/FluentSQL/QueryComparison.swift
@@ -71,7 +71,7 @@ extension QueryFilterValue {
 public func ~= <Model, Value>(lhs: KeyPath<Model, Value>, rhs: String) throws -> ModelFilter<Model>
     where Value: KeyStringDecodable, Model.Database.QueryFilter: DataPredicateComparisonConvertible
 {
-    return try _contains(lhs, .like, "%\(rhs)")
+    return try _contains(lhs, .like, .data("%\(rhs)"))
 }
 
 infix operator =~
@@ -79,7 +79,7 @@ infix operator =~
 public func =~ <Model, Value>(lhs: KeyPath<Model, Value>, rhs: String) throws -> ModelFilter<Model>
     where Value: KeyStringDecodable, Model.Database.QueryFilter: DataPredicateComparisonConvertible
 {
-    return try _contains(lhs, .like, "\(rhs)%")
+    return try _contains(lhs, .like, .data("\(rhs)%"))
 }
 
 infix operator ~~
@@ -87,14 +87,14 @@ infix operator ~~
 public func ~~ <Model, Value>(lhs: KeyPath<Model, Value>, rhs: String) throws -> ModelFilter<Model>
     where Value: KeyStringDecodable, Model.Database.QueryFilter: DataPredicateComparisonConvertible
 {
-    return try _contains(lhs, .like, "%\(rhs)%")
+    return try _contains(lhs, .like, .data("%\(rhs)%"))
 }
 
 /// Subset: IN.
 public func ~~ <Model, Value>(lhs: KeyPath<Model, Value>, rhs: [Value]) throws -> ModelFilter<Model>
     where Value: KeyStringDecodable, Model.Database.QueryFilter: DataPredicateComparisonConvertible
 {
-    return try _contains(lhs, .in, rhs)
+    return try _contains(lhs, .in, .array(rhs))
 }
 
 infix operator !~
@@ -103,11 +103,11 @@ infix operator !~
 public func !~ <Model, Value>(lhs: KeyPath<Model, Value>, rhs: [Value]) throws -> ModelFilter<Model>
     where Value: KeyStringDecodable, Model.Database.QueryFilter: DataPredicateComparisonConvertible
 {
-    return try _contains(lhs, .in, rhs)
+    return try _contains(lhs, .in, .array(rhs))
 }
 
 /// Operator helper func.
-private func _contains<M, V, T>(_ key: KeyPath<M, V>, _ comp: DataPredicateComparison, _ value: T) throws -> ModelFilter<M>
+private func _contains<M, V>(_ key: KeyPath<M, V>, _ comp: DataPredicateComparison, _ value: QueryFilterValue<M.Database>) throws -> ModelFilter<M>
     where V: KeyStringDecodable, M.Database.QueryFilter: DataPredicateComparisonConvertible
 {
     let filter = try QueryFilter<M.Database>(


### PR DESCRIPTION
- [x] adds a global `pivotNameConnector` for changing how pivot table names are generated
- [x] adds `!~` and `~~` operators for in/not-in subset filtering.
- [x] fixes #407, fixes #415, fixes #402 