### PR TITLE
Use coalesce to provide default values for aggregate functions that can result in null

### DIFF
--- a/Sources/Fluent/Query/QuerySupporting.swift
+++ b/Sources/Fluent/Query/QuerySupporting.swift
@@ -255,8 +255,8 @@ public protocol QuerySupporting: Database {
     ///     - method: Aggregate method to use.
     ///     - field: Keys to aggregate. Can be zero.
     ///     - default: Value to fall back on if the aggregate function returns NULL.
-    static func queryAggregate<C>(_ aggregate: QueryAggregate, _ fields: [QueryKey], default: C?) -> QueryKey
-        where C: Codable
+    static func queryAggregate<D>(_ aggregate: QueryAggregate, _ fields: [QueryKey], default: D?) -> QueryKey
+        where D: Decodable
 
     /// Creates a new `QueryKey` from an existing `QueryField`.
     ///

--- a/Sources/Fluent/Query/QuerySupporting.swift
+++ b/Sources/Fluent/Query/QuerySupporting.swift
@@ -254,7 +254,9 @@ public protocol QuerySupporting: Database {
     /// - parameters:
     ///     - method: Aggregate method to use.
     ///     - field: Keys to aggregate. Can be zero.
-    static func queryAggregate(_ aggregate: QueryAggregate, _ fields: [QueryKey]) -> QueryKey
+    ///     - default: Value to fall back on if the aggregate function returns NULL.
+    static func queryAggregate<C>(_ aggregate: QueryAggregate, _ fields: [QueryKey], default: C?) -> QueryKey
+        where C: Codable
 
     /// Creates a new `QueryKey` from an existing `QueryField`.
     ///

--- a/Sources/Fluent/Query/QuerySupporting.swift
+++ b/Sources/Fluent/Query/QuerySupporting.swift
@@ -249,14 +249,21 @@ public protocol QuerySupporting: Database {
     /// Special "all fields" query key.
     static var queryKeyAll: QueryKey { get }
 
-    /// Creates an aggregate-type (computed) query key.
+    /// Creates an aggregate-type (computed) query key, falling back on a default value if the aggregate functions returns NULL.
     ///
     /// - parameters:
     ///     - method: Aggregate method to use.
     ///     - field: Keys to aggregate. Can be zero.
     ///     - default: Value to fall back on if the aggregate function returns NULL.
-    static func queryAggregate<D>(_ aggregate: QueryAggregate, _ fields: [QueryKey], default: D?) -> QueryKey
+    static func queryAggregate<D>(_ aggregate: QueryAggregate, _ fields: [QueryKey], default: D) -> QueryKey
         where D: Decodable
+    
+    /// Creates an aggregate-type (computed) query key.
+    ///
+    /// - parameters:
+    ///     - method: Aggregate method to use.
+    ///     - field: Keys to aggregate. Can be zero.
+    static func queryAggregate(_ aggregate: QueryAggregate, _ fields: [QueryKey]) -> QueryKey
 
     /// Creates a new `QueryKey` from an existing `QueryField`.
     ///

--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Aggregate.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Aggregate.swift
@@ -70,7 +70,12 @@ extension QueryBuilder {
     public func aggregate<D, T>(_ method: Database.QueryAggregate, field: KeyPath<Result, T>, as type: D.Type = D.self, default: D?) -> Future<D>
         where D: Decodable
     {
-        return _aggregate(Database.queryAggregate(method, [Database.queryKey(Database.queryField(.keyPath(field)))], default: `default`))
+        guard let d = `default` else {
+            return _aggregate(Database.queryAggregate(method, [Database.queryKey(Database.queryField(.keyPath(field)))]))
+        }
+        
+        return _aggregate(Database.queryAggregate(method, [Database.queryKey(Database.queryField(.keyPath(field)))], default: d))
+        
     }
 
     /// Returns the number of results for this query.

--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Aggregate.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Aggregate.swift
@@ -16,19 +16,8 @@ extension QueryBuilder {
     ///     - field: Field to sum.
     ///     - default: Optional default to use.
     /// - returns: A `Future` containing the sum.
-    public func sum<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Decodable {
-        return self.count().flatMap { count in
-            switch count {
-            case 0:
-                if let d = `default` {
-                    return self.connection.map { _ in d }
-                } else {
-                    throw FluentError(identifier: "noSumResults", reason: "Sum query returned 0 results and no default was supplied.")
-                }
-            default:
-                return self.aggregate(Database.queryAggregateSum, field: field)
-            }
-        }
+    public func sum<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Codable {
+        return aggregate(Database.queryAggregateSum, field: field, default: `default`)
     }
 
     /// Returns the average of all entries for the supplied field.
@@ -37,9 +26,10 @@ extension QueryBuilder {
     ///
     /// - parameters:
     ///     - field: Field to average.
+    ///     - default: Optional default to use.
     /// - returns: A `Future` containing the average.
-    public func average<T>(_ field: KeyPath<Result, T>) -> Future<T> where T: Decodable {
-        return aggregate(Database.queryAggregateAverage, field: field)
+    public func average<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Codable {
+        return aggregate(Database.queryAggregateAverage, field: field, default: `default`)
     }
 
     /// Returns the minimum value of all entries for the supplied field.
@@ -48,9 +38,10 @@ extension QueryBuilder {
     ///
     /// - parameters:
     ///     - field: Field to find min for.
+    ///     - default: Optional default to use.
     /// - returns: A `Future` containing the min.
-    public func min<T>(_ field: KeyPath<Result, T>) -> Future<T> where T: Decodable {
-        return aggregate(Database.queryAggregateMinimum, field: field)
+    public func min<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Codable {
+        return aggregate(Database.queryAggregateMinimum, field: field, default: `default`)
     }
 
     /// Returns the maximum value of all entries for the supplied field.
@@ -59,9 +50,10 @@ extension QueryBuilder {
     ///
     /// - parameters:
     ///     - field: Field to find max for.
+    ///     - default: Optional default to use.
     /// - returns: A `Future` containing the max.
-    public func max<T>(_ field: KeyPath<Result, T>) -> Future<T> where T: Decodable {
-        return aggregate(Database.queryAggregateMaximum, field: field)
+    public func max<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Codable {
+        return aggregate(Database.queryAggregateMaximum, field: field, default: `default`)
     }
 
     /// Perform an aggregate action on the supplied field. Normally you will use one of
@@ -71,13 +63,14 @@ extension QueryBuilder {
     ///
     /// - parameters:
     ///     - method: Aggregate method to use.
-    ///     - field: Field to find max for.
+    ///     - field: Field to find aggregate for.
     ///     - type: `Decodable` type to decode the aggregate value as.
+    ///     - default: Optional default to use.
     /// - returns: A `Future` containing the aggregate.
-    public func aggregate<D, T>(_ method: Database.QueryAggregate, field: KeyPath<Result, T>, as type: D.Type = D.self) -> Future<D>
-        where D: Decodable
+    public func aggregate<D, T>(_ method: Database.QueryAggregate, field: KeyPath<Result, T>, as type: D.Type = D.self, default: D?) -> Future<D>
+        where D: Codable
     {
-        return _aggregate(Database.queryAggregate(method, [Database.queryKey(Database.queryField(.keyPath(field)))]))
+        return _aggregate(Database.queryAggregate(method, [Database.queryKey(Database.queryField(.keyPath(field)))], default: `default`))
     }
 
     /// Returns the number of results for this query.
@@ -86,7 +79,7 @@ extension QueryBuilder {
     ///
     /// - returns: A `Future` containing the count.
     public func count() -> Future<Int> {
-        return _aggregate(Database.queryAggregate(Database.queryAggregateCount, [Database.queryKeyAll]))
+        return _aggregate(Database.queryAggregate(Database.queryAggregateCount, [Database.queryKeyAll], default: 0))
     }
 
     // MARK: Private

--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Aggregate.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Aggregate.swift
@@ -16,7 +16,7 @@ extension QueryBuilder {
     ///     - field: Field to sum.
     ///     - default: Optional default to use.
     /// - returns: A `Future` containing the sum.
-    public func sum<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Codable {
+    public func sum<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Decodable {
         return aggregate(Database.queryAggregateSum, field: field, default: `default`)
     }
 
@@ -28,7 +28,7 @@ extension QueryBuilder {
     ///     - field: Field to average.
     ///     - default: Optional default to use.
     /// - returns: A `Future` containing the average.
-    public func average<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Codable {
+    public func average<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Decodable {
         return aggregate(Database.queryAggregateAverage, field: field, default: `default`)
     }
 
@@ -40,7 +40,7 @@ extension QueryBuilder {
     ///     - field: Field to find min for.
     ///     - default: Optional default to use.
     /// - returns: A `Future` containing the min.
-    public func min<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Codable {
+    public func min<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Decodable {
         return aggregate(Database.queryAggregateMinimum, field: field, default: `default`)
     }
 
@@ -52,7 +52,7 @@ extension QueryBuilder {
     ///     - field: Field to find max for.
     ///     - default: Optional default to use.
     /// - returns: A `Future` containing the max.
-    public func max<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Codable {
+    public func max<T>(_ field: KeyPath<Result, T>, default: T? = nil) -> Future<T> where T: Decodable {
         return aggregate(Database.queryAggregateMaximum, field: field, default: `default`)
     }
 
@@ -68,7 +68,7 @@ extension QueryBuilder {
     ///     - default: Optional default to use.
     /// - returns: A `Future` containing the aggregate.
     public func aggregate<D, T>(_ method: Database.QueryAggregate, field: KeyPath<Result, T>, as type: D.Type = D.self, default: D?) -> Future<D>
-        where D: Codable
+        where D: Decodable
     {
         return _aggregate(Database.queryAggregate(method, [Database.queryKey(Database.queryField(.keyPath(field)))], default: `default`))
     }

--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Aggregate.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Aggregate.swift
@@ -84,7 +84,7 @@ extension QueryBuilder {
     ///
     /// - returns: A `Future` containing the count.
     public func count() -> Future<Int> {
-        return _aggregate(Database.queryAggregate(Database.queryAggregateCount, [Database.queryKeyAll], default: 0))
+        return _aggregate(Database.queryAggregate(Database.queryAggregateCount, [Database.queryKeyAll]))
     }
 
     // MARK: Private

--- a/Sources/FluentSQL/SQL+QuerySupporting.swift
+++ b/Sources/FluentSQL/SQL+QuerySupporting.swift
@@ -158,8 +158,8 @@ extension QuerySupporting where
     QueryKey.Expression == QueryKey.Expression.Function.Argument.Expression
 {
     /// See `QuerySupporting`.
-    public static func queryAggregate<D>(_ name: QueryAggregate, _ fields: [QueryKey], default: D) -> QueryKey
-        where D: Decodable
+    public static func queryAggregate<C>(_ name: QueryAggregate, _ fields: [QueryKey], default: C) -> QueryKey
+        where C: Codable
     {
         let args: [QueryKey.Expression.Function.Argument] = fields.compactMap { expr in
             if expr.isAll {
@@ -170,8 +170,7 @@ extension QuerySupporting where
                 return nil
             }
         }
-        
-        return .expression(.coalesce(.function(.function(name, args)), .literal(.numeric(String(describing: `default`)))), alias: .identifier("fluentAggregate"))
+        return .expression(.coalesce(.function(.function(name, args)), .bind(.encodable(`default`))), alias: .identifier("fluentAggregate"))
     }
     
     /// See `QuerySupporting`.

--- a/Sources/FluentSQL/SQL+QuerySupporting.swift
+++ b/Sources/FluentSQL/SQL+QuerySupporting.swift
@@ -174,6 +174,8 @@ extension QuerySupporting where
         var expressions: [QueryKey.Expression] = [.function(.function(name, args))]
         if let d = `default` {
             expressions.append(.literal(.string(String(describing: d))))
+        } else {
+            expressions.append(.literal(.null))
         }
         
         let coalesced: QueryKey.Expression = .coalesce(expressions)

--- a/Sources/FluentSQL/SQL+QuerySupporting.swift
+++ b/Sources/FluentSQL/SQL+QuerySupporting.swift
@@ -171,7 +171,14 @@ extension QuerySupporting where
             }
         }
         
-        return .expression(.coalesce([.function(.function(name, args)), .literal(.string(String(describing: `default`)))]), alias: .identifier("fluentAggregate"))
+        var expressions: [QueryKey.Expression] = [.function(.function(name, args))]
+        if let d = `default` {
+            expressions.append(.literal(.string(String(describing: d))))
+        }
+        
+        let coalesced: QueryKey.Expression = .coalesce(expressions)
+        
+        return .expression(coalesced, alias: .identifier("fluentAggregate"))
     }
     
 }

--- a/Sources/FluentSQL/SQL+QuerySupporting.swift
+++ b/Sources/FluentSQL/SQL+QuerySupporting.swift
@@ -158,8 +158,8 @@ extension QuerySupporting where
     QueryKey.Expression == QueryKey.Expression.Function.Argument.Expression
 {
     /// See `QuerySupporting`.
-    public static func queryAggregate<C>(_ name: QueryAggregate, _ fields: [QueryKey], default: C?) -> QueryKey
-        where C: Codable
+    public static func queryAggregate<D>(_ name: QueryAggregate, _ fields: [QueryKey], default: D?) -> QueryKey
+        where D: Decodable
     {
         let args: [QueryKey.Expression.Function.Argument] = fields.compactMap { expr in
             if expr.isAll {
@@ -170,7 +170,8 @@ extension QuerySupporting where
                 return nil
             }
         }
-        return .expression(.coalesce([.function(.function(name, args)), .group(.bind(.encodable(`default`)))]), alias: .identifier("fluentAggregate"))
+        
+        return .expression(.coalesce([.function(.function(name, args)), .literal(.string(String(describing: `default`)))]), alias: .identifier("fluentAggregate"))
     }
     
 }

--- a/Sources/FluentSQL/SQL+QuerySupporting.swift
+++ b/Sources/FluentSQL/SQL+QuerySupporting.swift
@@ -158,7 +158,9 @@ extension QuerySupporting where
     QueryKey.Expression == QueryKey.Expression.Function.Argument.Expression
 {
     /// See `QuerySupporting`.
-    public static func queryAggregate(_ name: QueryAggregate, _ fields: [QueryKey]) -> QueryKey {
+    public static func queryAggregate<C>(_ name: QueryAggregate, _ fields: [QueryKey], default: C?) -> QueryKey
+        where C: Codable
+    {
         let args: [QueryKey.Expression.Function.Argument] = fields.compactMap { expr in
             if expr.isAll {
                 return .all
@@ -168,7 +170,7 @@ extension QuerySupporting where
                 return nil
             }
         }
-        return .expression(.function(.function(name, args)), alias: .identifier("fluentAggregate"))
+        return .expression(.coalesce([.function(.function(name, args)), .group(.bind(.encodable(`default`)))]), alias: .identifier("fluentAggregate"))
     }
     
 }

--- a/Sources/FluentSQL/SQL+QuerySupporting.swift
+++ b/Sources/FluentSQL/SQL+QuerySupporting.swift
@@ -173,7 +173,7 @@ extension QuerySupporting where
         
         var expressions: [QueryKey.Expression] = [.function(.function(name, args))]
         if let d = `default` {
-            expressions.append(.literal(.string(String(describing: d))))
+            expressions.append(.literal(.numeric(String(describing: d))))
         } else {
             expressions.append(.literal(.null))
         }


### PR DESCRIPTION
Implements the enhancement described in https://github.com/vapor/sql/issues/42