### PR TITLE
Fluent Session migration bugfix

### DIFF
--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -115,6 +115,11 @@ public final class Session: Model {
 }
 
 public struct CreateSession: Migration {
+    
+    public init() {
+        
+    }
+    
     public func prepare(on database: Database) -> EventLoopFuture<Void> {
         return database.schema("sessions")
             .field("id", .uuid, .identifier(auto: false))

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -92,7 +92,7 @@ private struct DatabaseSessionAuthenticator<User>: SessionAuthenticator
 }
 
 public final class Session: Model {
-    public static let schema = "sessions"
+    public static let schema = "_fluent_sessions"
     
     @ID(key: "id")
     public var id: UUID?
@@ -121,7 +121,7 @@ public struct CreateSession: Migration {
     }
     
     public func prepare(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema("sessions")
+        return database.schema("_fluent_sessions")
             .field("id", .uuid, .identifier(auto: false))
             .field("key", .string, .required)
             .field("data", .json, .required)
@@ -129,6 +129,6 @@ public struct CreateSession: Migration {
     }
     
     public func revert(on database: Database) -> EventLoopFuture<Void> {
-        return database.schema("sessions").delete()
+        return database.schema("_fluent_sessions").delete()
     }
 }


### PR DESCRIPTION
- Add public init() for `CreateSession`. This solves code protection level error when calling CreateSession() in app migration.
- Renamed Fluent Session table from `sessions` to `_fluent_sessions`. It's now obvious that `_fluent_sessions` is a system table. Since we already have `_fluent_migrations` I would continue with the same naming convention.