### PR TITLE
Fix spelling error in log message

### DIFF
--- a/Sources/Fluent/Service/RevertCommand.swift
+++ b/Sources/Fluent/Service/RevertCommand.swift
@@ -51,7 +51,7 @@ public final class RevertCommand: Command, Service {
                     return migration.migrationRevertAll(on: context.container)
                 }
             }.syncFlatten(on: context.container).map(to: Void.self) {
-                logger.info("Succesfully reverted all migrations")
+                logger.info("Successfully reverted all migrations")
             }
         } else {
             logger.info("Revert last batch of migrations requested")


### PR DESCRIPTION
While editing the book, I discovered a spelling error in the success message for "revert". This PR fixes that.