### PR TITLE
Adding support for decoding optional models

### DIFF
--- a/Sources/Fluent/QueryBuilder/QueryBuilder+Decode.swift
+++ b/Sources/Fluent/QueryBuilder/QueryBuilder+Decode.swift
@@ -16,6 +16,22 @@ extension QueryBuilder {
     public func alsoDecode<M>(_ type: M.Type) -> QueryBuilder<Database, (Result, M)> where M: Fluent.Model {
         return alsoDecode(M.self, M.entity)
     }
+    
+    /// Adds an additional type `D` to be decoded when run.
+    /// The new result for this query will be a tuple containing the previous result and this new result.
+    ///
+    ///     let joined = try User.query(on: req)
+    ///         .join(\Pet.userID, to: \User.id)
+    ///         .alsoDecode(Pet?.self)
+    ///         .all()
+    ///     print(joined) // Future<[(User, Pet)]>
+    ///
+    /// - parameters:
+    ///     - type: New model type `Optional<D>` to also decode.
+    /// - returns: `QueryBuilder` decoding type `(Result, Optional<D>)`.
+    public func alsoDecode<M>(_ type: Optional<M>.Type) -> QueryBuilder<Database, (Result, M?)> where M: Fluent.Model {
+        return alsoDecode(type, M.entity)
+    }
 
     /// Adds an additional type `D` to be decoded when run.
     /// The new result for this query will be a tuple containing the previous result and this new result.
@@ -35,6 +51,27 @@ extension QueryBuilder {
             return Database.queryDecode(row, entity: entity, as: D.self, on: conn).map { (result, $0) }
         }
     }
+    
+    /// Adds an additional type `D` to be decoded when run.
+    /// The new result for this query will be a tuple containing the previous result and this new result.
+    ///
+    ///     let joined = try User.query(on: req)
+    ///         .join(\Pet.userID, to: \User.id)
+    ///         .alsoDecode(PetDetail?.self, "pets")
+    ///         .all()
+    ///     print(joined) // Future<[(User, PetDetail)]>
+    ///
+    /// - parameters:
+    ///     - type: New decodable type `Optional<D>` to also decode.
+    ///     - entity: Entity name of this decodable type.
+    /// - returns: `QueryBuilder` decoding type `(Result, Optional<D>)`.
+    public func alsoDecode<D>(_ type: Optional<D>.Type, _ entity: String) -> QueryBuilder<Database, (Result, D?)> where D: Decodable {
+        return transformResult { row, conn, result in
+            return Database.queryDecode(row, entity: entity, as: D.self, on: conn)
+                .map { (result, $0) }
+                .catchMap { _ in (result, nil) }
+        }
+    }
 
     /// Sets the query to decode `Model` type `D` when run. The `Model`'s entity will be used.
     ///
@@ -49,6 +86,21 @@ extension QueryBuilder {
     /// - returns: `QueryBuilder` decoding type `D`.
     public func decode<Model>(_ type: Model.Type) -> QueryBuilder<Database, Model> where Model: Fluent.Model {
         return decode(data: Model.self, Model.entity)
+    }
+    
+    /// Sets the query to decode `Model` type `D` when run. The `Model`'s entity will be used.
+    ///
+    ///     let joined = try User.query(on: req)
+    ///         .join(Pet.self, field: \.userID, to: \.id)
+    ///         .decode(Pet?.self)
+    ///         .all()
+    ///     print(joined) // Future<[Pet]>
+    ///
+    /// - parameters:
+    ///     - type: New decodable type `Optional<D>` to decode.
+    /// - returns: `QueryBuilder` decoding type `Optional<D>`.
+    public func decode<Model>(_ type: Optional<Model>.Type) -> QueryBuilder<Database, Model?> where Model: Fluent.Model {
+        return decode(data: type, Model.entity)
     }
     
     /// Sets the query to decode `Decodable` type `D` when run. The data will be decoded from the supplied entity.
@@ -66,6 +118,26 @@ extension QueryBuilder {
     public func decode<D>(data type: D.Type, _ entity: String) -> QueryBuilder<Database, D> where D: Decodable {
         return changeResult { row, conn in
             return Database.queryDecode(row, entity: entity, as: D.self, on: conn)
+        }
+    }
+    
+    /// Sets the query to decode `Decodable` type `D` when run. The data will be decoded from the supplied entity.
+    ///
+    ///     let joined = try User.query(on: req)
+    ///         .join(Pet.self, field: \.userID, to: \.id)
+    ///         .decode(data: Pet?.self, "pets")
+    ///         .all()
+    ///     print(joined) // Future<[Pet]>
+    ///
+    /// - parameters:
+    ///     - type: New decodable type `Optional<D>` to decode.
+    ///     - entity: Table or collection to decode from.
+    /// - returns: `QueryBuilder` decoding type `Optional<D>`.
+    public func decode<D>(data type: Optional<D>.Type, _ entity: String) -> QueryBuilder<Database, D?> where D: Decodable {
+        return changeResult { row, conn in
+            return Database.queryDecode(row, entity: entity, as: D.self, on: conn)
+                .map(to: D?.self) { $0 }
+                .catchMap { _ in nil }
         }
     }
 


### PR DESCRIPTION
This could be useful when having a database structure that uses subclassing.

Think of the scenario where only the id of the superclass is know, but you need the extra information form the subclasses that also contain the same id. 

By using optional decoding, you would be able to left join the different types on the ids and from there derive what type it is.

The alternative would to do a `.find(...)` on the different models, but this would lead to more requests and possibly a lower performance.