### PR TITLE
Add Distinct to FluentSQLQuery

### DIFF
--- a/Sources/FluentSQL/FluentSQLQuery.swift
+++ b/Sources/FluentSQL/FluentSQLQuery.swift
@@ -1,13 +1,15 @@
 public protocol FluentSQLQuery {
     associatedtype Statement: FluentSQLQueryStatement
+    associatedtype Distinct: SQLDistinct
     associatedtype Expression: SQLExpression
     associatedtype Join: SQLJoin
     associatedtype OrderBy: SQLOrderBy
     associatedtype GroupBy: SQLGroupBy
     associatedtype TableIdentifier: SQLTableIdentifier
     associatedtype SelectExpression: SQLSelectExpression
-    
+
     var statement: Statement { get set }
+    var distinct: Distinct? { get set }
     var table: TableIdentifier { get set }
     var keys: [SelectExpression] { get set }
     var predicate: Expression? { get set }
@@ -18,7 +20,7 @@ public protocol FluentSQLQuery {
     var offset: Int? { get set }
     var values: [String: Expression] { get set }
     var defaultBinaryOperator: Expression.BinaryOperator { get set }
-    
+
     static func query(_ statement: Statement, _ table: TableIdentifier) -> Self
 }
 


### PR DESCRIPTION
References #599.

This modifies protocol `FluentSQLQuery` to allow the MySQL and PostgreSQL drivers to implement `SELECT DISTINCT`.

This is a breaking change that requires updates to everything that depends on FluentSQLQuery. I have submitted PRs to [fluent-mysql](https://github.com/vapor/fluent-mysql/pull/135), [fluent-postgresql](https://github.com/vapor/fluent-postgresql/pull/102) and [fluent-sqlite](https://github.com/vapor/fluent-sqlite/pull/27).

NB: This doesn't enable this usage: `MyObject.query(on: worker).distinct().all()`. Instead:

```swift
let builder = MyObject.query(on: worker)
builder.query.distinct = .distinct
return builder.all()
```
