### PR TITLE
Adds Response.created methods

### DIFF
--- a/Sources/Fluent/Fluent+Model.swift
+++ b/Sources/Fluent/Fluent+Model.swift
@@ -1,0 +1,46 @@
+import Vapor
+
+public protocol ModelContent: Content {
+    associatedtype ModelType: Model
+
+    init(model: ModelType) throws
+}
+
+extension Model where Self: Content {
+    public func verifyETag(on req: Request) throws -> Self {
+        guard let eTag = try self.eTag() else {
+            throw Abort(.internalServerError, reason: "Unable to generate ETag")
+        }
+
+        guard let ifMatch = req.headers.firstValue(name: .ifMatch) else {
+            throw Abort(.badRequest, reason: "Missing If-Match HTTP Header")
+        }
+
+        guard ifMatch == eTag else {
+            throw Abort(.preconditionFailed, reason: "Model state is no longer valid.")
+        }
+
+        return self
+    }
+}
+
+extension Model {
+    public func verifyETag<DTO>(_ dto: DTO.Type, on req: Request) throws -> Self
+        where DTO: ModelContent, DTO.ModelType == Self {
+            let dto = try DTO.init(model: self)
+
+            guard let eTag = try dto.eTag() else {
+                throw Abort(.internalServerError, reason: "Unable to generate ETag")
+            }
+
+            guard let ifMatch = req.headers.firstValue(name: .ifMatch) else {
+                throw Abort(.badRequest, reason: "Missing If-Match HTTP Header")
+            }
+
+            guard ifMatch == eTag else {
+                throw Abort(.preconditionFailed, reason: "Model state is no longer valid.")
+            }
+
+            return self
+    }
+}

--- a/Sources/Fluent/Fluent+Response.swift
+++ b/Sources/Fluent/Fluent+Response.swift
@@ -1,0 +1,114 @@
+import Vapor
+
+extension Response {
+    /// Creates a `Response` object that has a status of 201 (Created) and includes the `Location` HTTP header.
+    ///
+    /// Intended to be used in routes that create a new object.
+    ///
+    /// ### Note ###
+    /// The return type of your route should be `EventLoopFuture<Response>`.
+    ///
+    /// ### Example ###
+    /// ```swift
+    /// func create(req: Request) throws -> EventLoopFuture<Response> {
+    ///    let todo = try req.content.decode(Todo.self)
+    ///    return todo.create(on: req.db).flatMapThrowing {
+    ///        try .created(todo, for: req)
+    ///    }
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - obj: The newly created model.
+    ///   - request: The `Request` which is being responded to.
+    ///   - mediaType: How to encode the response, defaulting to `.json`
+    /// - Throws: If the object hasn't been created or the encoding fails.
+    /// - Returns: A `Response` object.
+    public static func created<T>(
+        _ obj: T,
+        for request: Request,
+        as mediaType: HTTPMediaType = .json
+    ) throws -> Response
+        where T: Model & Content, T.IDValue: CustomStringConvertible {
+            let id = String(describing: try obj.requireID())
+
+            return try self.created(obj, for: request, id: id, as: mediaType)
+    }
+
+    /// Creates a `Response` object that has a status of 201 (Created) and includes the `Location` HTTP header.
+    ///
+    /// Intended to be used in routes that create a new object. Many models contain the actual `id` which
+    /// is the primary key in the database as an `Int`, but then also include a public identifier like a `UUID`
+    /// that consumers utilize. This is simply a convenience method to return that public ID in the `Location` header.
+    ///
+    /// ### Note ###
+    /// The return type of your route should be `EventLoopFuture<Response>`.
+    ///
+    /// ### Example ###
+    /// ```swift
+    /// func create(req: Request) throws -> EventLoopFuture<Response> {
+    ///    let todo = try req.content.decode(Todo.self)
+    ///    return todo.create(on: req.db).flatMapThrowing {
+    ///        try .created(todo, for: req, id: todo.publicUUID.uuidString)
+    ///    }
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - obj: The newly created model.
+    ///   - request: The `Request` which is being responded to.
+    ///   - id: The user visible ID that the model should be queried against.
+    ///   - mediaType: How to encode the response, defaulting to `.json`
+    /// - Throws: If the object hasn't been created or the encoding fails.
+    /// - Returns: A `Response` object.
+    public static func created<T, ID>(
+        _ obj: T,
+        for request: Request,
+        id: ID,
+        as mediaType: HTTPMediaType = .json
+    ) throws -> Response
+        where T: Content, ID: CustomStringConvertible {
+            let id = String(describing: id)
+            let location = "\(request.url.string)/\(id)"
+
+            return try self.created(obj, location: location, as: mediaType)
+    }
+
+    /// Creates a `Response` object that has a status of 201 (Created) and includes the `Location` HTTP header.
+    ///
+    /// Intended to be used in routes that create a new object.
+    ///
+    /// ### Note ###
+    /// The return type of your route should be `EventLoopFuture<Response>`.
+    ///
+    /// ### Example ###
+    /// ```swift
+    /// func create(req: Request) throws -> EventLoopFuture<Response> {
+    ///    let todo = try req.content.decode(Todo.self)
+    ///    return todo.create(on: req.db).flatMapThrowing {
+    ///        let uuid = todo.publicUUID
+    ///        return try .created(todo, location: "\(req.url.string)/\(uuid)")
+    ///    }
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - obj: The newly created model.
+    ///   - location: The location header to use.
+    ///   - mediaType: How to encode the response, defaulting to `.json`
+    /// - Throws: If the encoding fails.
+    /// - Returns: A `Response` object.
+    public static func created<T>(
+        _ obj: T,
+        location: String,
+        as mediaType: HTTPMediaType = .json
+    ) throws -> Response
+        where T: Content {
+            let hash = try Insecure.MD5.hash(data: JSONEncoder().encode(obj))
+            let etag = hash.map { String(format: "%02hhx", $0) }.joined(separator: "")
+            let headers = HTTPHeaders([("Location", location), ("ETag", "\"\(etag)\"")])
+            let response = Response(status: .created, headers: headers)
+
+            try response.content.encode(obj, as: mediaType)
+
+            return response
+    }
+}
+

--- a/Sources/Fluent/Fluent+Response.swift
+++ b/Sources/Fluent/Fluent+Response.swift
@@ -101,12 +101,8 @@ extension Response {
         as mediaType: HTTPMediaType = .json
     ) throws -> Response
         where T: Content {
-            let hash = try Insecure.MD5.hash(data: JSONEncoder().encode(obj))
-            let etag = hash.map { String(format: "%02hhx", $0) }.joined(separator: "")
-            let headers = HTTPHeaders([("Location", location), ("ETag", "\"\(etag)\"")])
-            let response = Response(status: .created, headers: headers)
-
-            try response.content.encode(obj, as: mediaType)
+            let response = try Self.withETag(obj, includeBody: true, justCreated: true)
+            response.headers.add(name: .location, value: location)
 
             return response
     }

--- a/Tests/FluentTests/FluentCreatedTests.swift
+++ b/Tests/FluentTests/FluentCreatedTests.swift
@@ -1,0 +1,69 @@
+import Fluent
+import Vapor
+import XCTVapor
+
+final class FluentCreatedTests: XCTestCase {
+    // ETags are supposed to be hex strings surrounded by double quotes
+    static let eTagRegex = "^\"[a-fA-F0-9]+\"$"
+
+    func testWithCustomLocation() throws {
+        let headerString = UUID().uuidString
+        let response = try Response.created(Todo(), location: headerString)
+        let location = try XCTUnwrap(response.headers.firstValue(name: .location))
+        let etag = try XCTUnwrap(response.headers.firstValue(name: .eTag))
+        XCTAssertNotNil(etag.range(of: Self.eTagRegex, options: .regularExpression))
+        XCTAssertEqual(location, headerString)
+        XCTAssertEqual(response.status, HTTPStatus.created)
+    }
+
+    func testWithRequest() throws {
+        let todo = Todo()
+
+        let uri = URI(path: "https://www.example.com/todos")
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let req = Request(application: app, method: .POST, url: uri, on: app.eventLoopGroup.next())
+
+        let response = try Response.created(todo, for: req)
+        let location = try XCTUnwrap(response.headers.firstValue(name: .location))
+        let etag = try XCTUnwrap(response.headers.firstValue(name: .eTag))
+        XCTAssertNotNil(etag.range(of: Self.eTagRegex, options: .regularExpression))
+        XCTAssertNotNil(response.headers.firstValue(name: .eTag))
+        XCTAssertEqual(location, "\(uri.string)/\(todo.id!)")
+        XCTAssertEqual(response.status, HTTPStatus.created)
+    }
+
+    func testWithPublicID() throws {
+        let todo = Todo()
+
+        let uri = URI(path: "https://www.example.com/todos")
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let req = Request(application: app, method: .POST, url: uri, on: app.eventLoopGroup.next())
+
+        let response = try Response.created(todo, for: req, id: todo.publicUUID)
+        let location = try XCTUnwrap(response.headers.firstValue(name: .location))
+        let etag = try XCTUnwrap(response.headers.firstValue(name: .eTag))
+        XCTAssertNotNil(etag.range(of: Self.eTagRegex, options: .regularExpression))
+        XCTAssertNotNil(response.headers.firstValue(name: .eTag))
+        XCTAssertEqual(location, "\(uri.string)/\(todo.publicUUID)")
+        XCTAssertEqual(response.status, HTTPStatus.created)
+    }
+}
+
+private final class Todo: Model, Content {
+    static let schema = ""
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "uuid")
+    var publicUUID: UUID
+
+    init() {
+        self.id = UUID()
+        self.publicUUID = UUID()
+    }
+}


### PR DESCRIPTION
Provides convenience methods for returning newly created objects.  Sets the status code to 201 (Created) and includes the Location header.

```swift
func create(req: Request) throws -> EventLoopFuture<Response> {
    let todo = try req.content.decode(Todo.self)
    return todo.create(on: req.db).flatMapThrowing {
        try .created(todo, for: req)
    }
}
```