### PR TITLE
Fixed improper use of update in BenchmarkModels 

### DIFF
--- a/Sources/FluentBenchmark/Benchmarks/BenchmarkModels.swift
+++ b/Sources/FluentBenchmark/Benchmarks/BenchmarkModels.swift
@@ -16,7 +16,7 @@ extension Benchmarker where Database: QuerySupporting {
         // update
         b.bar = "fdsa"
         _ = try test(b.save(on: conn))
-        _ = try test(Foo.query(on: conn).filter(\Foo<Database>.id == a.id).update(data: ["baz": 314]))
+        _ = try test(Foo.query(on: conn).filter(\Foo<Database>.id == a.id).update(\.baz, to: 314).run())
 
         // read
         let fetched = try test(Foo<Database>.find(b.requireID(), on: conn))


### PR DESCRIPTION
Meanwhile implementing a mongo driver for Fluent I noticed there's a subtle difference in the protocol definition about bulk updates to certain fields, and data replacement.

I am firmly convinced that every call to `static func queryDataApply(_ data: QueryData, to query: inout Query)` is meant to fully replace the data.

Meanwhile every call to `static func queryDataSet<E: Encodable>(_ field: QueryField, to data: E, on query: inout Query)` should only update the specified fields.

Perhaps this doesn't affect the `SQL` drivers (I can see tests keeps passing), but it assumes that every driver applies the same logic about encoding/decoding `null` values as well as evaluating the presence of a specific `key`, but this is not always the case.

This pull request fixed an improper use of `update` in the BenchmarkModels tests.