### PR TITLE
Fix EXC_BAD_ACCESS in multi-threaded MySQL writes

### DIFF
--- a/Sources/Fluent/Model/Model.swift
+++ b/Sources/Fluent/Model/Model.swift
@@ -70,8 +70,14 @@ extension Model where Database: QuerySupporting {
 extension Model {
     /// Access the fluent identifier
     public var fluentID: ID? {
-        get { return self[keyPath: Self.idKey] }
-        set { self[keyPath: Self.idKey] = newValue }
+        get {
+            let path = Self.idKey
+            return self[keyPath: path]
+        }
+        set {
+            let path = Self.idKey
+            self[keyPath: path] = newValue
+        }
     }
 }
 


### PR DESCRIPTION
I have been doing extensive performance testing of FluentMySQL models and hit upon a 100% reproducible synchronization bug that appears to be a Swift compiler issue. Language version:

```
Apple Swift version 4.1 (swiftlang-902.0.48 clang-902.0.37.1)
Target: x86_64-apple-darwin17.4.0
```

Observations:
- I am saturating the Application with requests that each perform a simple model creation:
   `Category(name: self.name).save(on: req)`
- When 2 or more of the requests overlap in Database.ModelEvent.didCreate (when the fluentId is written to with the LAST_INSERT_ID), the process crashes with an EXC_BAD_ADDRESS in the key path setter for MySQLModel.id. 
<img width="1408" alt="screen shot 2018-04-01 at 9 22 28 am" src="https://user-images.githubusercontent.com/80599/38175394-a088c03e-3590-11e8-922a-5f3739cf58d9.png">

- In testing, this usually occurs between the 70th and 150th db write, so it's a high-frequency synchronization issue occurring on ~1% of database creates. 
- Turning on Xcode's Thread Sanitizer feature eliminates the bug, which tells me it's a compiler issue.
- After further debugging, the crash occurs on accessing Self.idKey as part of the fluentId setter. 
- However, accessing it and storing it in a local variable before the keyPath access is invoked eliminates the crash, hence the proposed fix.

Recommendation:
- Unfortunately, it is not possible to develop a minimal test case that guarantees reproduction (or elimination) of the issue in bounded time.
- Given how innocuous the fix is, I strongly suggest this patch be accepted even though there is no clear explanation for what is causing the crash or why this fixes it. My best guess is that the compiler is over-aggressively optimizing the single-line implementation, and encountering a synchronization bug in the protocol witness table used to dynamically dispatch the Self.idKey call. 