### PR TITLE
Add unique index to SessionRecord key

### DIFF
--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -58,21 +58,21 @@ private struct DatabaseSessions: SessionDriver {
     
     func createSession(_ data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
         let id = self.generateID()
-        return SessionRecord(key: id, data: data)
+        return SessionRecord(id: id, data: data)
             .create(on: request.db(self.databaseID))
             .map { id }
     }
     
     func readSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<SessionData?> {
         SessionRecord.query(on: request.db(self.databaseID))
-            .filter(\.$key == sessionID)
+            .filter(\.$id == sessionID)
             .first()
             .map { $0?.data }
     }
     
     func updateSession(_ sessionID: SessionID, to data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
         SessionRecord.query(on: request.db(self.databaseID))
-            .filter(\.$key == sessionID)
+            .filter(\.$id == sessionID)
             .set(\.$data, to: data)
             .update()
             .map { sessionID }
@@ -80,7 +80,7 @@ private struct DatabaseSessions: SessionDriver {
     
     func deleteSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<Void> {
         SessionRecord.query(on: request.db(self.databaseID))
-            .filter(\.$key == sessionID)
+            .filter(\.$id == sessionID)
             .delete()
     }
     
@@ -114,7 +114,6 @@ public final class SessionRecord: Model {
         func prepare(on database: Database) -> EventLoopFuture<Void> {
             database.schema("_fluent_sessions")
                 .id()
-                .field("key", .string, .required)
                 .field("data", .json, .required)
                 .create()
         }
@@ -128,16 +127,16 @@ public final class SessionRecord: Model {
         _Migration()
     }
     
-    @ID(key: "key")
-    public var key: SessionID?
+    @ID()
+    public var id: SessionID?
     
     @Field(key: "data")
     public var data: SessionData
     
     public init() { }
     
-    public init(key: SessionID, data: SessionData) {
-        self.key = key
+    public init(id: SessionID, data: SessionData) {
+        self.id = id
         self.data = data
     }
 }

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -133,7 +133,7 @@ public final class SessionRecord: Model {
     public var id: UUID?
     
     @ID(key: "key")
-    public var key: SessionID?
+    public var key: SessionID
     
     @Field(key: "data")
     public var data: SessionData

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -128,19 +128,15 @@ public final class SessionRecord: Model {
         _Migration()
     }
     
-    @ID(key: .id)
-    public var id: UUID?
-    
-    @Field(key: "key")
-    public var key: SessionID
+    @ID(key: "key")
+    public var key: SessionID?
     
     @Field(key: "data")
     public var data: SessionData
     
     public init() { }
     
-    public init(id: UUID? = nil, key: SessionID, data: SessionData) {
-        self.id = id
+    public init(key: SessionID, data: SessionData) {
         self.key = key
         self.data = data
     }

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -132,7 +132,7 @@ public final class SessionRecord: Model {
     @ID(key: .id)
     public var id: UUID?
     
-    @ID(key: "key")
+    @Field(key: "key")
     public var key: SessionID
     
     @Field(key: "data")

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -127,7 +127,7 @@ public final class SessionRecord: Model {
         _Migration()
     }
     
-    @ID()
+    @ID(custom: .id, generatedBy: .user)
     public var id: SessionID?
     
     @Field(key: "data")

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -140,7 +140,8 @@ public final class SessionRecord: Model {
     
     public init() { }
     
-    public init(key: SessionID, data: SessionData) {
+    public init(id: UUID? = nil, key: SessionID, data: SessionData) {
+        self.id = id
         self.key = key
         self.data = data
     }

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -58,21 +58,21 @@ private struct DatabaseSessions: SessionDriver {
     
     func createSession(_ data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
         let id = self.generateID()
-        return SessionRecord(id: id, data: data)
+        return SessionRecord(key: id, data: data)
             .create(on: request.db(self.databaseID))
             .map { id }
     }
     
     func readSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<SessionData?> {
         SessionRecord.query(on: request.db(self.databaseID))
-            .filter(\.$id == sessionID)
+            .filter(\.$key == sessionID)
             .first()
             .map { $0?.data }
     }
     
     func updateSession(_ sessionID: SessionID, to data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
         SessionRecord.query(on: request.db(self.databaseID))
-            .filter(\.$id == sessionID)
+            .filter(\.$key == sessionID)
             .set(\.$data, to: data)
             .update()
             .map { sessionID }
@@ -80,7 +80,7 @@ private struct DatabaseSessions: SessionDriver {
     
     func deleteSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<Void> {
         SessionRecord.query(on: request.db(self.databaseID))
-            .filter(\.$id == sessionID)
+            .filter(\.$key == sessionID)
             .delete()
     }
     
@@ -114,6 +114,7 @@ public final class SessionRecord: Model {
         func prepare(on database: Database) -> EventLoopFuture<Void> {
             database.schema("_fluent_sessions")
                 .id()
+                .field("key", .string, .required)
                 .field("data", .json, .required)
                 .create()
         }
@@ -127,16 +128,16 @@ public final class SessionRecord: Model {
         _Migration()
     }
     
-    @ID(custom: .id, generatedBy: .user)
-    public var id: SessionID?
+    @ID(key: "key")
+    public var key: SessionID?
     
     @Field(key: "data")
     public var data: SessionData
     
     public init() { }
     
-    public init(id: SessionID, data: SessionData) {
-        self.id = id
+    public init(key: SessionID, data: SessionData) {
+        self.key = key
         self.data = data
     }
 }

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -116,6 +116,7 @@ public final class SessionRecord: Model {
                 .id()
                 .field("key", .string, .required)
                 .field("data", .json, .required)
+                .unique(on: "key")
                 .create()
         }
 

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -129,6 +129,9 @@ public final class SessionRecord: Model {
         _Migration()
     }
     
+    @ID(key: .id)
+    public var id: UUID?
+    
     @ID(key: "key")
     public var key: SessionID?
     

--- a/Tests/FluentTests/SessionTests.swift
+++ b/Tests/FluentTests/SessionTests.swift
@@ -42,7 +42,8 @@ final class SessionTests: XCTestCase {
         // Add single query output with session data for session read.
         test.append([
             TestOutput([
-                "id": SessionID(string: sessionID!),
+                "id": UUID(),
+                "key": SessionID(string: sessionID!),
                 "data": SessionData(["name": "vapor"])
             ])
         ])

--- a/Tests/FluentTests/SessionTests.swift
+++ b/Tests/FluentTests/SessionTests.swift
@@ -42,8 +42,7 @@ final class SessionTests: XCTestCase {
         // Add single query output with session data for session read.
         test.append([
             TestOutput([
-                "id": UUID(),
-                "key": SessionID(string: sessionID!),
+                "id": SessionID(string: sessionID!),
                 "data": SessionData(["name": "vapor"])
             ])
         ])


### PR DESCRIPTION
Adds a unique index to `SessionRecord.key` to improve data integrity and key lookup performance (#680). 

⚠️ If you have already added the `SessionRecord` migration in production, you will need to add this unique index manually. 