### PR TITLE
serialize migrations + convenience methods

### DIFF
--- a/Sources/Fluent/Schema/SchemaSupporting+CRUD.swift
+++ b/Sources/Fluent/Schema/SchemaSupporting+CRUD.swift
@@ -9,7 +9,9 @@ extension SchemaSupporting {
         let creator = SchemaCreator(Model.self)
         return Future.flatMap(on: conn) {
             try closure(creator)
-            return self.schemaExecute(creator.schema, on: conn)
+            return conn.fluentOperation {
+                return self.schemaExecute(creator.schema, on: conn)
+            }
         }
     }
     
@@ -21,7 +23,9 @@ extension SchemaSupporting {
         let updater = SchemaUpdater(Model.self)
         return Future.flatMap(on: conn) {
             try closure(updater)
-            return self.schemaExecute(updater.schema, on: conn)
+            return conn.fluentOperation {
+                return self.schemaExecute(updater.schema, on: conn)
+            }
         }
     }
     
@@ -29,6 +33,8 @@ extension SchemaSupporting {
     public static func delete<Model>(_ model: Model.Type, on conn: Connection) -> Future<Void>
         where Model: Fluent.Model, Model.Database == Self
     {
-        return schemaExecute(Model.Database.schemaCreate(Model.Database.schemaActionDelete, Model.entity), on: conn)
+        return conn.fluentOperation {
+            return schemaExecute(Model.Database.schemaCreate(Model.Database.schemaActionDelete, Model.entity), on: conn)
+        }
     }
 }

--- a/Sources/Fluent/Service/MigrateCommand.swift
+++ b/Sources/Fluent/Service/MigrateCommand.swift
@@ -15,14 +15,7 @@ public final class MigrateCommand: Command, Service {
     static func migrate(on container: Container) throws -> Future<Void> {
         let logger = try container.make(Logger.self)
         if let migrations = try? container.make(MigrationConfig.self) {
-            return migrations.storage.map { (uid, migration) in
-                return {
-                    logger.info("Migrating '\(uid)' database")
-                    return migration.migrationPrepareBatch(on: container)
-                }
-            }.syncFlatten(on: container).map {
-                logger.info("Migrations complete")
-            }
+            return migrations.prepare(on: container)
         } else {
             logger.info("No migrations configured.")
             return .done(on: container)

--- a/Sources/Fluent/Service/RevertCommand.swift
+++ b/Sources/Fluent/Service/RevertCommand.swift
@@ -39,30 +39,14 @@ public final class RevertCommand: Command, Service {
             guard context.console.confirm("Are you sure you want to revert all migrations?") else {
                 throw FluentError(identifier: "cancelled", reason: "Migration revert cancelled.")
             }
-
-            return migrations.storage.map { (uid, migration) in
-                return {
-                    logger.info("Reverting all migrations on '\(uid)' database")
-                    return migration.migrationRevertAll(on: context.container)
-                }
-            }.syncFlatten(on: context.container).map(to: Void.self) {
-                logger.info("Successfully reverted all migrations")
-            }
+            return migrations.revertAll(on: context.container)
         } else {
             logger.info("Revert last batch of migrations requested")
             logger.warning("This will revert the last batch of migrations for all configured databases")
             guard context.console.confirm("Are you sure you want to revert the last batch of migrations?") else {
                 throw FluentError(identifier: "cancelled", reason: "Migration revert cancelled.")
             }
-
-            return migrations.storage.map { (uid, migration) in
-                return {
-                    logger.info("Reverting last batch of migrations on '\(uid)' database")
-                    return migration.migrationRevertBatch(on: context.container)
-                }
-            }.syncFlatten(on: context.container).map(to: Void.self) {
-                logger.info("Succesfully reverted last batch of migrations")
-            }
+            return migrations.revert(on: context.container)
         }
     }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -37,10 +37,11 @@ jobs:
     docker:
       - image: codevapor/swift:4.1
       - image: circleci/postgres:latest
+        name: psql-cleartext
         environment:
           POSTGRES_USER: vapor_username
           POSTGRES_DB: vapor_database
-          POSTGRES_PASSWORD: ""
+          POSTGRES_PASSWORD: vapor_password
     steps:
       - run:
           name: Clone Fluent PostgreSQL


### PR DESCRIPTION
- [x] SchemaSupporting CRUD methods now use `conn.fluentOperation` to ensure they run serialized.
- [x] `MigrationConfig` now exposes methods for running the migrations. 