### PR TITLE
Fix conditional Codable conformance

### DIFF
--- a/Sources/Fluent/Fluent+Paginate.swift
+++ b/Sources/Fluent/Fluent+Paginate.swift
@@ -13,4 +13,4 @@ extension QueryBuilder {
     }
 }
 
-extension Page: Content { }
+extension Page: Content, RequestDecodable, ResponseEncodable where T: Codable { }


### PR DESCRIPTION
This fixes an issue introduced in https://github.com/vapor/fluent-kit/pull/435 where `Page` does not automatically conform to `Codable` anymore (#730)