### PR TITLE
upgrade for compatibility

### DIFF
--- a/Sources/Fluent/Concurrency/ModelCredentialsAuthenticatable+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/ModelCredentialsAuthenticatable+Concurrency.swift
@@ -2,6 +2,8 @@ import NIOCore
 import Vapor
 import FluentKit
 
+
+@available(macOS 12, *)
 extension ModelCredentialsAuthenticatable {
     public static func asyncCredentialsAuthenticator(
         _ database: DatabaseID? = nil
@@ -10,6 +12,7 @@ extension ModelCredentialsAuthenticatable {
     }
 }
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 private struct AsyncModelCredentialsAuthenticator<User>: AsyncCredentialsAuthenticator
     where User: ModelCredentialsAuthenticatable
 {

--- a/Sources/Fluent/Concurrency/Pagination+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/Pagination+Concurrency.swift
@@ -2,6 +2,7 @@ import NIOCore
 import Vapor
 import FluentKit
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension QueryBuilder {
     public func paginate(
         for request: Request

--- a/Sources/Fluent/Concurrency/Sessions+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/Sessions+Concurrency.swift
@@ -2,6 +2,7 @@ import NIOCore
 import Vapor
 import FluentKit
 
+@available(macOS 12, *)
 extension Model where Self: SessionAuthenticatable, Self.SessionID == Self.IDValue {
     public static func asyncSessionAuthenticator(
         _ databaseID: DatabaseID? = nil
@@ -10,6 +11,7 @@ extension Model where Self: SessionAuthenticatable, Self.SessionID == Self.IDVal
     }
 }
 
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 private struct AsyncDatabaseSessionAuthenticator<User>: AsyncSessionAuthenticator
     where User: SessionAuthenticatable, User: Model, User.SessionID == User.IDValue
 {

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -56,8 +56,7 @@ extension Application {
             databases: self.databases,
             migrations: self.migrations,
             logger: self.logger,
-            on: self.eventLoopGroup.any(),
-            migrationLogLevel: self.fluent.migrationLogLevel
+            on: self.eventLoopGroup.any()
         )
     }
 


### PR DESCRIPTION
Migration.loglevel removed due to become obsolete.

 included multiple constraints mostly to macos12 due to concurrency.

it builds not been tested yet