### PR TITLE
Return updated/created/saved model from Future

### DIFF
--- a/Sources/Fluent/Model/Model+CRUD.swift
+++ b/Sources/Fluent/Model/Model+CRUD.swift
@@ -70,21 +70,21 @@ extension Future where T: Model {
     /// See `Model`.
     public func save(on connectable: DatabaseConnectable) -> Future<T> {
         return self.flatMap(to: T.self) { (model) in
-            return model.save(on: connectable).transform(to: model)
+            return model.save(on: connectable)
         }
     }
 
     /// See `Model`.
     public func create(on connectable: DatabaseConnectable) -> Future<T> {
         return self.flatMap(to: T.self) { (model) in
-            return model.create(on: connectable).transform(to: model)
+            return model.create(on: connectable)
         }
     }
 
     /// See `Model`.
     public func update(on connectable: DatabaseConnectable) -> Future<T> {
         return self.flatMap(to: T.self) { (model) in
-            return model.update(on: connectable).transform(to: model)
+            return model.update(on: connectable)
         }
     }
 


### PR DESCRIPTION
Given this code where `Client` is `Model` and `struct`:
```
        return try request.fromInput(to: Client.self)
            .save(on: request)
            .map {
                return try Client.Output(
                            id: $0.requireID(),
                            platform: $0.platform,
                            role: $0.role,
                            campaignId: $0.campaignId,
                            lastModifiedAt: $0.lastModifiedAt()
                )
            }
            .encode(status: .created, for: request)
```

The code will fail on `requireID()` because current implementation of `Future.save(on:)` returns the model that was passed to it, meaning the ID is still nil.

This PR fixes this scenario and return the return value from corresponding CRUD operations on `Model` like `save(on:)` etc.