### PR TITLE
Change default migrationName to include full type path

### DIFF
--- a/Sources/Fluent/Migration/AnyMigration.swift
+++ b/Sources/Fluent/Migration/AnyMigration.swift
@@ -15,8 +15,10 @@ public protocol AnyMigration {
 extension AnyMigration where Self: Migration {
     /// See `Migration`.
     public static var migrationName: String {
-        let _type = "\(type(of: self))"
-        return _type.components(separatedBy: ".Type").first ?? _type
+        return String(reflecting: self)
+            .components(separatedBy: ".")
+            .dropFirst()
+            .joined(separator: ".")
     }
 
     /// See `Migration`.


### PR DESCRIPTION
This PR changes the default `migrationName` by adding the entire type's path to the name.

Partially resolves https://github.com/vapor/fluent-postgresql/issues/82

#### Example:
Consider the following case:
```swift
class Foo {
    var kind: Kind

    enum Kind: Migration {
        ...
    }
}

class Bar {
    var kind: Kind

    enum Kind: Migration {
        ...
    }
}
```

The two classes, `Foo` and `Bar`, each have a nested enum called `Kind`, each a `Migration`.

Currently the default `migrationName` for both of these nested enums is the same: `"Kind"`. Meaning that one will be hidden by the other.

This PR would resolve that nuance by changing the default `migrationName` to return unique names: `"Foo.Kind"` and `"Bar.Kind"`.

#### Motivation:

This change is related to an issue discussed [here](https://github.com/vapor/fluent-postgresql/issues/82). The motivating factor being, that in Swift, the types `Foo.Kind` and `Bar.Kind` are unique and distinguishable by the type system. It should then be reasonable to expect the default `migrationName`s to be unique and distinguishable whereas currently, they are ambiguous. In order to fully resolve the [linked issue](https://github.com/vapor/fluent-postgresql/issues/82), and do so by default, this is a necessary change and will have a companion PR at `FluentPostgreSQL` to update the default `postgreSQLEnumTypeName` (https://github.com/vapor/fluent-postgresql/pull/83).

#### Impact:

This could potentially have an impact on existing codebases by changing `migrationName`s that are already in place.