### PR TITLE
Fix Timestampable when the models are structs.

### DIFF
--- a/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
@@ -23,7 +23,7 @@ extension QueryBuilder {
             let now = Date()
             timestampable.fluentUpdatedAt = now
             timestampable.fluentCreatedAt = now
-            copy = model
+            copy = timestampable as! Model
         } else {
             copy = model
         }
@@ -69,7 +69,7 @@ extension QueryBuilder {
         let copy: Model
         if var timestampable = model as? AnyTimestampable {
             timestampable.fluentUpdatedAt = Date()
-            copy = model
+            copy = timestampable as! Model
         } else {
             copy = model
         }

--- a/Sources/FluentBenchmark/Bar.swift
+++ b/Sources/FluentBenchmark/Bar.swift
@@ -2,7 +2,7 @@ import Async
 import Fluent
 import Foundation
 
-struct Bar<D>: Model, SoftDeletable where D: QuerySupporting {
+struct Bar<D>: Model, SoftDeletable, Timestampable where D: QuerySupporting {
     /// See Model.Database
     typealias Database = D
 
@@ -15,7 +15,17 @@ struct Bar<D>: Model, SoftDeletable where D: QuerySupporting {
     /// See Model.idKey
     static var idKey: IDKey { return \.id }
 
-    /// See SoftDeletable.deletedAtKey
+    /// See `Timestampable.createdAtKey`
+    static var createdAtKey: CreatedAtKey {
+        return \.createdAt
+    }
+
+    /// See `Timestampable.updatedAtKey`
+    static var updatedAtKey: UpdatedAtKey {
+        return \.updatedAt
+    }
+
+    /// See `SoftDeletable.deletedAtKey`
     static var deletedAtKey: DeletedAtKey {
         return \.deletedAt
     }
@@ -25,6 +35,12 @@ struct Bar<D>: Model, SoftDeletable where D: QuerySupporting {
 
     /// Test integer
     var baz: Int
+
+    /// See `Timestampable.createdAt`
+    var createdAt: Date?
+
+    /// See `Timestampable.updatedAt`
+    var updatedAt: Date?
 
     /// See `SoftDeletable.deletedAt`
     var deletedAt: Date?

--- a/Sources/FluentBenchmark/BenchmarkTimestampable.swift
+++ b/Sources/FluentBenchmark/BenchmarkTimestampable.swift
@@ -4,44 +4,81 @@ import Fluent
 import Foundation
 
 extension Benchmarker where Database: QuerySupporting {
-    /// The actual benchmark.
-    fileprivate func _benchmark(on conn: Database.Connection) throws {
-        // create
+    private func _benchmarkStruct(on conn: Database.Connection) throws {
+        var bar = Bar<Database>(baz: 1)
+        if bar.createdAt != nil || bar.updatedAt != nil {
+            fail("timestamps should be nil")
+        }
+
+        bar = try test(bar.save(on: conn))
+        guard let originalCreatedAt = bar.createdAt, let originalUpdatedAt = bar.updatedAt else {
+            fail("timestamps should exist after saving")
+            return
+        }
+        if !originalCreatedAt.isWithin(seconds: 0.1, of: Date()) ||
+           !originalUpdatedAt.isWithin(seconds: 0.1, of: Date()) {
+            fail("timestamps should be current")
+        }
+
+        // Ensure that there is a substantial difference between `originalUpdatedAt` and `updatedAt`.
+        Thread.sleep(forTimeInterval: 0.05)
+        bar = try test(bar.save(on: conn))
+        if bar.updatedAt! <= originalUpdatedAt {
+            fail("new updated at should be greater")
+        }
+
+        let f = try test(conn.query(Bar<Database>.self).filter(\.baz == 1).first())
+        guard let fetched = f else {
+            fail("could not fetch bar")
+            return
+        }
+
+        if !fetched.createdAt!.isWithin(seconds: 0.002, of: bar.createdAt!) ||
+           !fetched.updatedAt!.isWithin(seconds: 0.002, of: bar.updatedAt!) {
+            fail("fetched timestamps are >= 2ms different from expected according to model")
+        }
+    }
+
+    private func _benchmarkClass(on conn: Database.Connection) throws {
         let tanner = User<Database>(name: "Tanner", age: 23)
         if tanner.createdAt != nil || tanner.updatedAt != nil {
-            self.fail("timestamps should have been nil")
+            fail("timestamps should be nil")
         }
 
         _ = try test(tanner.save(on: conn))
-        if tanner.createdAt?.isWithin(seconds: 0.1, of: Date()) != true {
-            self.fail("timestamps should be current")
+        guard let originalCreatedAt = tanner.createdAt,
+              let originalUpdatedAt = tanner.updatedAt else {
+            fail("timestamps should exist after saving")
+            return
+        }
+        if !originalCreatedAt.isWithin(seconds: 0.1, of: Date()) ||
+           !originalUpdatedAt.isWithin(seconds: 0.1, of: Date()) {
+            fail("timestamps should be current")
         }
 
-        if tanner.updatedAt?.isWithin(seconds: 0.1, of: Date()) != true {
-            self.fail("timestamps should be current")
-        }
-
-        let originalUpdatedAt = tanner.updatedAt!
         // Ensure that there is a substantial difference between `originalUpdatedAt` and `updatedAt`.
         Thread.sleep(forTimeInterval: 0.05)
         _ = try test(tanner.save(on: conn))
-
         if tanner.updatedAt! <= originalUpdatedAt {
             self.fail("new updated at should be greater")
         }
-        
+
         let f = try test(conn.query(User<Database>.self).filter(\.name == "Tanner").first())
         guard let fetched = f else {
             self.fail("could not fetch user")
             return
         }
 
-        if !fetched.createdAt!.isWithin(seconds: 0.002, of: tanner.createdAt!) {
-            self.fail("fetched createdAt timestamp \(fetched.createdAt!.timeIntervalSince1970) is more than 2ms different from expected value \(tanner.createdAt!.timeIntervalSince1970)")
+        if !fetched.createdAt!.isWithin(seconds: 0.002, of: tanner.createdAt!) ||
+           !fetched.updatedAt!.isWithin(seconds: 0.002, of: tanner.updatedAt!) {
+            fail("fetched timestamps are >= 2ms different from expected according to model")
         }
-        if !fetched.updatedAt!.isWithin(seconds: 0.002, of: tanner.updatedAt!) {
-            self.fail("fetched updatedAt timestamp \(fetched.updatedAt!.timeIntervalSince1970) is more than 2ms different from expected value \(tanner.updatedAt!.timeIntervalSince1970)")
-        }
+    }
+
+    /// The actual benchmark.
+    fileprivate func _benchmark(on conn: Database.Connection) throws {
+        try _benchmarkStruct(on: conn)
+        try _benchmarkClass(on: conn)
     }
 
     /// Benchmark the Timestampable protocol
@@ -57,9 +94,11 @@ extension Benchmarker where Database: QuerySupporting & SchemaSupporting {
     /// The schema will be prepared first.
     public func benchmarkTimestampable_withSchema() throws {
         let conn = try test(pool.requestConnection())
+        try test(Bar<Database>.prepare(on: conn))
         try test(UserMigration<Database>.prepare(on: conn))
         defer {
             try? test(UserMigration<Database>.revert(on: conn))
+            try? test(Bar<Database>.revert(on: conn))
         }
         try self._benchmark(on: conn)
         pool.releaseConnection(conn)


### PR DESCRIPTION
Fixes #444.

Use the same strategy, `as!`, that is used for `SoftDeletable`.

If there are tests that I can/should add to a different repository, please let me know.