### PR TITLE
Export Custom Operators

### DIFF
--- a/Sources/Fluent/Exports.swift
+++ b/Sources/Fluent/Exports.swift
@@ -1,1 +1,8 @@
 @_exported import FluentKit
+
+infix operator ~~
+infix operator !~
+infix operator =~
+infix operator !~=
+infix operator !~~
+infix operator !=~

--- a/Sources/Fluent/Exports.swift
+++ b/Sources/Fluent/Exports.swift
@@ -1,8 +1,7 @@
 @_exported import FluentKit
 
 infix operator ~~
-infix operator !~
 infix operator =~
-infix operator !~=
-infix operator !~~
+infix operator !~
 infix operator !=~
+infix operator !~=

--- a/Tests/FluentTests/FluentOperatorTests.swift
+++ b/Tests/FluentTests/FluentOperatorTests.swift
@@ -1,0 +1,58 @@
+import Fluent
+import Vapor
+import XCTVapor
+
+final class FluentOperatorTests: XCTestCase {
+    func testCustomOperators() throws {
+        let db = DummyDatabase()
+
+        // name contains string anywhere, prefix, suffix
+        _ = Planet.query(on: db)
+            .filter(\.$name ~~ "art")
+        _ = Planet.query(on: db)
+            .filter(\.$name =~ "art")
+        _ = Planet.query(on: db)
+            .filter(\.$name ~= "art")
+        // name doesn't contain string anywhere, prefix, suffix
+        _ = Planet.query(on: db)
+            .filter(\.$name !~~ "art")
+        _ = Planet.query(on: db)
+            .filter(\.$name !=~ "art")
+        _ = Planet.query(on: db)
+            .filter(\.$name !~= "art")
+
+        // name in array
+        _ = Planet.query(on: db)
+            .filter(\.$name ~~ ["Earth", "Mars"])
+        // name not in array
+        _ = Planet.query(on: db)
+            .filter(\.$name !~ ["Earth", "Mars"])
+    }
+}
+private final class Planet: Model {
+    static let schema = "planets"
+
+    @ID(key: "id")
+    var id: Int?
+
+    @Field(key: "name")
+    var name: String
+}
+
+private struct DummyDatabase: Database {
+    var context: DatabaseContext {
+        fatalError()
+    }
+
+    func execute(query: DatabaseQuery, onRow: @escaping (DatabaseRow) -> ()) -> EventLoopFuture<Void> {
+        fatalError()
+    }
+
+    func execute(schema: DatabaseSchema) -> EventLoopFuture<Void> {
+        fatalError()
+    }
+
+    func withConnection<T>(_ closure: @escaping (Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+        fatalError()
+    }
+}

--- a/Tests/FluentTests/FluentOperatorTests.swift
+++ b/Tests/FluentTests/FluentOperatorTests.swift
@@ -15,7 +15,7 @@ final class FluentOperatorTests: XCTestCase {
             .filter(\.$name ~= "art")
         // name doesn't contain string anywhere, prefix, suffix
         _ = Planet.query(on: db)
-            .filter(\.$name !~~ "art")
+            .filter(\.$name !~ "art")
         _ = Planet.query(on: db)
             .filter(\.$name !=~ "art")
         _ = Planet.query(on: db)


### PR DESCRIPTION
Provides a workaround for [SR-12132](https://bugs.swift.org/browse/SR-12132) which causes custom operators defined in `FluentKit` to not be exported correctly (fixes vapor/fluent-kit#144, #656)

Custom operators for String filtering will now be available by importing just `Fluent`:

- `~~`: Value contains string
- `=~`: Value has string prefix
- `~=`: Value has string suffix
- `!~`: Value doesn't contain string
- `!=~`: Value doesn't have string prefix
- `!~=`: Value doesn't have string suffix

As well as operators for Array filtering:

- `~~`: Value in array
- `!~`: Value not in array