### PR TITLE
Generic QueryBuilder.groupBy Method

### DIFF
--- a/Sources/FluentSQL/QueryBuilder+GroupBy.swift
+++ b/Sources/FluentSQL/QueryBuilder+GroupBy.swift
@@ -7,4 +7,13 @@ extension QueryBuilder where Database.Query: FluentSQLQuery, Result: SQLTable {
         query.groupBy.append(.groupBy(.column(.keyPath(field))))
         return self
     }
+    
+    /// Adds a SQL group by to the query.
+    ///
+    ///     groupBy(\JoinedModel.id)
+    ///
+    public func groupBy<M, T>(_ field: KeyPath<M, T>) -> Self where M: SQLTable {
+        query.groupBy.append(.groupBy(.column(.keyPath(field))))
+        return self
+    }
 }

--- a/Sources/FluentSQL/QueryBuilder+GroupBy.swift
+++ b/Sources/FluentSQL/QueryBuilder+GroupBy.swift
@@ -7,6 +7,9 @@ extension QueryBuilder where Database.Query: FluentSQLQuery, Result: SQLTable {
         query.groupBy.append(.groupBy(.column(.keyPath(field))))
         return self
     }
+}
+
+extension QueryBuilder where Database.Query: FluentSQLQuery {
     
     /// Adds a SQL group by to the query.
     ///


### PR DESCRIPTION
Created a more generic version of the `QueryBuilder.groupBy(_:)` method where the `field` parameter root type can be any type conforming to `SQLTable`:

```swift
User.query(on: conn).join(\User.id, to: \Pet.userID).groupBy(\Pet.age)
```

This implementation was put in a different extension than the original `QueryBuilder.groupBy(_:)` method because it doesn't require the `QueryBuilder.Result` type to conform to `SQLTable`.