### PR TITLE
Don't ignore migration name for `MigrationConfig.add` method overloads

### DIFF
--- a/Sources/Fluent/Migration/MigrationConfig.swift
+++ b/Sources/Fluent/Migration/MigrationConfig.swift
@@ -81,7 +81,7 @@ public struct MigrationConfig: Service {
         Model: Fluent.Model,
         Model.Database: SchemaSupporting & QuerySupporting
     {
-        self.add(migration: Model.self, database: database)
+        self.add(migration: Model.self, database: database, name: name)
         Model.defaultDatabase = database
     }
 
@@ -107,7 +107,7 @@ public struct MigrationConfig: Service {
         Model: Fluent.Model,
         Model.Database: QuerySupporting
     {
-        self.add(migration: Model.self, database: database)
+        self.add(migration: Model.self, database: database, name: name)
         Model.defaultDatabase = database
     }
 


### PR DESCRIPTION
The ability to specify migration names was added in #428, but some of the `MigrationConfig.add` method overloads didn't actually use it. This is fixed now.