### PR TITLE
sum results fix

### DIFF
--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Aggregate.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Aggregate.swift
@@ -1,10 +1,16 @@
 extension QueryBuilder {
     // MARK: Aggregate
 
-    /// Returns the sum of all entries for the supplied field, falling back to the default value if the Future containing the sum resolves to an Error.
+    /// Returns the sum of all entries for the supplied field.
     ///
     ///     let totalLikes = try Post.query(on: conn).sum(\.likes)
-    ///     let totalViralPostLikes = try Post.query(on: conn).filter(\.likes >= 10_000_000).sum(\.likes, default: 0)
+    ///
+    /// If a default value is supplied, it will be used when the sum's result
+    /// set is empty and no sum can be determined.
+    ///
+    ///     let totalViralPostLikes = try Post.query(on: conn)
+    ///         .filter(\.likes >= 10_000_000)
+    ///         .sum(\.likes, default: 0)
     ///
     /// - parameters:
     ///     - field: Field to sum.


### PR DESCRIPTION
Builds upon #571 with improved error handling logic. Instead of converting _all_ errors to default (which could include syntax errors, etc) sum will now only use the default if the result set is known to be empty.