### PR TITLE
Add default implementation for CredentialsAuthenticatable

### DIFF
--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -99,7 +99,7 @@ private struct DatabaseSessionAuthenticator<User>: SessionAuthenticator
     let databaseID: DatabaseID?
 
     func authenticate(sessionID: User.SessionID, for request: Request) -> EventLoopFuture<Void> {
-        User.find(sessionID, on: request.db).map {
+        User.find(sessionID, on: request.db(self.databaseID)).map {
             if let user = $0 {
                 request.auth.login(user)
             }

--- a/Sources/Fluent/ModelCredentialsAuthenticatable.swift
+++ b/Sources/Fluent/ModelCredentialsAuthenticatable.swift
@@ -25,6 +25,11 @@ extension ModelCredentialsAuthenticatable {
 public struct ModelCredentials: Content {
     public let username: String
     public let password: String
+
+    public init(username: String, password: String) {
+        self.username = username
+        self.password = password
+    }
 }
 
 private struct ModelCredentialsAuthenticator<User>: CredentialsAuthenticator

--- a/Sources/Fluent/ModelCredentialsAuthenticatable.swift
+++ b/Sources/Fluent/ModelCredentialsAuthenticatable.swift
@@ -1,0 +1,49 @@
+import Vapor
+
+public protocol ModelCredentialsAuthenticatable: Model, Authenticatable {
+    static var usernameKey: KeyPath<Self, Field<String>> { get }
+    static var passwordHashKey: KeyPath<Self, Field<String>> { get }
+    func verify(password: String) throws -> Bool
+}
+
+extension ModelCredentialsAuthenticatable {
+    public static func credentialsAuthenticator(
+        database: DatabaseID? = nil
+    ) -> Authenticator {
+        ModelCredentialsAuthenticator<Self>(database: database)
+    }
+
+    var _$username: Field<String> {
+        self[keyPath: Self.usernameKey]
+    }
+
+    var _$passwordHash: Field<String> {
+        self[keyPath: Self.passwordHashKey]
+    }
+}
+
+public struct ModelCredentials: Content {
+    public let username: String
+    public let password: String
+}
+
+private struct ModelCredentialsAuthenticator<User>: CredentialsAuthenticator
+    where User: ModelCredentialsAuthenticatable
+{
+    typealias Credentials = ModelCredentials
+
+    public let database: DatabaseID?
+
+    func authenticate(credentials: ModelCredentials, for request: Request) -> EventLoopFuture<Void> {
+        User.query(on: request.db(self.database)).filter(\._$username == credentials.username).first().flatMapThrowing { foundUser in
+            guard let user = foundUser else {
+                return
+            }
+            guard try user.verify(password: credentials.password) else {
+                return
+            }
+            request.auth.login(user)
+        }
+    }
+}
+

--- a/Tests/FluentTests/CredentialTests.swift
+++ b/Tests/FluentTests/CredentialTests.swift
@@ -1,8 +1,90 @@
-//
-//  File.swift
-//  
-//
-//  Created by Tim Condon on 04/12/2020.
-//
+import XCTFluent
+import XCTVapor
+import Fluent
+import Vapor
 
-import Foundation
+final class CredentialTests: XCTestCase {
+
+    func testCredentialsAuthentication() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        // Setup test db.
+        let test = ArrayTestDatabase()
+        app.databases.use(test.configuration, as: .test)
+
+        // Configure sessions.
+        app.sessions.use(.fluent)
+        app.middleware.use(app.sessions.middleware)
+
+        // Setup routes.
+        let sessionRoutes = app.grouped(CredentialsUser.sessionAuthenticator())
+
+        let credentialRoutes = sessionRoutes.grouped(CredentialsUser.credentialsAuthenticator())
+        credentialRoutes.post("login") { req -> Response in
+            guard req.auth.has(User.self) else {
+                throw Abort(.unauthorized)
+            }
+            return req.redirect(to: "/protected")
+        }
+
+        let protectedRoutes = sessionRoutes.grouped(User.redirectMiddleware(path: "/login"))
+        protectedRoutes.get("protected") { req -> HTTPStatus in
+            _ = try req.auth.require(User.self)
+            return .ok
+        }
+
+        // Test login
+        let loginData = ModelCredentials(username: "something", password: "else")
+        try app.test(.POST, "/login", beforeRequest: { req in
+            try req.content.encode(loginData, as: .urlEncodedForm)
+        }) { res in
+            XCTAssertEqual(res.status, .seeOther)
+            XCTAssertEqual(res.headers[.location].first, "/protected")
+            let sessionID = try XCTUnwrap(res.headers.setCookie?["vapor-session"]?.string)
+
+            // Test accessing protected route
+            try app.test(.GET, "/protected", beforeRequest: { req in
+                var cookies = HTTPCookies()
+                cookies["vapor-session"] = .init(string: sessionID)
+                req.headers.cookie = cookies
+            }) { res in
+                XCTAssertEqual(res.status, .ok)
+            }
+        }
+
+
+    }
+}
+
+final class CredentialsUser: Model {
+    static let schema = "users"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "username")
+    var username: String
+
+    @Field(key: "password")
+    var password: String
+
+    init() { }
+
+    init(id: UUID? = nil, username: String, password: String) {
+        self.id = id
+        self.username = username
+        self.password = password
+    }
+}
+
+
+extension CredentialsUser: ModelCredentialsAuthenticatable {
+    static let usernameKey = \CredentialsUser.$username
+    static let passwordHashKey = \CredentialsUser.$password
+
+    func verify(password: String) throws -> Bool {
+        try Bcrypt.verify(password, created: self.password)
+    }
+}
+extension CredentialsUser: ModelSessionAuthenticatable {}

--- a/Tests/FluentTests/CredentialTests.swift
+++ b/Tests/FluentTests/CredentialTests.swift
@@ -10,8 +10,8 @@ final class CredentialTests: XCTestCase {
         defer { app.shutdown() }
 
         // Setup test db.
-        let test = ArrayTestDatabase()
-        app.databases.use(test.configuration, as: .test)
+        let testDB = ArrayTestDatabase()
+        app.databases.use(testDB.configuration, as: .test)
 
         // Configure sessions.
         app.middleware.use(app.sessions.middleware)
@@ -37,10 +37,10 @@ final class CredentialTests: XCTestCase {
         let password = "password-\(Int.random())"
         let passwordHash = try Bcrypt.hash(password)
         let testUser = CredentialsUser(id: UUID(), username: "user-\(Int.random())", password: passwordHash)
-        test.append([TestOutput(testUser)])
-        test.append([TestOutput(testUser)])
-        test.append([TestOutput(testUser)])
-        test.append([TestOutput(testUser)])
+        testDB.append([TestOutput(testUser)])
+        testDB.append([TestOutput(testUser)])
+        testDB.append([TestOutput(testUser)])
+        testDB.append([TestOutput(testUser)])
 
         // Test login
         let loginData = ModelCredentials(username: testUser.username, password: password)

--- a/Tests/FluentTests/CredentialTests.swift
+++ b/Tests/FluentTests/CredentialTests.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Tim Condon on 04/12/2020.
+//
+
+import Foundation

--- a/Tests/FluentTests/CredentialTests.swift
+++ b/Tests/FluentTests/CredentialTests.swift
@@ -14,7 +14,6 @@ final class CredentialTests: XCTestCase {
         app.databases.use(test.configuration, as: .test)
 
         // Configure sessions.
-        app.sessions.use(.fluent)
         app.middleware.use(app.sessions.middleware)
 
         // Setup routes.
@@ -28,7 +27,7 @@ final class CredentialTests: XCTestCase {
             return req.redirect(to: "/protected")
         }
 
-        let protectedRoutes = sessionRoutes.grouped(User.redirectMiddleware(path: "/login"))
+        let protectedRoutes = sessionRoutes.grouped(CredentialsUser.redirectMiddleware(path: "/login"))
         protectedRoutes.get("protected") { req -> HTTPStatus in
             _ = try req.auth.require(CredentialsUser.self)
             return .ok
@@ -38,9 +37,10 @@ final class CredentialTests: XCTestCase {
         let password = "password-\(Int.random())"
         let passwordHash = try Bcrypt.hash(password)
         let testUser = CredentialsUser(id: UUID(), username: "user-\(Int.random())", password: passwordHash)
-        test.append([
-            testUser
-        ])
+        test.append([TestOutput(testUser)])
+        test.append([TestOutput(testUser)])
+        test.append([TestOutput(testUser)])
+        test.append([TestOutput(testUser)])
 
         // Test login
         let loginData = ModelCredentials(username: testUser.username, password: password)

--- a/Tests/FluentTests/SessionTests.swift
+++ b/Tests/FluentTests/SessionTests.swift
@@ -48,7 +48,7 @@ final class SessionTests: XCTestCase {
             TestOutput([
                 "id": UUID(),
                 "key": SessionID(string: sessionID!),
-                "data": SessionData(["name": "vapor"])
+                "data": SessionData(initialData: ["name": "vapor"])
             ])
         ])
         // Add empty query output for session update.


### PR DESCRIPTION
Improves the experience for users writing web applications. Adds a `ModelCredentialsAuthenticator` to automatically conform `Model` types to `CredentialsAuthenticatable` and provide a middleware to use.

This can be used when logging in users via a web form, as shown in the tests. This also backfills some tests for ModelSessionAuthenticatable.

Also fixes a bug where the SessionAuthenticator was not using the provided `DatabaseID`

Resolves #710
Resolves #701

Docs here vapor/docs#576