### PR TITLE
Update to match FluentKit's declared version minimums

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,12 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.5.2
 import PackageDescription
 
 let package = Package(
     name: "fluent",
     platforms: [
-       .macOS(.v10_15),
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         .library(name: "Fluent", targets: ["Fluent"]),

--- a/Sources/Fluent/Concurrency/FluentProvider+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/FluentProvider+Concurrency.swift
@@ -1,8 +1,7 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
-import NIOCore
-import Vapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+import Vapor
+import FluentKit
+
 extension Application {
     /// Automatically runs forward migrations without confirmation.
     /// This can be triggered by passing `--auto-migrate` flag.
@@ -20,5 +19,3 @@ extension Application {
         }.get()
     }
 }
-
-#endif

--- a/Sources/Fluent/Concurrency/ModelCredentialsAuthenticatable+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/ModelCredentialsAuthenticatable+Concurrency.swift
@@ -1,9 +1,7 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 import Vapor
 import FluentKit
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension ModelCredentialsAuthenticatable {
     public static func asyncCredentialsAuthenticator(
         _ database: DatabaseID? = nil
@@ -12,7 +10,6 @@ extension ModelCredentialsAuthenticatable {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 private struct AsyncModelCredentialsAuthenticator<User>: AsyncCredentialsAuthenticator
     where User: ModelCredentialsAuthenticatable
 {
@@ -29,6 +26,3 @@ private struct AsyncModelCredentialsAuthenticator<User>: AsyncCredentialsAuthent
         }
     }
 }
-
-#endif
-

--- a/Sources/Fluent/Concurrency/Pagination+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/Pagination+Concurrency.swift
@@ -1,9 +1,7 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 import Vapor
 import FluentKit
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension QueryBuilder {
     public func paginate(
         for request: Request
@@ -12,5 +10,3 @@ extension QueryBuilder {
         return try await self.paginate(page)
     }
 }
-
-#endif

--- a/Sources/Fluent/Concurrency/Sessions+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/Sessions+Concurrency.swift
@@ -1,9 +1,7 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 import Vapor
 import FluentKit
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension Model where Self: SessionAuthenticatable, Self.SessionID == Self.IDValue {
     public static func asyncSessionAuthenticator(
         _ databaseID: DatabaseID? = nil
@@ -12,7 +10,6 @@ extension Model where Self: SessionAuthenticatable, Self.SessionID == Self.IDVal
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 private struct AsyncDatabaseSessionAuthenticator<User>: AsyncSessionAuthenticator
     where User: SessionAuthenticatable, User: Model, User.SessionID == User.IDValue
 {
@@ -24,6 +21,3 @@ private struct AsyncDatabaseSessionAuthenticator<User>: AsyncSessionAuthenticato
         }
     }
 }
-
-#endif
-

--- a/Sources/Fluent/Fluent+Cache.swift
+++ b/Sources/Fluent/Fluent+Cache.swift
@@ -1,3 +1,5 @@
+import NIOCore
+import Foundation
 import Vapor
 import FluentKit
 

--- a/Sources/Fluent/Fluent+Paginate.swift
+++ b/Sources/Fluent/Fluent+Paginate.swift
@@ -1,4 +1,5 @@
 import Vapor
+import NIOCore
 import FluentKit
 
 extension QueryBuilder {

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -1,3 +1,5 @@
+import Foundation
+import NIOCore
 import Vapor
 import FluentKit
 

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -1,5 +1,6 @@
 import ConsoleKit
 import NIOCore
+import NIOPosix
 import Logging
 import Vapor
 import FluentKit

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -1,3 +1,6 @@
+import ConsoleKit
+import NIOCore
+import Logging
 import Vapor
 import FluentKit
 

--- a/Sources/Fluent/MigrateCommand.swift
+++ b/Sources/Fluent/MigrateCommand.swift
@@ -1,3 +1,6 @@
+
+import ConsoleKit
+import FluentKit
 import Vapor
 
 public final class MigrateCommand: Command {

--- a/Sources/Fluent/ModelAuthenticatable.swift
+++ b/Sources/Fluent/ModelAuthenticatable.swift
@@ -1,4 +1,5 @@
 import Vapor
+import NIOCore
 import FluentKit
 
 public protocol ModelAuthenticatable: Model, Authenticatable {

--- a/Sources/Fluent/ModelCredentialsAuthenticatable.swift
+++ b/Sources/Fluent/ModelCredentialsAuthenticatable.swift
@@ -1,4 +1,5 @@
 import Vapor
+import NIOCore
 import FluentKit
 
 public protocol ModelCredentialsAuthenticatable: Model, Authenticatable {

--- a/Sources/Fluent/ModelTokenAuthenticatable.swift
+++ b/Sources/Fluent/ModelTokenAuthenticatable.swift
@@ -1,4 +1,5 @@
 import Vapor
+import NIOCore
 import FluentKit
 
 public protocol ModelTokenAuthenticatable: Model, Authenticatable {


### PR DESCRIPTION
This should help fix building in Xcode.

Also bumps minimum Swift version to 5.5.2 and removes outdated compiler conditionals on concurrency support, incidentally enabling back-deployment in the process.