### PR TITLE
allow query on model to use non-default database

### DIFF
--- a/Sources/Fluent/Model/Model.swift
+++ b/Sources/Fluent/Model/Model.swift
@@ -346,10 +346,11 @@ extension Model where Database: QuerySupporting {
     ///
     /// - parameters:
     ///     - conn: Something `DatabaseConnectable` to create the `QueryBuilder` on.
+    ///     - database: Database identifier for the database this should run on. If `nil`, the model's default database is used.
     ///     - withSoftDeleted: If `true`, soft-deleted models will be included in the results. Defaults to `false`.
     /// - returns: A new `QueryBuilder` for this model.
-    public static func query(on conn: DatabaseConnectable, withSoftDeleted: Bool = false) -> QueryBuilder<Self.Database, Self> {
-        return query(on: conn.databaseConnection(to: Self.defaultDatabase), withSoftDeleted: withSoftDeleted)
+    public static func query(on conn: DatabaseConnectable, to database: DatabaseIdentifier<Database>? = nil, withSoftDeleted: Bool = false) -> QueryBuilder<Self.Database, Self> {
+        return query(on: conn.databaseConnection(to: database ?? Self.defaultDatabase), withSoftDeleted: withSoftDeleted)
     }
 
     /// Attempts to find an instance of this model with the supplied identifier.


### PR DESCRIPTION
I often use `Model.query(on: req)...` followed by a series of nested callbacks. For example:
```
Model.query(on: req).all().flatMap { models in
    loadNextThing().flatMap { thing in
        loadNextThing().flatMap { thing in
            loadNextThing().map { thing in
                ...
            }
        }
    }
}
```

Changing the query to use a database that isn't the model's default makes things messier:
```
req.withPooledConnection(to: .replica) { conn in
    Model.query(on: conn).all().flatMap { models in
        loadNextThing().flatMap { thing in
            loadNextThing().flatMap { thing in
                loadNextThing().map { thing in
                    ...
                }
            }
        }
    }
}
```

This PR would allow the default database to be changed without more nesting:
```
Model.query(on: req, to: .replica).all().flatMap { models in
    loadNextThing().flatMap { thing in
        loadNextThing().flatMap { thing in
            loadNextThing().map { thing in
                ...
            }
        }
    }
}
```

One downside (which @0xTim noted) is that the following confusing code would be possible to write:
```
Model.query(on: connectionToReplicaA, to: .replicaB).all().flatMap { models in
    loadNextThing().flatMap { thing in
        loadNextThing().flatMap { thing in
            loadNextThing().map { thing in
                ...
            }
        }
    }
}
```

An alternative might be to make `static func query(on connection: Future<Self.Database.Connection>, withSoftDeleted: Bool)` public. The function I modified in this PR is simply a wrapper around this internal function and is its only caller. Making that function public would enable something like the following:

```
let replicaConnection = req.withPooledConnection(to: .replica)
Model.query(on: replicaConnection).all().flatMap { models in
    loadNextThing().flatMap { thing in
        loadNextThing().flatMap { thing in
            loadNextThing().map { thing in
                ...
            }
        }
    }
}
```

Another alternative would be for me to accept our async reality and leave it be. 🙃