### PR TITLE
Created QueryBuilder.sort(_:_:) overload that takes a generic model type

### DIFF
--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Sort.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Sort.swift
@@ -12,6 +12,18 @@ extension QueryBuilder {
     public func sort<T>(_ key: KeyPath<Result, T>, _ direction: Database.QuerySortDirection = Database.querySortDirectionAscending) -> Self {
         return sort(Database.querySort(Database.queryField(.keyPath(key)), direction))
     }
+    
+    /// Add a sort to the query builder for a field.
+    ///
+    ///     let users = try User.query(on: conn).sort(\.name, .ascending)
+    ///
+    /// - parameters:
+    ///     - key: Swift `KeyPath` to field on model to sort.
+    ///     - direction: Direction to sort the fields, ascending or descending.
+    /// - returns: Query builder for chaining.
+    public func sort<M, T>(_ key: KeyPath<M, T>, _ direction: Database.QuerySortDirection = Database.querySortDirectionAscending) -> Self {
+        return sort(Database.querySort(Database.queryField(.keyPath(key)), direction))
+    }
 
     /// Adds a custom sort to the query builder.
     ///


### PR DESCRIPTION
This is good for sorting on joined models, like this:

```swift
Galaxy.query(on: conn).join(\Galaxy.id, to: \Planet.galaxyID).sort(\Planet.name).all()
```