### PR TITLE
Add a dependency to CacheKit.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/service.git", from: "1.0.0-rc.2"),
     ],
     targets: [
-        .target(name: "Fluent", dependencies: ["Async", "Console", "Command", "Core", "DatabaseKit", "Logging", "Service"]),
+        .target(name: "Fluent", dependencies: ["Async", "CacheKit", "Console", "Command", "Core", "DatabaseKit", "Logging", "Service"]),
         .testTarget(name: "FluentTests", dependencies: ["FluentBenchmark", "FluentSQL"]),
         .target(name: "FluentBenchmark", dependencies: ["Fluent", "FluentSQL"]),
         .target(name: "FluentSQL", dependencies: ["Fluent", "SQL"]),

--- a/Sources/Fluent/Cache/FluentCache.swift
+++ b/Sources/Fluent/Cache/FluentCache.swift
@@ -1,4 +1,5 @@
 import Async
+import CacheKit
 import Foundation
 import Service
 


### PR DESCRIPTION
This is required to build Fluent's `FluentCache.swift` after b674c2c8804aa3a698e647b38843cfcd43e83a2b. CI should pass once https://github.com/vapor/database-kit/pull/30 is merged.

/cc @pedantix