### PR TITLE
Asyncification of Fluent provider

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: all
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 6
+    allow:
+      - dependency-type: all
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "Fluent", targets: ["Fluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.38.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.50.0"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.45.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.91.1"),
     ],
     targets: [
         .target(name: "Fluent", dependencies: [

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,0 +1,44 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "fluent",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
+    ],
+    products: [
+        .library(name: "Fluent", targets: ["Fluent"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.45.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.91.1"),
+    ],
+    targets: [
+        .target(
+            name: "Fluent",
+            dependencies: [
+                .product(name: "FluentKit", package: "fluent-kit"),
+                .product(name: "Vapor", package: "vapor"),
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableExperimentalFeature("StrictConcurrency=complete"),
+            ]
+        ),
+        .testTarget(
+            name: "FluentTests",
+            dependencies: [
+                .target(name: "Fluent"),
+                .product(name: "XCTFluent", package: "fluent-kit"),
+                .product(name: "XCTVapor", package: "vapor"),
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableExperimentalFeature("StrictConcurrency=complete"),
+            ]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 <p align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/1130717/259915558-d72ded24-bc79-4b1b-8f8b-398bf0640f9a.png">
-  <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/1130717/259915594-3fb46670-44a7-4677-a7b2-30f9bcf873af.png">
-  <img src="https://user-images.githubusercontent.com/1130717/259915594-3fb46670-44a7-4677-a7b2-30f9bcf873af.png" height="96" alt="Fluent">
-</picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vapor/fluent/assets/1130717/f4708c0b-3c9e-4e8b-9508-aa1ca6481c70">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/vapor/fluent/assets/1130717/bc4e1040-1e8a-4c0c-a24d-e87221a01af3">
+  <img src="https://github.com/vapor/fluent/assets/1130717/bc4e1040-1e8a-4c0c-a24d-e87221a01af3" height="96" alt="Fluent">
+</picture> 
 <br>
 <br>
-<a href="https://docs.vapor.codes/4.0/fluent/overview/"><img src="https://img.shields.io/badge/read_the-docs-2196f3.svg" alt="Documentation"></a>
-<a href="https://discord.gg/vapor"><img src="https://img.shields.io/discord/431917998102675485.svg" alt="Team Chat"></a>
-<a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License"></a>
-<a href="https://github.com/vapor/fluent/actions/workflows/test.yml"><img src="https://github.com/vapor/fluent/actions/workflows/test.yml/badge.svg" alt="Continuous Integration"></a>
-<a href="https://swift.org"><img src="https://img.shields.io/badge/swift-5.6-brightgreen.svg" alt="Swift 5.6"></a>
+<a href="https://docs.vapor.codes/4.0/"><img src="https://design.vapor.codes/images/readthedocs.svg" alt="Documentation"></a>
+<a href="https://discord.gg/vapor"><img src="https://design.vapor.codes/images/discordchat.svg" alt="Team Chat"></a>
+<a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
+<a href="https://github.com/vapor/fluent/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/fluent/test.yml?event=push&style=plastic&logo=github&label=test&logoColor=%23ccc" alt="Continuous Integration"></a>
+<a href="https://codecov.io/github/vapor/fluent"><img src="https://img.shields.io/codecov/c/github/vapor/fluent?style=plastic&logo=codecov&label=Codecov&token=yDzzHja8lt"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift57up.svg" alt="Swift 5.7+"></a>
 </p>
+
 <br>
+
+The Fluent package makes it easy to use FluentKit in Vapor applications by tying the FluentKit database abstraction layer into the Vapor application lifecycle. It also provides helpers for mapping FluentKit's models to Vapor's authentication APIs.
+
+For more information, see the [Fluent documentation](https://docs.vapor.codes/fluent/overview/).

--- a/Sources/Fluent/Concurrency/ModelCredentialsAuthenticatable+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/ModelCredentialsAuthenticatable+Concurrency.swift
@@ -1,11 +1,11 @@
 import NIOCore
 import Vapor
-import FluentKit
+@preconcurrency import FluentKit
 
 extension ModelCredentialsAuthenticatable {
     public static func asyncCredentialsAuthenticator(
         _ database: DatabaseID? = nil
-    ) -> AsyncAuthenticator {
+    ) -> any AsyncAuthenticator {
         AsyncModelCredentialsAuthenticator<Self>(database: database)
     }
 }

--- a/Sources/Fluent/Concurrency/Sessions+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/Sessions+Concurrency.swift
@@ -1,11 +1,11 @@
 import NIOCore
 import Vapor
-import FluentKit
+@preconcurrency import FluentKit
 
 extension Model where Self: SessionAuthenticatable, Self.SessionID == Self.IDValue {
     public static func asyncSessionAuthenticator(
         _ databaseID: DatabaseID? = nil
-    ) -> AsyncAuthenticator {
+    ) -> any AsyncAuthenticator {
         AsyncDatabaseSessionAuthenticator<Self>(databaseID: databaseID)
     }
 }

--- a/Sources/Fluent/Docs.docc/images/vapor-fluent-logo.svg
+++ b/Sources/Fluent/Docs.docc/images/vapor-fluent-logo.svg
@@ -1,0 +1,22 @@
+<svg version="1.1" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @media(prefers-color-scheme:dark){:root{--color-logo-shape:#000;--color-logo-base:#fff;}}
+    body[data-color-scheme="dark"]{--color-logo-shape:#000;--color-logo-base:#fff;}
+    #d{fill:var(--color-logo-base,#000)}#h{fill:var(--color-logo-shape,#fff)}
+  </style>
+  <path id="d" d="M6,47l58-47,58,47-58,45z" />
+  <path id="s" d="M6,47v12l58,45v-12z" />
+  <path id="h" d="M83.16,37.9l-13.45,2.82,3.6-10.63c.68-2-.82-4.06-3.35-4.6-2.53-.55-5.13.64-5.8,2.64l-3.6,10.62-9.84-7.8c-1.85-1.48-4.85-1.48-6.7,0-1.86,1.46-1.86,3.83,0,5.3l9.85,7.8-13.45,2.82c-2.53.53-4.04,2.6-3.36,4.6s3.28,3.2,5.8,2.66l13.45-2.82-3.6,10.63c-.68,2,.82,4.06,3.35,4.6,1.7.37,3.42-.1,4.6-.96.6-.42.97-1.05,1.22-1.68l3.6-10.62,9.84,7.8c1.85,1.48,4.85,1.48,6.7,0,1.86-1.46,1.86-3.83,0-5.3l-9.85-7.8,13.45-2.82c.84-.18,1.56-.52,2.13-.97,1.15-.9,1.68-2.28,1.23-3.62-.68-2-3.28-3.2-5.8-2.66z" />
+  </defs>
+  <use href="#s" fill="#38c0ff" y="24"/>
+  <use href="#s" fill="#6bd0ff" y="12"/>
+  <use href="#s" fill="#9ee0ff"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#s" fill="#e438ff" y="24"/>
+    <use href="#s" fill="#eb6bff" y="12"/>
+    <use href="#s" fill="#f29eff"/>
+  </g>
+  <use href="#d"/>
+  <use href="#h"/>
+</svg>

--- a/Sources/Fluent/Docs.docc/index.md
+++ b/Sources/Fluent/Docs.docc/index.md
@@ -1,5 +1,5 @@
 # ``Fluent``
 
-Fluent makes it easy for you to use FluentKit in your Vapor application. It ties together the FluentKit database abstraction layer with the Vapor application lifecycle. It also provides helpers for mapping FluentKit's models to Vapor's authentication APIs.
+The Fluent package makes it easy to use FluentKit in Vapor applications by tying the FluentKit database abstraction layer into the Vapor application lifecycle. It also provides helpers for mapping FluentKit's models to Vapor's authentication APIs.
 
-For more information, see the [Vapor documentation](https://docs.vapor.codes/fluent/overview/).
+For more information, see the [Fluent documentation](https://docs.vapor.codes/fluent/overview/).

--- a/Sources/Fluent/Docs.docc/theme-settings.json
+++ b/Sources/Fluent/Docs.docc/theme-settings.json
@@ -1,0 +1,21 @@
+{
+  "theme": {
+    "aside": { "border-radius": "6px", "border-style": "double", "border-width": "3px" },
+    "border-radius": "0",
+    "button": { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
+    "code":   { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
+    "color": {
+      "fluent": "#392048",
+      "documentation-intro-fill":  "radial-gradient(circle at top, var(--color-fluent) 30%, #000 100%)",
+      "documentation-intro-accent": "var(--color-fluent)",
+      "logo-base":  { "dark": "#fff", "light": "#000" },
+      "logo-shape": { "dark": "#000", "light": "#fff" },
+      "fill":       { "dark": "#000", "light": "#fff" }
+    },
+    "icons": { "technology": "/fluent/images/vapor-fluent-logo.svg" }
+  },
+  "features": {
+    "quickNavigation": { "enable": true },
+    "i18n": { "enable": true }
+  }
+}

--- a/Sources/Fluent/Fluent+Cache.swift
+++ b/Sources/Fluent/Fluent+Cache.swift
@@ -1,14 +1,14 @@
 import NIOCore
 import Foundation
 import Vapor
-import FluentKit
+@preconcurrency import FluentKit
 
 extension Application.Caches {
-    public var fluent: Cache {
+    public var fluent: any Cache {
         self.fluent(nil)
     }
 
-    public func fluent(_ db: DatabaseID?) -> Cache {
+    public func fluent(_ db: DatabaseID?) -> any Cache {
         FluentCache(id: db, database: self.application.db(db))
     }
 }
@@ -27,9 +27,9 @@ extension Application.Caches.Provider {
 
 private struct FluentCache: Cache {
     let id: DatabaseID?
-    let database: Database
+    let database: any Database
     
-    init(id: DatabaseID?, database: Database) {
+    init(id: DatabaseID?, database: any Database) {
         self.id = id
         self.database = database
     }
@@ -78,7 +78,7 @@ public final class CacheEntry: Model {
     public static let schema: String = "_fluent_cache"
     
     struct Create: Migration {
-        func prepare(on database: Database) -> EventLoopFuture<Void> {
+        func prepare(on database: any Database) -> EventLoopFuture<Void> {
             database.schema("_fluent_cache")
                 .id()
                 .field("key", .string, .required)
@@ -87,12 +87,12 @@ public final class CacheEntry: Model {
                 .create()
         }
         
-        func revert(on database: Database) -> EventLoopFuture<Void> {
+        func revert(on database: any Database) -> EventLoopFuture<Void> {
             database.schema("_fluent_cache").delete()
         }
     }
 
-    public static var migration: Migration {
+    public static var migration: any Migration {
         Create()
     }
     

--- a/Sources/Fluent/Fluent+History.swift
+++ b/Sources/Fluent/Fluent+History.swift
@@ -1,5 +1,5 @@
 import Vapor
-import FluentKit
+@preconcurrency import FluentKit
 
 struct RequestQueryHistory: StorageKey {
     typealias Value = QueryHistory

--- a/Sources/Fluent/Fluent+Pagination.swift
+++ b/Sources/Fluent/Fluent+Pagination.swift
@@ -5,7 +5,7 @@ struct RequestPaginationKey: StorageKey {
     typealias Value = RequestPagination
 }
 
-struct RequestPagination {
+struct RequestPagination: Sendable {
     let pageSizeLimit: PageLimit?
 }
 

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -1,7 +1,7 @@
 import Foundation
 import NIOCore
 import Vapor
-import FluentKit
+@preconcurrency import FluentKit
 
 extension Application.Fluent {
     public var sessions: Sessions {
@@ -29,13 +29,13 @@ extension ModelSessionAuthenticatable {
 extension Model where Self: SessionAuthenticatable, Self.SessionID == Self.IDValue {
     public static func sessionAuthenticator(
         _ databaseID: DatabaseID? = nil
-    ) -> Authenticator {
+    ) -> any Authenticator {
         DatabaseSessionAuthenticator<Self>(databaseID: databaseID)
     }
 }
 
 extension Application.Fluent.Sessions {
-    public func driver(_ databaseID: DatabaseID? = nil) -> SessionDriver {
+    public func driver(_ databaseID: DatabaseID? = nil) -> any SessionDriver {
         DatabaseSessions(databaseID: databaseID)
     }
 }
@@ -114,7 +114,7 @@ public final class SessionRecord: Model {
     public static let schema = "_fluent_sessions"
 
     struct Create: Migration {
-        func prepare(on database: Database) -> EventLoopFuture<Void> {
+        func prepare(on database: any Database) -> EventLoopFuture<Void> {
             database.schema("_fluent_sessions")
                 .id()
                 .field("key", .string, .required)
@@ -123,12 +123,12 @@ public final class SessionRecord: Model {
                 .create()
         }
 
-        func revert(on database: Database) -> EventLoopFuture<Void> {
+        func revert(on database: any Database) -> EventLoopFuture<Void> {
             database.schema("_fluent_sessions").delete()
         }
     }
 
-    public static var migration: Migration {
+    public static var migration: any Migration {
         Create()
     }
     

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -139,7 +139,7 @@ extension Application {
                 migrationLogLevel: .info
             )
             self.application.lifecycle.use(Lifecycle())
-            self.application.commands.use(MigrateCommand(), as: "migrate")
+            self.application.asyncCommands.use(MigrateCommand(), as: "migrate")
         }
         
         public var migrationLogLevel: Logger.Level {

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -6,11 +6,11 @@ import Vapor
 import FluentKit
 
 extension Request {
-    public var db: Database {
+    public var db: any Database {
         self.db(nil)
     }
 
-    public func db(_ id: DatabaseID?) -> Database {
+    public func db(_ id: DatabaseID?) -> any Database {
         self.application
             .databases
             .database(
@@ -28,16 +28,16 @@ extension Request {
 }
 
 extension Application {
-    public var db: Database {
+    public var db: any Database {
         self.db(nil)
     }
 
-    public func db(_ id: DatabaseID?) -> Database {
+    public func db(_ id: DatabaseID?) -> any Database {
         self.databases
             .database(
                 id,
                 logger: self.logger,
-                on: self.eventLoopGroup.next(),
+                on: self.eventLoopGroup.any(),
                 history: self.fluent.history.historyEnabled ? self.fluent.history.history : nil,
                 pageSizeLimit: self.fluent.pagination.pageSizeLimit
             )!
@@ -78,12 +78,12 @@ extension Application {
     }
 
     public struct Fluent {
-        final class Storage {
+        final class Storage: @unchecked Sendable {
             let databases: Databases
             let migrations: Migrations
             var migrationLogLevel: Logger.Level
 
-            init(threadPool: NIOThreadPool, on eventLoopGroup: EventLoopGroup, migrationLogLevel: Logger.Level) {
+            init(threadPool: NIOThreadPool, on eventLoopGroup: any EventLoopGroup, migrationLogLevel: Logger.Level) {
                 self.databases = Databases(
                     threadPool: threadPool,
                     on: eventLoopGroup
@@ -106,7 +106,7 @@ extension Application {
                     @Flag(name: "auto-revert", help: "If true, Fluent will automatically revert your database on boot")
                     var autoRevert: Bool
 
-                    init() { }
+                    init() {}
                 }
 
                 let signature = try Signature(from: &application.environment.commandInput)

--- a/Sources/Fluent/MigrateCommand.swift
+++ b/Sources/Fluent/MigrateCommand.swift
@@ -1,9 +1,8 @@
-
 import ConsoleKit
 import FluentKit
 import Vapor
 
-public final class MigrateCommand: Command {
+public final class MigrateCommand: AsyncCommand {
     public struct Signature: CommandSignature {
         @Flag(name: "revert")
         var revert: Bool
@@ -14,23 +13,23 @@ public final class MigrateCommand: Command {
     public let signature = Signature()
 
     public var help: String {
-        return "Prepare or revert your database migrations"
+        "Prepare or revert your database migrations"
     }
 
     init() { }
 
-    public func run(using context: CommandContext, signature: Signature) throws {
+    public func run(using context: CommandContext, signature: Signature) async throws {
         context.console.info("Migrate Command: \(signature.revert ? "Revert" : "Prepare")")
-        try context.application.migrator.setupIfNeeded().wait()
+        try await context.application.migrator.setupIfNeeded().get()
         if signature.revert {
-            try self.revert(using: context)
+            try await self.revert(using: context)
         } else {
-            try self.prepare(using: context)
+            try await self.prepare(using: context)
         }
     }
 
-    private func revert(using context: CommandContext) throws {
-        let migrations = try context.application.migrator.previewRevertLastBatch().wait()
+    private func revert(using context: CommandContext) async throws {
+        let migrations = try await context.application.migrator.previewRevertLastBatch().get()
         guard migrations.count > 0 else {
             context.console.print("No migrations to revert.")
             return
@@ -43,15 +42,15 @@ public final class MigrateCommand: Command {
             context.console.print(dbid?.string ?? "default")
         }
         if context.console.confirm("Would you like to continue?".consoleText(.warning)) {
-            try context.application.migrator.revertLastBatch().wait()
+            try await context.application.migrator.revertLastBatch().get()
             context.console.print("Migration successful")
         } else {
             context.console.warning("Migration cancelled")
         }
     }
 
-    private func prepare(using context: CommandContext) throws {
-        let migrations = try context.application.migrator.previewPrepareBatch().wait()
+    private func prepare(using context: CommandContext) async throws {
+        let migrations = try await context.application.migrator.previewPrepareBatch().get()
         guard migrations.count > 0 else {
             context.console.print("No new migrations.")
             return
@@ -64,7 +63,7 @@ public final class MigrateCommand: Command {
             context.console.print(dbid?.string ?? "default")
         }
         if context.console.confirm("Would you like to continue?".consoleText(.warning)) {
-            try context.application.migrator.prepareBatch().wait()
+            try await context.application.migrator.prepareBatch().get()
             context.console.print("Migration successful")
         } else {
             context.console.warning("Migration cancelled")

--- a/Sources/Fluent/ModelAuthenticatable.swift
+++ b/Sources/Fluent/ModelAuthenticatable.swift
@@ -1,6 +1,6 @@
 import Vapor
 import NIOCore
-import FluentKit
+@preconcurrency import FluentKit
 
 public protocol ModelAuthenticatable: Model, Authenticatable {
     static var usernameKey: KeyPath<Self, Field<String>> { get }
@@ -11,7 +11,7 @@ public protocol ModelAuthenticatable: Model, Authenticatable {
 extension ModelAuthenticatable {
     public static func authenticator(
         database: DatabaseID? = nil
-    ) -> Authenticator {
+    ) -> any Authenticator {
         ModelAuthenticator<Self>(database: database)
     }
 

--- a/Sources/Fluent/ModelCredentialsAuthenticatable.swift
+++ b/Sources/Fluent/ModelCredentialsAuthenticatable.swift
@@ -1,6 +1,6 @@
 import Vapor
 import NIOCore
-import FluentKit
+@preconcurrency import FluentKit
 
 public protocol ModelCredentialsAuthenticatable: Model, Authenticatable {
     static var usernameKey: KeyPath<Self, Field<String>> { get }
@@ -11,7 +11,7 @@ public protocol ModelCredentialsAuthenticatable: Model, Authenticatable {
 extension ModelCredentialsAuthenticatable {
     public static func credentialsAuthenticator(
         database: DatabaseID? = nil
-    ) -> Authenticator {
+    ) -> any Authenticator {
         ModelCredentialsAuthenticator<Self>(database: database)
     }
 
@@ -24,7 +24,7 @@ extension ModelCredentialsAuthenticatable {
     }
 }
 
-public struct ModelCredentials: Content {
+public struct ModelCredentials: Content, Sendable {
     public let username: String
     public let password: String
 

--- a/Sources/Fluent/ModelTokenAuthenticatable.swift
+++ b/Sources/Fluent/ModelTokenAuthenticatable.swift
@@ -1,6 +1,6 @@
 import Vapor
 import NIOCore
-import FluentKit
+@preconcurrency import FluentKit
 
 public protocol ModelTokenAuthenticatable: Model, Authenticatable {
     associatedtype User: Model & Authenticatable
@@ -12,7 +12,7 @@ public protocol ModelTokenAuthenticatable: Model, Authenticatable {
 extension ModelTokenAuthenticatable {
     public static func authenticator(
         database: DatabaseID? = nil
-    ) -> Authenticator {
+    ) -> any Authenticator {
         ModelTokenAuthenticator<Self>(database: database)
     }
 

--- a/Sources/Fluent/PageLimit.swift
+++ b/Sources/Fluent/PageLimit.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct PageLimit {
+public struct PageLimit: Sendable {
     public let value: Int?
     
     public static var noLimit: PageLimit {

--- a/Tests/FluentTests/CacheTests.swift
+++ b/Tests/FluentTests/CacheTests.swift
@@ -8,7 +8,7 @@ final class CacheTests: XCTestCase {
         XCTAssertEqual(CacheEntry.migration.name, "Fluent.CacheEntry.Create")
     }
     
-    func testCacheGet() throws {
+    func testCacheGet() async throws {
         let app = Application(.testing)
         defer { app.shutdown() }
 
@@ -23,7 +23,7 @@ final class CacheTests: XCTestCase {
         // simulate cache miss
         test.append([])
         do {
-            let foo = try app.cache.get("foo", as: String.self).wait()
+            let foo = try await app.cache.get("foo", as: String.self)
             XCTAssertNil(foo)
         }
         
@@ -33,12 +33,12 @@ final class CacheTests: XCTestCase {
             "value": "\"bar\""
         ])])
         do {
-            let foo = try app.cache.get("foo", as: String.self).wait()
+            let foo = try await app.cache.get("foo", as: String.self)
             XCTAssertEqual(foo, "bar")
         }
     }
 
-    func testCacheSet() throws {
+    func testCacheSet() async throws {
         let app = Application(.testing)
         defer { app.shutdown() }
 
@@ -64,6 +64,6 @@ final class CacheTests: XCTestCase {
         // Configure cache.
         app.caches.use(.fluent)
         
-        try app.cache.set("foo", to: "bar").wait()
+        try await app.cache.set("foo", to: "bar")
     }
 }

--- a/Tests/FluentTests/OperatorTests.swift
+++ b/Tests/FluentTests/OperatorTests.swift
@@ -49,7 +49,7 @@ private struct DummyDatabase: Database {
         fatalError()
     }
 
-    func execute(query: DatabaseQuery, onOutput: @escaping (DatabaseOutput) -> ()) -> EventLoopFuture<Void> {
+    func execute(query: DatabaseQuery, onOutput: @escaping (any DatabaseOutput) -> ()) -> EventLoopFuture<Void> {
         fatalError()
     }
 
@@ -61,11 +61,11 @@ private struct DummyDatabase: Database {
         fatalError()
     }
     
-    func withConnection<T>(_ closure: @escaping (Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+    func withConnection<T>(_ closure: @escaping (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
         fatalError()
     }
     
-    func transaction<T>(_ closure: @escaping (Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+    func transaction<T>(_ closure: @escaping (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
         fatalError()
     }
 }

--- a/Tests/FluentTests/QueryHistoryTests.swift
+++ b/Tests/FluentTests/QueryHistoryTests.swift
@@ -65,17 +65,16 @@ final class QueryHistoryTests: XCTestCase {
             TestOutput(["id": 1, "content": "a"]),
             TestOutput(["id": 2, "content": "b"]),
         ])
+        test.append([
+            TestOutput(["id": 1, "content": "a"]),
+            TestOutput(["id": 2, "content": "b"]),
+        ])
 
         app.get("foo") { req -> EventLoopFuture<[Post]> in
             req.fluent.history.start()
             return Post.query(on: req.db).all().flatMap { posts -> EventLoopFuture<[Post]> in
                 XCTAssertEqual(req.fluent.history.queries.count, 1)
                 req.fluent.history.stop()
-
-                test.append([
-                    TestOutput(["id": 1, "content": "a"]),
-                    TestOutput(["id": 2, "content": "b"]),
-                ])
 
                 return Post.query(on: req.db).all()
             }.map { posts in
@@ -89,7 +88,7 @@ final class QueryHistoryTests: XCTestCase {
         }
     }
 
-    func testQueryHistoryForApp() throws {
+    func testQueryHistoryForApp() async throws {
         let app = Application(.testing)
         defer { app.shutdown() }
 
@@ -102,14 +101,14 @@ final class QueryHistoryTests: XCTestCase {
             TestOutput(["id": 2, "content": "b"]),
         ])
 
-        _ = try Post.query(on: app.db).all().wait()
+        _ = try await Post.query(on: app.db).all()
 
         test.append([
             TestOutput(["id": 1, "content": "a"]),
             TestOutput(["id": 2, "content": "b"]),
         ])
 
-        _ = try Post.query(on: app.db).all().wait()
+        _ = try await Post.query(on: app.db).all()
 
         test.append([
             TestOutput(["id": 1, "content": "a"]),
@@ -117,7 +116,7 @@ final class QueryHistoryTests: XCTestCase {
         ])
 
         app.fluent.history.stop()
-        _ = try Post.query(on: app.db).all().wait()
+        _ = try await Post.query(on: app.db).all()
         XCTAssertEqual(app.fluent.history.queries.count, 2)
     }
 }

--- a/Tests/FluentTests/RepositoryTests.swift
+++ b/Tests/FluentTests/RepositoryTests.swift
@@ -74,7 +74,7 @@ extension ByteBuffer {
 }
 
 private extension Request {
-    var posts: PostRepository {
+    var posts: any PostRepository {
         self.application.posts.makePosts!(self)
     }
 }
@@ -93,9 +93,9 @@ private extension Application {
     }
 }
 
-private struct PostRepositoryFactory {
-    var makePosts: ((Request) -> PostRepository)?
-    mutating func use(_ makePosts: @escaping (Request) -> PostRepository) {
+private struct PostRepositoryFactory: @unchecked Sendable { // not actually Sendable but the compiler doesn't need to know that
+    var makePosts: ((Request) -> any PostRepository)?
+    mutating func use(_ makePosts: @escaping (Request) -> any PostRepository) {
         self.makePosts = makePosts
     }
 }
@@ -123,7 +123,7 @@ private final class Post: Model, Content, Equatable {
 
 private struct TestPostRepository: PostRepository {
     let posts: [Post]
-    let eventLoop: EventLoop
+    let eventLoop: any EventLoop
 
     func all() -> EventLoopFuture<[Post]> {
         self.eventLoop.makeSucceededFuture(self.posts)
@@ -131,7 +131,7 @@ private struct TestPostRepository: PostRepository {
 }
 
 private struct DatabasePostRepository: PostRepository {
-    let database: Database
+    let database: any Database
     func all() -> EventLoopFuture<[Post]> {
         database.query(Post.self).all()
     }

--- a/Tests/FluentTests/SessionTests.swift
+++ b/Tests/FluentTests/SessionTests.swift
@@ -91,14 +91,14 @@ extension DatabaseID {
 }
 
 struct StaticDatabase: DatabaseConfiguration, DatabaseDriver {
-    let database: Database
-    var middleware: [AnyModelMiddleware] = []
+    let database: any Database
+    var middleware: [any AnyModelMiddleware] = []
     
-    func makeDriver(for databases: Databases) -> DatabaseDriver {
+    func makeDriver(for databases: Databases) -> any DatabaseDriver {
         self
     }
 
-    func makeDatabase(with context: DatabaseContext) -> Database {
+    func makeDatabase(with context: DatabaseContext) -> any Database {
         self.database
     }
 


### PR DESCRIPTION
Updates the Fluent provider package to be (mostly) `Sendable`-correct and switches `MigrateCommand` to being async to avoid dangerous misuse of `EventLoopFuture.wait()`.

Bumps minimum Swift version to 5.7 (matching Vapor).