### PR TITLE
Adds EntityTaggableModel for ETag responses

### DIFF
--- a/Sources/Fluent/etag/Fluent+EntityTaggableModel.swift
+++ b/Sources/Fluent/etag/Fluent+EntityTaggableModel.swift
@@ -1,0 +1,20 @@
+import Vapor
+
+public extension EventLoopFuture where Value: EntityTaggableModel {
+    /// Verifies that the ETag stored in the database matches the ETag passed via the `If-Match` HTTP header.
+    /// - Parameters:
+    ///   - req: The `Request` object.
+    func verifyETag(on req: Request) -> EventLoopFuture<Value> {
+        return self.flatMapThrowing { model -> Value in
+            guard let ifMatch = req.headers.first(name: .ifMatch) else {
+                throw Abort(.badRequest, reason: "Missing If-Match HTTP Header.")
+            }
+
+            guard ifMatch == model.eTag else {
+                throw Abort(.preconditionFailed, reason: "Model state is no longer valid.")
+            }
+
+            return model
+        }
+    }
+}

--- a/Sources/Fluent/etag/ModelContent.swift
+++ b/Sources/Fluent/etag/ModelContent.swift
@@ -1,0 +1,8 @@
+import Vapor
+
+/// Protocol meant for DTO type objects that are initializable by a `Model` object
+public protocol ModelContent: Content {
+    associatedtype ModelType: Model
+
+    init(model: ModelType) throws
+}

--- a/Sources/Fluent/etag/Response+ETag.swift
+++ b/Sources/Fluent/etag/Response+ETag.swift
@@ -1,6 +1,6 @@
 import Vapor
 
-extension Response {
+public extension Response {
     // MARK: - DTO related -
 
     /// Returns a `Response` with appropriate ETag headers.

--- a/Sources/Fluent/etag/Response+ETag.swift
+++ b/Sources/Fluent/etag/Response+ETag.swift
@@ -1,0 +1,117 @@
+import Vapor
+
+extension Response {
+    // MARK: - DTO related -
+
+    /// Returns a `Response` with appropriate ETag headers.
+    ///
+    /// Use this method when you generate a DTO for the model to be returned, and would like to
+    /// automatically include the appropriate HTTP ETag header.
+    /// - Parameters:
+    ///   - dto: The type of DTO which should be generated based on the returned `model`
+    ///   - model: The `Model` being returned.
+    ///   - status: The HTTP Status code.
+    ///   - headers: The HTTP headers to use
+    /// - Throws: If the DTO fails to generate.
+    /// - Returns: The `Response` object.
+    static func withETag<D, M>(
+        _ dto: D.Type,
+        _ model: M,
+        status: HTTPStatus = .ok,
+        headers: HTTPHeaders = .init()
+    ) throws -> Response where D: ModelContent, M: EntityTaggableModel, M == D.ModelType {
+        let response = Response(status: status, headers: headers)
+        let content = try dto.init(model: model)
+        try response.content.encode(content)
+
+        response.headers.add(name: .eTag, value: model.eTag)
+
+        return response
+    }
+
+    /// Returns a `Response` with appropriate ETag and Location headers and an HTTP status of 201 (Created)
+    ///
+    /// Use this method when you generate a DTO for the model to be returned, and would like to
+    /// automatically include the appropriate HTTP ETag and Location headers.
+    /// - Parameters:
+    ///   - dto: The type of DTO which should be generated based on the returned `model`
+    ///   - model: The `Model` being returned.
+    ///   - location: The value to place in the HTTP Location header.
+    ///   - headers: The HTTP headers to use
+    /// - Throws: If the DTO fails to generate.
+    /// - Returns: The `Response` object.
+    static func createdWithETag<D, M>(
+        _ dto: D.Type,
+        _ model: M,
+        location: String? = nil,
+        headers: HTTPHeaders = .init()
+    ) throws -> Response where D: ModelContent, M: EntityTaggableModel, M == D.ModelType {
+        var headers = headers
+        if let location = location {
+            headers.add(name: .location, value: location)
+        }
+
+        return try withETag(dto, model, status: .created, headers: headers)
+    }
+
+    /// Returns a `Response` with appropriate ETag and Location headers and an HTTP status of 201 (Created)
+    ///
+    /// Use this method when you generate a DTO for the model to be returned, and would like to
+    /// automatically include the appropriate HTTP ETag and Location headers.
+    /// - Parameters:
+    ///   - dto: The type of DTO which should be generated based on the returned `model`
+    ///   - model: The `Model` being returned.
+    ///   - locationFrom: The `Request` used to generate a default Location header.
+    ///   - headers: The HTTP headers to use
+    /// - Throws: If the DTO fails to generate.
+    /// - Returns: The `Response` object.
+    static func createdWithETag<D, M>(
+        _ dto: D.Type,
+        _ model: M,
+        locationFrom req: Request? = nil,
+        headers: HTTPHeaders = .init()
+    ) throws -> Response where D: ModelContent, M: EntityTaggableModel, M == D.ModelType {
+        let location = try req?.location(for: model)
+
+        return try createdWithETag(dto, model, location: location, headers: headers)
+    }
+
+    // MARK: - Model related -
+    static func withETag<M>(_ model: M, status: HTTPStatus = .ok, headers: HTTPHeaders = .init()) throws -> Response where M: Content & EntityTaggableModel {
+        let response = Response(status: status, headers: headers)
+        try response.content.encode(model)
+
+        response.headers.add(name: .eTag, value: model.eTag)
+
+        return response
+    }
+
+    static func createdWithETag<M>(
+        _ model: M,
+        location: String? = nil,
+        headers: HTTPHeaders = .init()
+    ) throws -> Response where M: EntityTaggableModel & Content {
+        var headers = headers
+        if let location = location {
+            headers.add(name: .location, value: location)
+        }
+
+        return try withETag(model, status: .created, headers: headers)
+    }
+
+    static func createdWithETag<M>(
+        _ model: M,
+        locationFrom req: Request? = nil,
+        headers: HTTPHeaders = .init()
+    ) throws -> Response where M: EntityTaggableModel & Content {
+        let location = try req?.location(for: model)
+        return try createdWithETag(model, location: location, headers: headers)
+    }
+}
+
+private extension Request {
+    func location<M>(for model: M) throws -> String where M: Model {
+        let id = try String(describing: model.requireID())
+        return "\(self.url.string)/\(id)"
+    }
+}


### PR DESCRIPTION
Adds a `verifyETag(on:)` to `EventLoopFuture` to verify incoming ETag.

Adds a `ModelContent` protocol which tags `Content` which includes an `init(model:)` constructor to generate a DTO based on a model.

Adds `withETag` and `createdWithETag` methods to generate a `Response` that includes the etag and location (on created) headers.

**Must be released at the same time as https://github.com/vapor/fluent-kit/pull/243**