### PR TITLE
Adds the ability to retrieve query history

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Fluent", targets: ["Fluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("query-history-2")),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0-rc.2.4"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Fluent", targets: ["Fluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0-rc.2"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", .branch("query-history-2")),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [

--- a/Sources/Fluent/Fluent+History.swift
+++ b/Sources/Fluent/Fluent+History.swift
@@ -13,14 +13,37 @@ struct FluentHistory {
     let enabled: Bool
 }
 
+extension Request {
+    public struct Fluent {
+        let request: Request
+
+        public var history: History {
+            .init(fluent: self)
+        }
+
+        public struct History {
+            let fluent: Fluent
+        }
+    }
+}
+
 extension Application.Fluent.History {
     var historyEnabled: Bool {
-        return (self.fluent.application.storage[FluentHistoryKey.self]?.enabled) ?? false
+        storage[FluentHistoryKey.self]?.enabled ?? false
+    }
+
+    var storage: Storage {
+        get {
+            self.fluent.application.storage
+        }
+        nonmutating set {
+            self.fluent.application.storage = newValue
+        }
     }
 
     var history: QueryHistory {
-        guard historyEnabled else { return .init() }
-        return self.fluent.application.storage[RequestQueryHistory.self] ?? .init()
+        guard self.historyEnabled else { return .init() }
+        return storage[RequestQueryHistory.self] ?? .init()
     }
 
     /// The queries stored in this lifecycle history
@@ -30,30 +53,38 @@ extension Application.Fluent.History {
 
     /// Start recording the query history
     public func start() {
-        self.fluent.application.storage[FluentHistoryKey.self] = .init(enabled: true)
-        self.fluent.application.storage[RequestQueryHistory.self] = .init()
+        storage[FluentHistoryKey.self] = .init(enabled: true)
+        storage[RequestQueryHistory.self] = .init()
     }
 
     /// Stop recording the query history
     public func stop() {
-        self.fluent.application.storage[FluentHistoryKey.self] = .init(enabled: false)
-        self.fluent.application.storage[RequestQueryHistory.self] = nil
+        storage[FluentHistoryKey.self] = .init(enabled: false)
     }
 
     /// Clear the stored query history
     public func clear() {
-        self.fluent.application.storage[RequestQueryHistory.self] = .init()
+        storage[RequestQueryHistory.self] = .init()
     }
 }
 
 extension Request.Fluent.History {
     var historyEnabled: Bool {
-        return (self.fluent.request.storage[FluentHistoryKey.self]?.enabled) ?? false
+        return (storage[FluentHistoryKey.self]?.enabled) ?? false
+    }
+
+    var storage: Storage {
+        get {
+            self.fluent.request.storage
+        }
+        nonmutating set {
+            self.fluent.request.storage = newValue
+        }
     }
 
     var history: QueryHistory {
         guard historyEnabled else { return .init() }
-        return self.fluent.request.storage[RequestQueryHistory.self] ?? .init()
+        return storage[RequestQueryHistory.self] ?? .init()
     }
 
     /// The queries stored in this lifecycle history
@@ -69,12 +100,11 @@ extension Request.Fluent.History {
 
     /// Stop recording the query history
     public func stop() {
-        self.fluent.request.storage[FluentHistoryKey.self] = .init(enabled: false)
-        self.fluent.request.storage[RequestQueryHistory.self] = nil
+        storage[FluentHistoryKey.self] = .init(enabled: false)
     }
 
     /// Clear the stored query history
     public func clear() {
-        self.fluent.request.storage[RequestQueryHistory.self] = .init()
+        storage[RequestQueryHistory.self] = .init()
     }
 }

--- a/Sources/Fluent/Fluent+History.swift
+++ b/Sources/Fluent/Fluent+History.swift
@@ -41,14 +41,13 @@ extension Application.Fluent.History {
         }
     }
 
-    var history: QueryHistory {
-        guard self.historyEnabled else { return .init() }
-        return storage[RequestQueryHistory.self] ?? .init()
+    var history: QueryHistory? {
+        return storage[RequestQueryHistory.self]
     }
 
     /// The queries stored in this lifecycle history
     public var queries: [DatabaseQuery] {
-        return history.queries
+        return history?.queries ?? []
     }
 
     /// Start recording the query history
@@ -82,14 +81,13 @@ extension Request.Fluent.History {
         }
     }
 
-    var history: QueryHistory {
-        guard historyEnabled else { return .init() }
-        return storage[RequestQueryHistory.self] ?? .init()
+    var history: QueryHistory? {
+        return storage[RequestQueryHistory.self]
     }
 
     /// The queries stored in this lifecycle history
     public var queries: [DatabaseQuery] {
-        return history.queries
+        return history?.queries ?? []
     }
 
     /// Start recording the query history

--- a/Sources/Fluent/Fluent+History.swift
+++ b/Sources/Fluent/Fluent+History.swift
@@ -1,19 +1,60 @@
 import Vapor
+import FluentKit
+
+struct RequestQueryHistory: StorageKey {
+    typealias Value = QueryHistory
+}
+
+struct FluentHistoryKey: StorageKey {
+    typealias Value = FluentHistory
+}
+
+struct FluentHistory {
+    let enabled: Bool
+}
 
 extension Application.Fluent {
     var historyEnabled: Bool {
-        return (self.application.storage[HistoryKey.self]?.enabled) ?? false
+        return (self.application.storage[FluentHistoryKey.self]?.enabled) ?? false
     }
 
-    public func enableQueryHistory() {
-        self.application.storage[HistoryKey.self] = .init(enabled: true)
+    public var history: QueryHistory? {
+        guard historyEnabled else { return nil }
+        return self.application.storage[RequestQueryHistory.self]
     }
 
-    public struct History {
-        let enabled: Bool
+    public func startRecording() {
+        self.application.storage[FluentHistoryKey.self] = .init(enabled: true)
+        self.application.storage[RequestQueryHistory.self] = .init()
     }
 
-    struct HistoryKey: StorageKey {
-        typealias Value = History
+    public func stopRecording() {
+        self.application.storage[FluentHistoryKey.self] = .init(enabled: false)
+        self.application.storage[RequestQueryHistory.self] = nil
+    }
+
+    public func clearHistory() {
+        self.application.storage[RequestQueryHistory.self] = .init()
+    }
+}
+
+extension Request.Fluent {
+    var historyEnabled: Bool {
+        return (self.request.storage[FluentHistoryKey.self]?.enabled) ?? false
+    }
+
+    public var history: QueryHistory? {
+        guard historyEnabled else { return nil }
+        return self.request.storage[RequestQueryHistory.self]
+    }
+
+    public func startRecording() {
+        self.request.storage[FluentHistoryKey.self] = .init(enabled: true)
+        self.request.storage[RequestQueryHistory.self] = .init()
+    }
+
+    public func stopRecording() {
+        self.request.storage[FluentHistoryKey.self] = .init(enabled: false)
+        self.request.storage[RequestQueryHistory.self] = nil
     }
 }

--- a/Sources/Fluent/Fluent+History.swift
+++ b/Sources/Fluent/Fluent+History.swift
@@ -1,0 +1,19 @@
+import Vapor
+
+extension Application.Fluent {
+    var historyEnabled: Bool {
+        return (self.application.storage[HistoryKey.self]?.enabled) ?? false
+    }
+
+    public func enableQueryHistory() {
+        self.application.storage[HistoryKey.self] = .init(enabled: true)
+    }
+
+    public struct History {
+        let enabled: Bool
+    }
+
+    struct HistoryKey: StorageKey {
+        typealias Value = History
+    }
+}

--- a/Sources/Fluent/Fluent+History.swift
+++ b/Sources/Fluent/Fluent+History.swift
@@ -13,48 +13,68 @@ struct FluentHistory {
     let enabled: Bool
 }
 
-extension Application.Fluent {
+extension Application.Fluent.History {
     var historyEnabled: Bool {
-        return (self.application.storage[FluentHistoryKey.self]?.enabled) ?? false
+        return (self.fluent.application.storage[FluentHistoryKey.self]?.enabled) ?? false
     }
 
-    public var history: QueryHistory? {
-        guard historyEnabled else { return nil }
-        return self.application.storage[RequestQueryHistory.self]
+    var history: QueryHistory {
+        guard historyEnabled else { return .init() }
+        return self.fluent.application.storage[RequestQueryHistory.self] ?? .init()
     }
 
-    public func startRecording() {
-        self.application.storage[FluentHistoryKey.self] = .init(enabled: true)
-        self.application.storage[RequestQueryHistory.self] = .init()
+    /// The queries stored in this lifecycle history
+    public var queries: [DatabaseQuery] {
+        return history.queries
     }
 
-    public func stopRecording() {
-        self.application.storage[FluentHistoryKey.self] = .init(enabled: false)
-        self.application.storage[RequestQueryHistory.self] = nil
+    /// Start recording the query history
+    public func start() {
+        self.fluent.application.storage[FluentHistoryKey.self] = .init(enabled: true)
+        self.fluent.application.storage[RequestQueryHistory.self] = .init()
     }
 
-    public func clearHistory() {
-        self.application.storage[RequestQueryHistory.self] = .init()
+    /// Stop recording the query history
+    public func stop() {
+        self.fluent.application.storage[FluentHistoryKey.self] = .init(enabled: false)
+        self.fluent.application.storage[RequestQueryHistory.self] = nil
+    }
+
+    /// Clear the stored query history
+    public func clear() {
+        self.fluent.application.storage[RequestQueryHistory.self] = .init()
     }
 }
 
-extension Request.Fluent {
+extension Request.Fluent.History {
     var historyEnabled: Bool {
-        return (self.request.storage[FluentHistoryKey.self]?.enabled) ?? false
+        return (self.fluent.request.storage[FluentHistoryKey.self]?.enabled) ?? false
     }
 
-    public var history: QueryHistory? {
-        guard historyEnabled else { return nil }
-        return self.request.storage[RequestQueryHistory.self]
+    var history: QueryHistory {
+        guard historyEnabled else { return .init() }
+        return self.fluent.request.storage[RequestQueryHistory.self] ?? .init()
     }
 
-    public func startRecording() {
-        self.request.storage[FluentHistoryKey.self] = .init(enabled: true)
-        self.request.storage[RequestQueryHistory.self] = .init()
+    /// The queries stored in this lifecycle history
+    public var queries: [DatabaseQuery] {
+        return history.queries
     }
 
-    public func stopRecording() {
-        self.request.storage[FluentHistoryKey.self] = .init(enabled: false)
-        self.request.storage[RequestQueryHistory.self] = nil
+    /// Start recording the query history
+    public func start() {
+        self.fluent.request.storage[FluentHistoryKey.self] = .init(enabled: true)
+        self.fluent.request.storage[RequestQueryHistory.self] = .init()
+    }
+
+    /// Stop recording the query history
+    public func stop() {
+        self.fluent.request.storage[FluentHistoryKey.self] = .init(enabled: false)
+        self.fluent.request.storage[RequestQueryHistory.self] = nil
+    }
+
+    /// Clear the stored query history
+    public func clear() {
+        self.fluent.request.storage[RequestQueryHistory.self] = .init()
     }
 }

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -7,24 +7,18 @@ extension Request {
     }
 
     public func db(_ id: DatabaseID?) -> Database {
-        self.application.databases
-            .database(id, logger: self.logger, on: self.eventLoop, history: self.fluent.history.historyEnabled ? self.fluent.history.history : nil)!
+        self.application
+            .databases
+            .database(
+                id,
+                logger: self.logger,
+                on: self.eventLoop,
+                history: self.fluent.history.historyEnabled ? self.fluent.history.history : nil
+            )!
     }
 
     public var fluent: Fluent {
         .init(request: self)
-    }
-
-    public struct Fluent {
-        let request: Request
-
-        public var history: History {
-            .init(fluent: self)
-        }
-
-        public struct History {
-            let fluent: Fluent
-        }
     }
 }
 
@@ -35,7 +29,12 @@ extension Application {
 
     public func db(_ id: DatabaseID?) -> Database {
         self.databases
-            .database(id, logger: self.logger, on: self.eventLoopGroup.next(), history: self.fluent.history.historyEnabled ? self.fluent.history.history : nil)!
+            .database(
+                id,
+                logger: self.logger,
+                on: self.eventLoopGroup.next(),
+                history: self.fluent.history.historyEnabled ? self.fluent.history.history : nil
+            )!
     }
 
     public var databases: Databases {

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -8,7 +8,7 @@ extension Request {
 
     public func db(_ id: DatabaseID?) -> Database {
         self.application.databases
-            .database(id, logger: self.logger, on: self.eventLoop, history: self.fluent.history)!
+            .database(id, logger: self.logger, on: self.eventLoop, history: self.fluent.history.historyEnabled ? self.fluent.history.history : nil)!
     }
 
     public var fluent: Fluent {
@@ -17,6 +17,14 @@ extension Request {
 
     public struct Fluent {
         let request: Request
+
+        public var history: History {
+            .init(fluent: self)
+        }
+
+        public struct History {
+            let fluent: Fluent
+        }
     }
 }
 
@@ -27,7 +35,7 @@ extension Application {
 
     public func db(_ id: DatabaseID?) -> Database {
         self.databases
-            .database(id, logger: self.logger, on: self.eventLoopGroup.next(), history: self.fluent.history)!
+            .database(id, logger: self.logger, on: self.eventLoopGroup.next(), history: self.fluent.history.historyEnabled ? self.fluent.history.history : nil)!
     }
 
     public var databases: Databases {
@@ -123,6 +131,14 @@ extension Application {
             )
             self.application.lifecycle.use(Lifecycle())
             self.application.commands.use(MigrateCommand(), as: "migrate")
+        }
+
+        public var history: History {
+            .init(fluent: self)
+        }
+
+        public struct History {
+            let fluent: Fluent
         }
     }
 

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -1,24 +1,33 @@
 import Vapor
+import FluentKit
 
 extension Request {
+    public var queryHistory: QueryHistory {
+        return .init()
+    }
+
     public var db: Database {
         self.db(nil)
     }
 
     public func db(_ id: DatabaseID?) -> Database {
         self.application.databases
-            .database(id, logger: self.logger, on: self.eventLoop)!
+            .database(id, logger: self.logger, on: self.eventLoop, history: self.application.fluent.historyEnabled ? queryHistory : nil)!
     }
 }
 
 extension Application {
+    public var queryHistory: QueryHistory {
+        return .init()
+    }
+
     public var db: Database {
         self.db(nil)
     }
 
     public func db(_ id: DatabaseID?) -> Database {
         self.databases
-            .database(id, logger: self.logger, on: self.eventLoopGroup.next())!
+            .database(id, logger: self.logger, on: self.eventLoopGroup.next(), history: self.fluent.historyEnabled ? queryHistory : nil)!
     }
 
     public var databases: Databases {

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -2,32 +2,32 @@ import Vapor
 import FluentKit
 
 extension Request {
-    public var queryHistory: QueryHistory {
-        return .init()
-    }
-
     public var db: Database {
         self.db(nil)
     }
 
     public func db(_ id: DatabaseID?) -> Database {
         self.application.databases
-            .database(id, logger: self.logger, on: self.eventLoop, history: self.application.fluent.historyEnabled ? queryHistory : nil)!
+            .database(id, logger: self.logger, on: self.eventLoop, history: self.fluent.history)!
+    }
+
+    public var fluent: Fluent {
+        .init(request: self)
+    }
+
+    public struct Fluent {
+        let request: Request
     }
 }
 
 extension Application {
-    public var queryHistory: QueryHistory {
-        return .init()
-    }
-
     public var db: Database {
         self.db(nil)
     }
 
     public func db(_ id: DatabaseID?) -> Database {
         self.databases
-            .database(id, logger: self.logger, on: self.eventLoopGroup.next(), history: self.fluent.historyEnabled ? queryHistory : nil)!
+            .database(id, logger: self.logger, on: self.eventLoopGroup.next(), history: self.fluent.history)!
     }
 
     public var databases: Databases {

--- a/Tests/FluentTests/QueryHistoryTests.swift
+++ b/Tests/FluentTests/QueryHistoryTests.swift
@@ -1,0 +1,76 @@
+import Fluent
+import Vapor
+import XCTFluent
+import XCTVapor
+
+final class QueryHistoryTests: XCTestCase {
+    func testQueryHistoryDisabled() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let test = ArrayTestDatabase()
+        app.databases.use(test.configuration, as: .test)
+
+        test.append([
+            TestOutput(["id": 1, "content": "a"]),
+            TestOutput(["id": 2, "content": "b"]),
+        ])
+
+        app.get("foo") { req -> EventLoopFuture<[Post]> in
+            return Post.query(on: req.db).all().map { posts in
+                XCTAssertEqual(req.queryHistory.queries.count, 0)
+                return posts
+            }
+        }
+
+        try app.testable().test(.GET, "foo") { res in
+            XCTAssertEqual(res.status, .ok)
+        }
+    }
+
+    func testQueryHistoryEnabled() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.fluent.enableQueryHistory()
+        let test = ArrayTestDatabase()
+        app.databases.use(test.configuration, as: .test)
+
+        test.append([
+            TestOutput(["id": 1, "content": "a"]),
+            TestOutput(["id": 2, "content": "b"]),
+        ])
+
+        app.get("foo") { req -> EventLoopFuture<[Post]> in
+            return Post.query(on: req.db).all().map { posts in
+                XCTAssertEqual(req.queryHistory.queries.count, 1)
+                return posts
+            }
+        }
+
+        try app.testable().test(.GET, "foo") { res in
+            XCTAssertEqual(res.status, .ok)
+        }
+    }
+}
+
+private final class Post: Model, Content, Equatable {
+    static func == (lhs: Post, rhs: Post) -> Bool {
+        lhs.id == rhs.id && lhs.content == rhs.content
+    }
+
+    static var schema: String { "posts" }
+
+    @ID(custom: .id)
+    var id: Int?
+
+    @Field(key: "content")
+    var content: String
+
+    init() { }
+
+    init(id: Int? = nil, content: String) {
+        self.id = id
+        self.content = content
+    }
+}

--- a/Tests/FluentTests/QueryHistoryTests.swift
+++ b/Tests/FluentTests/QueryHistoryTests.swift
@@ -18,7 +18,7 @@ final class QueryHistoryTests: XCTestCase {
 
         app.get("foo") { req -> EventLoopFuture<[Post]> in
             return Post.query(on: req.db).all().map { posts in
-                XCTAssertEqual(req.fluent.history?.queries.count, nil)
+                XCTAssertEqual(req.fluent.history.queries.count, 0)
                 return posts
             }
         }
@@ -41,9 +41,9 @@ final class QueryHistoryTests: XCTestCase {
         ])
 
         app.get("foo") { req -> EventLoopFuture<[Post]> in
-            req.fluent.startRecording()
+            req.fluent.history.start()
             return Post.query(on: req.db).all().map { posts in
-                XCTAssertEqual(req.fluent.history?.queries.count, 1)
+                XCTAssertEqual(req.fluent.history.queries.count, 1)
                 return posts
             }
         }
@@ -66,10 +66,10 @@ final class QueryHistoryTests: XCTestCase {
         ])
 
         app.get("foo") { req -> EventLoopFuture<[Post]> in
-            req.fluent.startRecording()
+            req.fluent.history.start()
             return Post.query(on: req.db).all().flatMap { posts -> EventLoopFuture<[Post]> in
-                XCTAssertEqual(req.fluent.history?.queries.count, 1)
-                req.fluent.stopRecording()
+                XCTAssertEqual(req.fluent.history.queries.count, 1)
+                req.fluent.history.stop()
 
                 test.append([
                     TestOutput(["id": 1, "content": "a"]),
@@ -78,7 +78,7 @@ final class QueryHistoryTests: XCTestCase {
 
                 return Post.query(on: req.db).all()
             }.map { posts in
-                XCTAssertEqual(req.fluent.history?.queries.count, nil)
+                XCTAssertEqual(req.fluent.history.queries.count, 0)
                 return posts
             }
         }
@@ -92,7 +92,7 @@ final class QueryHistoryTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        app.fluent.startRecording()
+        app.fluent.history.start()
         let test = ArrayTestDatabase()
         app.databases.use(test.configuration, as: .test)
 
@@ -127,7 +127,7 @@ final class QueryHistoryTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
         }
 
-        XCTAssertEqual(app.fluent.history?.queries.count, 3)
+        XCTAssertEqual(app.fluent.history.queries.count, 3)
     }
 }
 


### PR DESCRIPTION
Tracks database query history for a `Request` or `Application` (#689). 

To use on the `Application`:
```swift
app.fluent.history.start()
app.fluent.history.stop()
app.fluent.history.clear()
```

Access the history by calling:
```swift 
app.fluent.history.queries
```

The same methods/properties exist on `Request`:
```swift
req.fluent.history.start()
req.fluent.history.stop()
req.fluent.history.clear()
req.fluent.history
```