### PR TITLE
Add cache protocol

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
+        .package(url: "https://github.com/vapor/vapor.git", .branch("cache-protocol")),
     ],
     targets: [
         .target(name: "Fluent", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/vapor.git", .branch("cache-protocol")),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.39.0"),
     ],
     targets: [
         .target(name: "Fluent", dependencies: [

--- a/Sources/Fluent/Fluent+Cache.swift
+++ b/Sources/Fluent/Fluent+Cache.swift
@@ -72,7 +72,7 @@ private struct FluentCache: Cache {
 }
 
 public final class CacheEntry: Model {
-    public static let schema: String = "_cache"
+    public static let schema: String = "_fluent_cache"
     
     struct Create: Migration {
         func prepare(on database: Database) -> EventLoopFuture<Void> {

--- a/Sources/Fluent/Fluent+Cache.swift
+++ b/Sources/Fluent/Fluent+Cache.swift
@@ -1,0 +1,111 @@
+import Vapor
+
+extension Application.Caches {
+    public var fluent: Cache {
+        self.fluent(nil)
+    }
+
+    public func fluent(_ db: DatabaseID?) -> Cache {
+        FluentCache(id: db, database: self.application.db(db))
+    }
+}
+
+extension Application.Caches.Provider {
+    public static var fluent: Self {
+        .fluent(nil)
+    }
+
+    public static func fluent(_ db: DatabaseID?) -> Self {
+        .init {
+            $0.caches.use { $0.caches.fluent(db) }
+        }
+    }
+}
+
+private struct FluentCache: Cache {
+    let id: DatabaseID?
+    let database: Database
+    
+    init(id: DatabaseID?, database: Database) {
+        self.id = id
+        self.database = database
+    }
+    
+    func get<T>(_ key: String, as type: T.Type) -> EventLoopFuture<T?>
+        where T: Decodable
+    {
+        CacheEntry.query(on: self.database)
+            .filter(\.$key == key)
+            .first()
+            .flatMapThrowing { entry -> T? in
+                if let entry = entry {
+                    return try JSONDecoder().decode(T.self, from: Data(entry.value.utf8))
+                } else {
+                    return nil
+                }
+            }
+    }
+    
+    func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void>
+        where T: Encodable
+    
+    {
+        if let value = value {
+            do {
+                let data = try JSONEncoder().encode(value)
+                let entry = CacheEntry(
+                    key: key,
+                    value: String(decoding: data, as: UTF8.self)
+                )
+                return entry.create(on: self.database)
+            } catch {
+                return self.database.eventLoop.makeFailedFuture(error)
+            }
+        } else {
+            return CacheEntry.query(on: self.database).filter(\.$key == key).delete()
+        }
+    }
+    
+    func `for`(_ request: Request) -> Self {
+        .init(id: self.id, database: request.db(self.id))
+    }
+}
+
+public final class CacheEntry: Model {
+    public static let schema: String = "_cache"
+    
+    struct Create: Migration {
+        func prepare(on database: Database) -> EventLoopFuture<Void> {
+            database.schema("_fluent_cache")
+                .id()
+                .field("key", .string, .required)
+                .field("value", .string, .required)
+                .unique(on: "key")
+                .create()
+        }
+        
+        func revert(on database: Database) -> EventLoopFuture<Void> {
+            database.schema("_fluent_cache").delete()
+        }
+    }
+
+    public static var migration: Migration {
+        Create()
+    }
+    
+    @ID(key: .id)
+    public var id: UUID?
+    
+    @Field(key: "key")
+    public var key: String
+    
+    @Field(key: "value")
+    public var value: String
+    
+    public init() { }
+    
+    public init(id: UUID? = nil, key: String, value: String) {
+        self.key = key
+        self.value = value
+    }
+}

--- a/Tests/FluentTests/CacheTests.swift
+++ b/Tests/FluentTests/CacheTests.swift
@@ -1,0 +1,69 @@
+import XCTFluent
+import XCTVapor
+import Fluent
+import Vapor
+
+final class CacheTests: XCTestCase {
+    func testCacheMigrationName() {
+        XCTAssertEqual(CacheEntry.migration.name, "Fluent.CacheEntry.Create")
+    }
+    
+    func testCacheGet() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        // Setup test db.
+        let test = ArrayTestDatabase()
+        app.databases.use(test.configuration, as: .test)
+        app.migrations.add(CacheEntry.migration)
+
+        // Configure cache.
+        app.caches.use(.fluent)
+        
+        // simulate cache miss
+        test.append([])
+        do {
+            let foo = try app.cache.get("foo", as: String.self).wait()
+            XCTAssertNil(foo)
+        }
+        
+        // simulate cache hit
+        test.append([TestOutput([
+            "key": "foo",
+            "value": "\"bar\""
+        ])])
+        do {
+            let foo = try app.cache.get("foo", as: String.self).wait()
+            XCTAssertEqual(foo, "bar")
+        }
+    }
+
+    func testCacheSet() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        // Setup test db.
+        let test = CallbackTestDatabase { query in
+            switch query.input[0] {
+            case .dictionary(let dict):
+                switch dict["value"] {
+                case .bind(let value as String):
+                    XCTAssertEqual(value, "\"bar\"")
+                default: XCTFail("unexpected value")
+                }
+                
+            default: XCTFail("unexpected input")
+            }
+            return [
+                TestOutput(["id": UUID()])
+            ]
+        }
+        app.databases.use(test.configuration, as: .test)
+        app.migrations.add(CacheEntry.migration)
+
+        // Configure cache.
+        app.caches.use(.fluent)
+        
+        try app.cache.set("foo", to: "bar").wait()
+    }
+}


### PR DESCRIPTION
Add Fluent implementation for Vapor's new cache protocol: https://github.com/vapor/vapor/pull/2558

```swift
app.caches.use(.fluent)
// Or with specific database id
app.caches.use(.fluent(.foo))
```

Make sure to add the `CacheEntry` migration (similar to `SessionRecord`).

```swift
app.migrations.add(CacheEntry.migration)
```