### PR TITLE
Lifecycle Hooks

### DIFF
--- a/Sources/Fluent/Model/Model.swift
+++ b/Sources/Fluent/Model/Model.swift
@@ -43,6 +43,8 @@ public protocol Model: AnyModel, Reflectable {
     /// Called before a model is deleted.
     /// Throwing will cancel the deletion.
     func willDelete(on connection: Database.Connection) throws -> Future<Self>
+    /// Called after a model has been deleted.
+    func didDelete(on connection: Database.Connection) throws -> Future<Void>
 }
 
 /// Type-erased model.
@@ -120,6 +122,11 @@ extension Model {
     /// See Model.willDelete()
     public func willDelete(on connection: Database.Connection) throws -> Future<Self> {
         return Future.map(on: connection) { self }
+    }
+    
+    /// See Model.didDelete()
+    public func didDelete(on connection: Database.Connection) throws -> Future<Void> {
+        return .done(on: connection)
     }
 }
 

--- a/Sources/Fluent/Query/QuerySupporting.swift
+++ b/Sources/Fluent/Query/QuerySupporting.swift
@@ -44,4 +44,5 @@ public enum ModelEvent {
     case didUpdate
     case willRead
     case willDelete
+    case didDelete
 }

--- a/Sources/FluentBenchmark/BenchmarkLifecycleHooks.swift
+++ b/Sources/FluentBenchmark/BenchmarkLifecycleHooks.swift
@@ -1,0 +1,115 @@
+import Async
+import Service
+import Dispatch
+import Fluent
+import Foundation
+
+extension Benchmarker where Database: QuerySupporting {
+    fileprivate func _benchmark(on conn: Database.Connection) throws {
+        //create a lifecycle user
+        let user = LifecycleUser<Database>(name: "user")
+        _ = try test(user.save(on: conn))
+        
+        if !LifecycleUserStateTracking.willCreateCalled || !LifecycleUserStateTracking.didCreateCalled {
+            self.fail("willCreate and didCreate should be called")
+        }
+        
+        //update the user
+        user.name =  "new name"
+        _ = try test(user.save(on: conn))
+        
+        if !LifecycleUserStateTracking.willUpdateCalled || !LifecycleUserStateTracking.didUpdateCalled {
+            self.fail("willUpdate and didUpdate should be called")
+        }
+        
+        //delete the user
+        _ = try test(user.delete(on: conn))
+        
+        if !LifecycleUserStateTracking.willDeleteCalled || !LifecycleUserStateTracking.didDeleteCalled {
+            self.fail("willDelete and didDelete should be called")
+        }
+    }
+    
+    public func benchmarkLifecycle() throws {
+        let conn = try test(pool.requestConnection())
+        try self._benchmark(on: conn)
+        pool.releaseConnection(conn)
+    }
+}
+
+extension Benchmarker where Database: QuerySupporting & SchemaSupporting {
+    /// Benchmarks misc bugs, preparing the schema first.
+    public func benchmarkLifecycleHooks_withSchema() throws {
+        let conn = try test(pool.requestConnection())
+        try test(LifecycleUser<Database>.prepare(on: conn))
+        defer { try? test(LifecycleUser<Database>.revert(on: conn)) }
+        try self._benchmark(on: conn)
+        pool.releaseConnection(conn)
+    }
+}
+
+final class LifecycleUser<D>:  Model where D: QuerySupporting {
+    /// See Model.Database
+    typealias Database = D
+    
+    /// See Model.ID
+    typealias ID = Int
+    
+    /// See Model.idKey
+    static var idKey: IDKey { return \.id }
+    
+    static var entity: String { return "lifecycle_users" }
+    
+    /// Foo's identifier
+    var id: Int?
+    
+    /// Name string
+    var name: String?
+    
+    /// Creates a new `BasicUser`
+    init(id: Int? = nil, name: String?) {
+        self.id = id
+        self.name = name
+    }
+    
+    func willCreate(on connection: D.Connection) throws -> EventLoopFuture<LifecycleUser<D>> {
+        LifecycleUserStateTracking.willCreateCalled = true
+        return Future.map(on: connection) { self }
+    }
+    
+    func didCreate(on connection: D.Connection) throws -> EventLoopFuture<LifecycleUser<D>> {
+        LifecycleUserStateTracking.didCreateCalled = true
+        return Future.map(on: connection) { self }
+    }
+    
+    func willUpdate(on connection: D.Connection) throws -> EventLoopFuture<LifecycleUser<D>> {
+        LifecycleUserStateTracking.willUpdateCalled = true
+        return Future.map(on: connection) { self }
+    }
+    
+    func didUpdate(on connection: D.Connection) throws -> EventLoopFuture<LifecycleUser<D>> {
+        LifecycleUserStateTracking.didUpdateCalled = true
+        return Future.map(on: connection) { self }
+    }
+    
+    func willDelete(on connection: D.Connection) throws -> EventLoopFuture<LifecycleUser<D>> {
+        LifecycleUserStateTracking.willDeleteCalled = true
+        return Future.map(on: connection) { self }
+    }
+    
+    func didDelete(on connection: D.Connection) throws -> EventLoopFuture<Void> {
+        LifecycleUserStateTracking.didDeleteCalled = true
+        return .done(on: connection)
+    }
+}
+
+class LifecycleUserStateTracking {
+    static var willCreateCalled = false
+    static var didCreateCalled = false
+    static var willUpdateCalled = false
+    static var didUpdateCalled = false
+    static var willDeleteCalled = false
+    static var didDeleteCalled = false
+}
+
+extension LifecycleUser: Migration where D: SchemaSupporting { }


### PR DESCRIPTION
This PR:

- Adds a didDelete hook (#433)
- Calls willDelete and didDelete on SoftDeleteable models (#453)
    - I decided it’s cleaner to avoid a separate set of `willSoftDelete` and `didSoftDelete` and instead just call the regular methods upon soft deleting 
- [WIP] Fixes a bug on deleting on object via the QueryBuilder (#488)
- Adds tests

Still working on the QueryBuilder bug fix