### PR TITLE
Added Mass Insertions to QueryBuilder

### DIFF
--- a/Sources/Fluent/Model/Model+CRUD.swift
+++ b/Sources/Fluent/Model/Model+CRUD.swift
@@ -95,3 +95,11 @@ extension Future where T: Model {
         }
     }
 }
+
+extension Array where Element: Model {
+    
+    /// See `Model`.
+    public func save(on connectable: DatabaseConnectable) -> Future<[Element]> {
+        return Element.query(on: connectable).create(self)
+    }
+}

--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Model.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Model.swift
@@ -77,7 +77,9 @@ extension QueryBuilder where Result: Model, Result.Database == Database {
             let create: Future<[Result]> = willCreate.flatten(on: conn).flatMap { models -> Future<[Result]> in
                 var copy = models
                 var modelCreated = 0
-                try Database.queryDataApply(Database.queryEncode(models, entity: Result.entity), to: &self.query)
+                try models.forEach { model in
+                    try Database.queryDataApply(Database.queryEncode(model, entity: Result.entity), to: &self.query)
+                }
                 return self.run(Database.queryActionCreate) { created in
                     guard modelCreated < copy.count else { return }
                     

--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Model.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Model.swift
@@ -28,43 +28,78 @@ extension QueryBuilder where Result: Model, Result.Database == Database {
     ///     - model: `Model` to create.
     /// - returns: A `Future` containing the created `Model`.
     public func create(_ model: Result) -> Future<Result> {
-        Database.queryActionApply(Database.queryActionCreate, to: &query)
-        var copy = model
-        
-        // set timestamps
-        if Result.createdAtKey != nil || Result.updatedAtKey != nil {
-            let now = Date()
-            
-            if Result.createdAtKey != nil, copy.fluentCreatedAt == nil {
-                copy.fluentCreatedAt = now
+        return create([model]).map { created in
+            guard let first = created.first else {
+                throw FluentError(identifier: "noModelCreated", reason: "Expected a model to be returned after it is created, but none where found.")
             }
-
-            if Result.updatedAtKey != nil, copy.fluentUpdatedAt == nil {
-                copy.fluentUpdatedAt = now
-            }
-        }
-
-        return connection.flatMap { conn in
-            return Database.modelEvent(event: .willCreate, model: copy, on: conn).flatMap { model in
-                return try model.willCreate(on: conn)
-            }.flatMap { model -> Future<Result> in
-                var copy = model
-                try Database.queryDataApply(Database.queryEncode(copy, entity: Result.entity), to: &self.query)
-                return self.run(Database.queryActionCreate) {
-                    // to support reference types that may be ignoring return values
-                    // set the id on the existing value before replacing it
-                    copy.fluentID = $0.fluentID
-                    // if a model is returned, use it since it may have default values
-                    copy = $0
-                }.map { copy }
-            }.flatMap { model in
-                return Database.modelEvent(event: .didCreate, model: model, on: conn)
-            }.flatMap { model in
-                return try model.didCreate(on: conn)
-            }
+            return first
         }
     }
 
+    
+    /// Saves an array of models as new items in the database.
+    /// This method can auto-generate the IDs depending on the ID type.
+    ///
+    ///     let users = [User(...), User(...), User(...)]
+    ///     User.query(on: conn).create(users)
+    ///
+    /// - parameters:
+    ///   - models: `Model` objects to create.
+    /// - returns: A `Future` containg the created `Model` objects.
+    func create(_ models: [Result]) -> Future<[Result]> {
+        Database.queryActionApply(Database.queryActionCreate, to: &query)
+        var copy: [Result] = []
+        copy.reserveCapacity(models.count)
+        
+        if Result.createdAtKey != nil || Result.updatedAtKey != nil {
+            let now = Date()
+            
+            for var model in models {
+                if Result.createdAtKey != nil, model.fluentCreatedAt == nil {
+                    model.fluentCreatedAt = now
+                }
+                
+                if Result.updatedAtKey != nil, model.fluentUpdatedAt == nil {
+                    model.fluentUpdatedAt = now
+                }
+                copy.append(model)
+            }
+        } else {
+            copy = models
+        }
+        
+        return connection.flatMap { conn in
+            let willCreate: [Future<Result>] = copy.map { model -> Future<Result> in
+                return Database.modelEvent(event: .willCreate, model: model, on: conn).flatMap { model in
+                    return try model.willCreate(on: conn)
+                }
+            }
+            let create: Future<[Result]> = willCreate.flatten(on: conn).flatMap { models -> Future<[Result]> in
+                var copy = models
+                var modelCreated = 0
+                try Database.queryDataApply(Database.queryEncode(models, entity: Result.entity), to: &self.query)
+                return self.run(Database.queryActionCreate) { created in
+                    guard modelCreated < copy.count else { return }
+                    
+                    copy[modelCreated].fluentID = created.fluentID
+                    copy[modelCreated] = created
+                    
+                    modelCreated += 1
+                }.transform(to: copy)
+            }
+            let didCreate: Future<[Result]> = create.flatMap { models in
+                return models.map { model in
+                    return Database.modelEvent(event: .didCreate, model: model, on: conn)
+                }.flatten(on: conn)
+            }.flatMap { models in
+                return try models.map { model -> Future<Result> in
+                    return try model.didCreate(on: conn)
+                }.flatten(on: conn)
+            }
+            return didCreate
+        }
+    }
+    
     /// Updates the model. This requires that the model has its ID set.
     ///
     ///     let user: User = ...

--- a/Sources/FluentBenchmark/Benchmarks/BenchmarkModels.swift
+++ b/Sources/FluentBenchmark/Benchmarks/BenchmarkModels.swift
@@ -6,8 +6,7 @@ extension Benchmarker where Database: QuerySupporting {
         let a = Foo<Database>(bar: "asdf", baz: 42)
         let b = Foo<Database>(bar: "asdf", baz: 42)
         
-        _ = try test(a.save(on: conn))
-        _ = try test(b.save(on: conn))
+        _ = try test([a, b].save(on: conn))
         var count = try test(Foo<Database>.query(on: conn).count())
         if count != 2 {
             self.fail("count should have been 2")

--- a/Sources/FluentSQL/FluentSQLQuery.swift
+++ b/Sources/FluentSQL/FluentSQLQuery.swift
@@ -16,7 +16,7 @@ public protocol FluentSQLQuery {
     var groupBy: [GroupBy] { get set }
     var limit: Int? { get set }
     var offset: Int? { get set }
-    var values: [String: Expression] { get set }
+    var values: [[String: Expression]] { get set }
     var defaultBinaryOperator: Expression.BinaryOperator { get set }
     
     static func query(_ statement: Statement, _ table: TableIdentifier) -> Self

--- a/Sources/FluentSQL/SQL+QuerySupporting.swift
+++ b/Sources/FluentSQL/SQL+QuerySupporting.swift
@@ -264,14 +264,16 @@ extension QuerySupporting where Query: FluentSQLQuery, QueryField: SQLColumnIden
     public static func queryDataSet<E>(_ field: QueryField, to data: E, on query: inout Query)
         where E: Encodable
     {
-        query.values[field.identifier.string] = .bind(.encodable(data))
+        query.values.indices.forEach { index in
+            query.values[index][field.identifier.string] = .bind(.encodable(data))
+        }
     }
 }
 
 extension QuerySupporting where Query: FluentSQLQuery, QueryData == Dictionary<String, Query.Expression> {
     /// See `QuerySupporting`.
     public static func queryDataApply(_ data: QueryData, to query: inout Query) {
-        query.values = data
+        query.values.append(data)
     }
 }
 


### PR DESCRIPTION
Adds mass insertions to `QueryBuilder`, so you can save an array of models with a single database operation:

```swift
let users = [User(name: "Greg"), User(name: "Caleb"), User(name: "Tanner")]
users.create(on: connection)
```

Fixes https://github.com/vapor/fluent/issues/569

Requires: https://github.com/vapor/fluent-sqlite/pull/26, https://github.com/vapor/fluent-postgresql/pull/99, https://github.com/vapor/fluent-mysql/pull/129