### PR TITLE
deletes MigrationLog migration when reverting all

### DIFF
--- a/Sources/Fluent/Migration/MigrationSupporting.swift
+++ b/Sources/Fluent/Migration/MigrationSupporting.swift
@@ -3,7 +3,14 @@ public protocol MigrationSupporting: QuerySupporting {
     /// Prepares this connection for handling `Migration`s.
     ///
     /// - parameters:
-    ///     - conn: Connection to prepare.
+    ///     - conn: Connection to prepare on.
     /// - returns: A future that will be completed when the preparation is finished.
     static func prepareMigrationMetadata(on conn: Connection) -> Future<Void>
+    
+    /// Un-prepares this connection for handlign `Migration`s.
+    ///
+    /// - parameters:
+    ///     - conn: Connection to revert on.
+    /// - returns: A future that will be completed when the reversion is finished.
+    static func revertMigrationMetadata(on conn: Connection) -> Future<Void>
 }

--- a/Sources/Fluent/Migration/Migrations.swift
+++ b/Sources/Fluent/Migration/Migrations.swift
@@ -38,6 +38,8 @@ internal struct Migrations<Database>: AnyMigrations where Database: MigrationSup
         return container.withNewConnection(to: database) { conn in
             return Database.prepareMigrationMetadata(on: conn).flatMap {
                 return MigrationLog<Database>.revertAll(self.migrations, on: conn, using: container)
+            }.flatMap {
+                return Database.revertMigrationMetadata(on: conn)
             }
         }
     }

--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Filter.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Filter.swift
@@ -82,13 +82,16 @@ extension QueryBuilder {
     /// - returns: Query builder for chaining.
     @discardableResult
     private func filter(_ field: Database.QueryField, _ method: Database.QueryFilterMethod, _ value: Database.QueryFilterValue) -> Self {
-        return filter(Database.queryFilter(field, method, value))
+        return filter(custom: Database.queryFilter(field, method, value))
     }
 
     /// Add a manually created filter to the query builder.
+    ///
+    ///     builder.filter(custom: ...)
+    ///
     /// - returns: Query builder for chaining.
     @discardableResult
-    public func filter(_ filter: Database.QueryFilter) -> Self {
+    public func filter(custom filter: Database.QueryFilter) -> Self {
         Database.queryFilterApply(filter, to: &query)
         return self
     }

--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Operators.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Operators.swift
@@ -7,7 +7,7 @@ extension QueryBuilder {
     ///         when filtering using key paths.
     @discardableResult
     public func filter(_ value: FilterOperator<Database, Result>) -> Self {
-        return filter(value.filter)
+        return filter(custom: value.filter)
     }
 
     /// Applies a filter from one of the filter operators (==, !=, etc) to a joined model.
@@ -21,7 +21,7 @@ extension QueryBuilder {
     ///         when filtering using key paths.
     @discardableResult
     public func filter<A>(_ value: FilterOperator<Database, A>) -> Self {
-        return filter(value.filter)
+        return filter(custom: value.filter)
     }
 }
 

--- a/Sources/Fluent/Schema/SchemaSupporting+Migration.swift
+++ b/Sources/Fluent/Schema/SchemaSupporting+Migration.swift
@@ -3,6 +3,11 @@ extension SchemaSupporting where Self: MigrationSupporting {
     public static func prepareMigrationMetadata(on conn: Connection) -> Future<Void> {
         return MigrationLog<Self>.prepareMetadata(on: conn)
     }
+    
+    /// See `MigrationSupporting`.
+    public static func revertMigrationMetadata(on conn: Connection) -> Future<Void> {
+        return MigrationLog<Self>.revertMetadata(on: conn)
+    }
 }
 
 // MARK: Private

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,6 @@
 version: 2
 
 jobs:
-
   macos:
     macos:
       xcode: "9.2"
@@ -9,7 +8,6 @@ jobs:
       - checkout
       - run: swift build
       - run: swift test
-
   linux:
     docker:
       - image: codevapor/swift:4.1
@@ -21,8 +19,6 @@ jobs:
       - run: 
           name: Run unit tests
           command: swift test
-
-
   linux-release:
     docker:
       - image: codevapor/swift:4.1
@@ -31,13 +27,11 @@ jobs:
       - run: 
           name: Compile code with optimizations
           command: swift build -c release
-
-
   linux-postgresql:
     docker:
       - image: codevapor/swift:4.1
       - image: circleci/postgres:latest
-        name: psql-cleartext
+        name: psql
         environment:
           POSTGRES_USER: vapor_username
           POSTGRES_DB: vapor_database
@@ -55,8 +49,6 @@ jobs:
           name: Run Fluent PostgreSQL unit tests
           command: swift test
           working_directory: ~/fluent-postgresql
-
-
   linux-mysql:
     docker:
       - image: codevapor/swift:4.1
@@ -79,8 +71,6 @@ jobs:
           name: Run Fluent MySQL unit tests
           command: swift test
           working_directory: ~/fluent-mysql
-
-
   linux-sqlite:
     docker:
       - image: codevapor/swift:4.1
@@ -106,8 +96,6 @@ workflows:
       - linux-mysql
       - linux-sqlite
       - linux-release
-      # - macos
-
   nightly:
     triggers:
       - schedule:
@@ -116,7 +104,5 @@ workflows:
             branches:
               only:
                 - master
-                
     jobs:
       - linux
-      # - macos


### PR DESCRIPTION
- [x] Running revert all migrations now deletes the `fluent` (MigrationLog) entity as well. 
- [x] `builder.filter(custom:)` is the new name for the generic filter accepting overload to prevent ambiguity
- [x] Fixes https://github.com/vapor/fluent-mysql/issues/107 
- [x] Fixes https://github.com/vapor/fluent-mysql/issues/120.