### PR TITLE
Reducing availability check for Concurrency code

### DIFF
--- a/Sources/Fluent/Concurrency/FluentProvider+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/FluentProvider+Concurrency.swift
@@ -2,7 +2,7 @@
 import NIOCore
 import Vapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Application {
     /// Automatically runs forward migrations without confirmation.
     /// This can be triggered by passing `--auto-migrate` flag.

--- a/Sources/Fluent/Concurrency/ModelCredentialsAuthenticatable+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/ModelCredentialsAuthenticatable+Concurrency.swift
@@ -2,7 +2,7 @@
 import NIOCore
 import Vapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ModelCredentialsAuthenticatable {
     public static func asyncCredentialsAuthenticator(
         _ database: DatabaseID? = nil
@@ -11,7 +11,7 @@ extension ModelCredentialsAuthenticatable {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private struct AsyncModelCredentialsAuthenticator<User>: AsyncCredentialsAuthenticator
     where User: ModelCredentialsAuthenticatable
 {

--- a/Sources/Fluent/Concurrency/Pagination+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/Pagination+Concurrency.swift
@@ -2,7 +2,7 @@
 import NIOCore
 import Vapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension QueryBuilder {
     public func paginate(
         for request: Request

--- a/Sources/Fluent/Concurrency/Sessions+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/Sessions+Concurrency.swift
@@ -2,7 +2,7 @@
 import NIOCore
 import Vapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Model where Self: SessionAuthenticatable, Self.SessionID == Self.IDValue {
     public static func asyncSessionAuthenticator(
         _ databaseID: DatabaseID? = nil
@@ -11,7 +11,7 @@ extension Model where Self: SessionAuthenticatable, Self.SessionID == Self.IDVal
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private struct AsyncDatabaseSessionAuthenticator<User>: AsyncSessionAuthenticator
     where User: SessionAuthenticatable, User: Model, User.SessionID == User.IDValue
 {

--- a/Tests/FluentTests/CredentialTests.swift
+++ b/Tests/FluentTests/CredentialTests.swift
@@ -63,7 +63,7 @@ final class CredentialTests: XCTestCase {
     }
     
 #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testAsyncCredentialsAuthentication() async throws {
         let app = Application(.testing)
         defer { app.shutdown() }


### PR DESCRIPTION
From Xcode 13.2, support for Swift Concurrency has been back ported down to macOS 10.15, iOS 13, tvOS 13 and watchOS 6

This depends on https://github.com/vapor/vapor/pull/2883 and https://github.com/vapor/fluent-kit/pull/532, I'll update Package.swift once those PRs are merged and there is a new release with them