### PR TITLE
Fix bug on filter for empty group

### DIFF
--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Filter.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Filter.swift
@@ -122,8 +122,11 @@ extension QueryBuilder {
         let sub = query
         query = main
 
-        // apply the sub-filters as a group
-        Database.queryFilterApply(Database.queryFilterGroup(relation, Database.queryFilters(for: sub)), to: &query)
+        // apply the sub-filters as a group, if there are any
+        let queryFilters = Database.queryFilters(for: sub)
+        if !queryFilters.isEmpty {
+            Database.queryFilterApply(Database.queryFilterGroup(relation, queryFilters), to: &query)
+        }
         return self
     }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - run:
           name: Clone Fluent PostgreSQL
-          command: git clone -b master https://github.com/vapor/fluent-postgresql.git
+          command: git clone -b 1 https://github.com/vapor/fluent-postgresql.git
           working_directory: ~/
       - run:
           name: Switch Fluent PostgreSQL to this Fluent revision


### PR DESCRIPTION
When using the `QueryBuilder` and a filter group with `or`, the resulting SQL statement is incorrect, if no filters are provided.

Since this is a mix between an issue and a proposition of a solution, I'm first describing the issue:

### Steps to reproduce
```swift
User.query(on: req).group(.or) { query in
    // No filters here...
}.all()
```

### Expected behavior
No filters, so no restrictions on the query, so the statement should be:
`SELECT * FROM "User" WHERE []`.

### Actual behavior
I get the following error: `[ ERROR ] SQLiteError.error: near ")": syntax error (SQLiteStatement.swift:15)`, caused by the SQL statement `SELECT * FROM "User" WHERE () []`.

### My solution
Since Fluent 4 seems to work quite differently, I chose to apply this PR on version 3. This feels a bit "hacky", and I'm not sure if it should be at another point inside the query building stack, but this is a solution to the error.

### But... why?
Why should you use `.group` without any filters? Because sometimes you loop over an array of filters, which could be empty.