### PR TITLE
Add support for copying query builders.

### DIFF
--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Copy.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Copy.swift
@@ -1,0 +1,16 @@
+extension QueryBuilder {
+    // MARK: Copy
+
+    /// Creates a copy of the current query builder. Useful for constructing two similar, but not identical, queries.
+    ///
+    /// Example: two queries sorted by different criteria.
+    ///
+    ///     let baseQuery = try User.query(on: conn).filter(\.name == "foo")
+    ///     let sortedByID = baseQuery.copy().sort(\.id, .ascending)
+    ///     let sortedByName = baseQuery.copy().sort(\.name, .ascending)
+    ///
+    /// - returns: A copy of the current query builder that can be manipulated independently of the original.
+    public func copy() -> Self {
+        return .init(query: self.query, on: self.connection, resultTransformer: self.resultTransformer)
+    }
+}


### PR DESCRIPTION
Creates a copy of the current query builder. Useful for constructing two similar, but not identical, queries.

Example: two queries sorted by different criteria.

```
let baseQuery = try User.query(on: conn).filter(\.name == "foo")
let sortedByID = baseQuery.copy().sort(\.id, .ascending)
let sortedByName = baseQuery.copy().sort(\.name, .ascending)
```

Example: two queries, one sorted, one counting. (Used e.g. for pagination; see https://github.com/nodes-vapor/paginator/blob/0c1ce194d3ea4564c782e94ba3ea4f09b5d87ad1/Sources/Paginator/Paginatable/QueryBuilderPaginatable.swift#L55.)

```
let baseQuery = try User.query(on: conn).filter(\.name == "foo")
let sortedQuery = baseQuery.copy().sort(\.id, .ascending)
let countQuery = baseQuery.copy().count()
```

(Without the copy, this will add the `ORDER BY` clause to the query, which Postgres chokes on.)