### PR TITLE
Fix deprecated renamed fix for ModelTokenAuthenticatable

### DIFF
--- a/Sources/Fluent/Deprecated.swift
+++ b/Sources/Fluent/Deprecated.swift
@@ -3,7 +3,7 @@ import Vapor
 @available(*, deprecated, renamed: "ModelAuthenticatable")
 public typealias ModelUser = ModelAuthenticatable
 
-@available(*, deprecated, renamed: "ModelAuthenticatable")
+@available(*, deprecated, renamed: "ModelTokenAuthenticatable")
 public typealias ModelUserToken = ModelTokenAuthenticatable
 
 extension Application.Fluent.Sessions {


### PR DESCRIPTION
Fixes incorrect rename deprecation for `ModelTokenAuthenticatable` (#677). 