### PR TITLE
Fix up Fluent provider for Sendable-correct FluentKit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,4 +8,5 @@ on:
 
 jobs:
   unit-tests:
-     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
+    uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
+    secrets: inherit

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(
@@ -13,18 +13,37 @@ let package = Package(
         .library(name: "Fluent", targets: ["Fluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.45.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.91.1"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.94.1"),
     ],
     targets: [
-        .target(name: "Fluent", dependencies: [
-            .product(name: "FluentKit", package: "fluent-kit"),
-            .product(name: "Vapor", package: "vapor"),
-        ]),
-        .testTarget(name: "FluentTests", dependencies: [
-            .target(name: "Fluent"),
-            .product(name: "XCTFluent", package: "fluent-kit"),
-            .product(name: "XCTVapor", package: "vapor"),
-        ]),
+        .target(
+            name: "Fluent",
+            dependencies: [
+                .product(name: "FluentKit", package: "fluent-kit"),
+                .product(name: "Vapor", package: "vapor"),
+            ],
+            swiftSettings: swiftSettings
+        ),
+        .testTarget(
+            name: "FluentTests",
+            dependencies: [
+                .target(name: "Fluent"),
+                .product(name: "XCTFluent", package: "fluent-kit"),
+                .product(name: "XCTVapor", package: "vapor"),
+            ],
+            swiftSettings: swiftSettings
+        ),
     ]
 )
+
+var swiftSettings: [SwiftSetting] { [
+    .enableUpcomingFeature("ConciseMagicFile"),
+    .enableUpcomingFeature("ForwardTrailingClosures"),
+    .enableUpcomingFeature("ImportObjcForwardDeclarations"),
+    .enableUpcomingFeature("DisableOutwardActorInference"),
+    .enableUpcomingFeature("IsolatedDefaultValues"),
+    .enableUpcomingFeature("GlobalConcurrency"),
+    .enableUpcomingFeature("StrictConcurrency"),
+    .enableExperimentalFeature("StrictConcurrency=complete"),
+] }

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "Fluent", targets: ["Fluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.45.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.91.1"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.94.1"),
     ],
     targets: [
         .target(
@@ -23,10 +23,7 @@ let package = Package(
                 .product(name: "FluentKit", package: "fluent-kit"),
                 .product(name: "Vapor", package: "vapor"),
             ],
-            swiftSettings: [
-                .enableUpcomingFeature("ExistentialAny"),
-                .enableExperimentalFeature("StrictConcurrency=complete"),
-            ]
+            swiftSettings: swiftSettings
         ),
         .testTarget(
             name: "FluentTests",
@@ -35,10 +32,19 @@ let package = Package(
                 .product(name: "XCTFluent", package: "fluent-kit"),
                 .product(name: "XCTVapor", package: "vapor"),
             ],
-            swiftSettings: [
-                .enableUpcomingFeature("ExistentialAny"),
-                .enableExperimentalFeature("StrictConcurrency=complete"),
-            ]
+            swiftSettings: swiftSettings
         ),
     ]
 )
+
+var swiftSettings: [SwiftSetting] { [
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("ConciseMagicFile"),
+    .enableUpcomingFeature("ForwardTrailingClosures"),
+    .enableUpcomingFeature("ImportObjcForwardDeclarations"),
+    .enableUpcomingFeature("DisableOutwardActorInference"),
+    .enableUpcomingFeature("IsolatedDefaultValues"),
+    .enableUpcomingFeature("GlobalConcurrency"),
+    .enableUpcomingFeature("StrictConcurrency"),
+    .enableExperimentalFeature("StrictConcurrency=complete"),
+] }

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 <a href="https://docs.vapor.codes/4.0/"><img src="https://design.vapor.codes/images/readthedocs.svg" alt="Documentation"></a>
 <a href="https://discord.gg/vapor"><img src="https://design.vapor.codes/images/discordchat.svg" alt="Team Chat"></a>
 <a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
-<a href="https://github.com/vapor/fluent/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/fluent/test.yml?event=push&style=plastic&logo=github&label=test&logoColor=%23ccc" alt="Continuous Integration"></a>
-<a href="https://codecov.io/github/vapor/fluent"><img src="https://img.shields.io/codecov/c/github/vapor/fluent?style=plastic&logo=codecov&label=Codecov&token=yDzzHja8lt"></a>
-<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift57up.svg" alt="Swift 5.7+"></a>
+<a href="https://github.com/vapor/fluent/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/fluent/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration"></a>
+<a href="https://codecov.io/github/vapor/fluent"><img src="https://img.shields.io/codecov/c/github/vapor/fluent?style=plastic&logo=codecov&label=codecov&token=yDzzHja8lt"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift58up.svg" alt="Swift 5.8+"></a>
 </p>
 
 <br>

--- a/Sources/Fluent/Concurrency/FluentProvider+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/FluentProvider+Concurrency.swift
@@ -1,4 +1,3 @@
-
 import Vapor
 import FluentKit
 

--- a/Sources/Fluent/Concurrency/ModelCredentialsAuthenticatable+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/ModelCredentialsAuthenticatable+Concurrency.swift
@@ -1,6 +1,6 @@
 import NIOCore
 import Vapor
-@preconcurrency import FluentKit
+import FluentKit
 
 extension ModelCredentialsAuthenticatable {
     public static func asyncCredentialsAuthenticator(

--- a/Sources/Fluent/Concurrency/Sessions+Concurrency.swift
+++ b/Sources/Fluent/Concurrency/Sessions+Concurrency.swift
@@ -1,6 +1,6 @@
 import NIOCore
 import Vapor
-@preconcurrency import FluentKit
+import FluentKit
 
 extension Model where Self: SessionAuthenticatable, Self.SessionID == Self.IDValue {
     public static func asyncSessionAuthenticator(

--- a/Sources/Fluent/Docs.docc/theme-settings.json
+++ b/Sources/Fluent/Docs.docc/theme-settings.json
@@ -1,6 +1,6 @@
 {
   "theme": {
-    "aside": { "border-radius": "6px", "border-style": "double", "border-width": "3px" },
+    "aside": { "border-radius": "16px", "border-style": "double", "border-width": "3px" },
     "border-radius": "0",
     "button": { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },
     "code":   { "border-radius": "16px", "border-width": "1px", "border-style": "solid" },

--- a/Sources/Fluent/Exports.swift
+++ b/Sources/Fluent/Exports.swift
@@ -1,12 +1,4 @@
-#if swift(>=5.8)
-
 @_documentation(visibility: internal) @_exported import FluentKit
-
-#else
-
-@_exported import FluentKit
-
-#endif
 
 infix operator ~~
 infix operator =~

--- a/Sources/Fluent/Fluent+Cache.swift
+++ b/Sources/Fluent/Fluent+Cache.swift
@@ -1,7 +1,7 @@
 import NIOCore
 import Foundation
 import Vapor
-@preconcurrency import FluentKit
+import FluentKit
 
 extension Application.Caches {
     public var fluent: any Cache {
@@ -49,10 +49,7 @@ private struct FluentCache: Cache {
             }
     }
     
-    func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void>
-        where T: Encodable
-    
-    {
+    func set(_ key: String, to value: (some Encodable)?) -> EventLoopFuture<Void> {
         if let value = value {
             do {
                 let data = try JSONEncoder().encode(value)
@@ -74,7 +71,7 @@ private struct FluentCache: Cache {
     }
 }
 
-public final class CacheEntry: Model {
+public final class CacheEntry: Model, @unchecked Sendable {
     public static let schema: String = "_fluent_cache"
     
     struct Create: Migration {

--- a/Sources/Fluent/Fluent+History.swift
+++ b/Sources/Fluent/Fluent+History.swift
@@ -1,5 +1,5 @@
 import Vapor
-@preconcurrency import FluentKit
+import FluentKit
 
 struct RequestQueryHistory: StorageKey {
     typealias Value = QueryHistory
@@ -42,12 +42,12 @@ extension Application.Fluent.History {
     }
 
     var history: QueryHistory? {
-        return storage[RequestQueryHistory.self]
+        storage[RequestQueryHistory.self]
     }
 
     /// The queries stored in this lifecycle history
     public var queries: [DatabaseQuery] {
-        return history?.queries ?? []
+        history?.queries ?? []
     }
 
     /// Start recording the query history
@@ -82,12 +82,12 @@ extension Request.Fluent.History {
     }
 
     var history: QueryHistory? {
-        return storage[RequestQueryHistory.self]
+        storage[RequestQueryHistory.self]
     }
 
     /// The queries stored in this lifecycle history
     public var queries: [DatabaseQuery] {
-        return history?.queries ?? []
+        history?.queries ?? []
     }
 
     /// Start recording the query history

--- a/Sources/Fluent/Fluent+Sessions.swift
+++ b/Sources/Fluent/Fluent+Sessions.swift
@@ -1,7 +1,7 @@
 import Foundation
 import NIOCore
 import Vapor
-@preconcurrency import FluentKit
+import FluentKit
 
 extension Application.Fluent {
     public var sessions: Sessions {
@@ -42,7 +42,7 @@ extension Application.Fluent.Sessions {
 
 extension Application.Sessions.Provider {
     public static var fluent: Self {
-        return .fluent(nil)
+        .fluent(nil)
     }
 
     public static func fluent(_ databaseID: DatabaseID?) -> Self {
@@ -110,7 +110,7 @@ private struct DatabaseSessionAuthenticator<User>: SessionAuthenticator
     }
 }
 
-public final class SessionRecord: Model {
+public final class SessionRecord: Model, @unchecked Sendable {
     public static let schema = "_fluent_sessions"
 
     struct Create: Migration {

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -4,7 +4,7 @@ import NIOPosix
 import NIOConcurrencyHelpers
 import Logging
 import Vapor
-@preconcurrency import FluentKit
+import FluentKit
 
 extension Request {
     public var db: any Database {

--- a/Sources/Fluent/ModelAuthenticatable.swift
+++ b/Sources/Fluent/ModelAuthenticatable.swift
@@ -1,6 +1,6 @@
 import Vapor
 import NIOCore
-@preconcurrency import FluentKit
+import FluentKit
 
 public protocol ModelAuthenticatable: Model, Authenticatable {
     static var usernameKey: KeyPath<Self, Field<String>> { get }

--- a/Sources/Fluent/ModelCredentialsAuthenticatable.swift
+++ b/Sources/Fluent/ModelCredentialsAuthenticatable.swift
@@ -1,6 +1,6 @@
 import Vapor
 import NIOCore
-@preconcurrency import FluentKit
+import FluentKit
 
 public protocol ModelCredentialsAuthenticatable: Model, Authenticatable {
     static var usernameKey: KeyPath<Self, Field<String>> { get }

--- a/Sources/Fluent/ModelTokenAuthenticatable.swift
+++ b/Sources/Fluent/ModelTokenAuthenticatable.swift
@@ -1,6 +1,6 @@
 import Vapor
 import NIOCore
-@preconcurrency import FluentKit
+import FluentKit
 
 public protocol ModelTokenAuthenticatable: Model, Authenticatable {
     associatedtype User: Model & Authenticatable

--- a/Tests/FluentTests/CredentialTests.swift
+++ b/Tests/FluentTests/CredentialTests.swift
@@ -123,7 +123,7 @@ final class CredentialTests: XCTestCase {
     }
 }
 
-final class CredentialsUser: Model {
+final class CredentialsUser: Model, @unchecked Sendable {
     static let schema = "users"
 
     @ID(key: .id)

--- a/Tests/FluentTests/OperatorTests.swift
+++ b/Tests/FluentTests/OperatorTests.swift
@@ -30,7 +30,7 @@ final class OperatorTests: XCTestCase {
             .filter(\.$name !~ ["Earth", "Mars"])
     }
 }
-private final class Planet: Model {
+private final class Planet: Model, @unchecked Sendable {
     static let schema = "planets"
 
     @ID(custom: .id)
@@ -49,7 +49,7 @@ private struct DummyDatabase: Database {
         fatalError()
     }
 
-    func execute(query: DatabaseQuery, onOutput: @escaping (any DatabaseOutput) -> ()) -> EventLoopFuture<Void> {
+    func execute(query: DatabaseQuery, onOutput: @escaping @Sendable (any DatabaseOutput) -> ()) -> EventLoopFuture<Void> {
         fatalError()
     }
 
@@ -61,11 +61,11 @@ private struct DummyDatabase: Database {
         fatalError()
     }
     
-    func withConnection<T>(_ closure: @escaping (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+    func withConnection<T>(_ closure: @escaping @Sendable (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
         fatalError()
     }
     
-    func transaction<T>(_ closure: @escaping (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+    func transaction<T>(_ closure: @escaping @Sendable (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
         fatalError()
     }
 }

--- a/Tests/FluentTests/QueryHistoryTests.swift
+++ b/Tests/FluentTests/QueryHistoryTests.swift
@@ -121,7 +121,7 @@ final class QueryHistoryTests: XCTestCase {
     }
 }
 
-private final class Post: Model, Content, Equatable {
+private final class Post: Model, Content, Equatable, @unchecked Sendable {
     static func == (lhs: Post, rhs: Post) -> Bool {
         lhs.id == rhs.id && lhs.content == rhs.content
     }

--- a/Tests/FluentTests/RepositoryTests.swift
+++ b/Tests/FluentTests/RepositoryTests.swift
@@ -100,7 +100,7 @@ private struct PostRepositoryFactory: @unchecked Sendable { // not actually Send
     }
 }
 
-private final class Post: Model, Content, Equatable {
+private final class Post: Model, Content, Equatable, @unchecked Sendable {
     static func == (lhs: Post, rhs: Post) -> Bool {
         lhs.id == rhs.id && lhs.content == rhs.content
     }

--- a/Tests/FluentTests/SessionTests.swift
+++ b/Tests/FluentTests/SessionTests.swift
@@ -65,7 +65,7 @@ final class SessionTests: XCTestCase {
     }
 }
 
-final class User: Model {
+final class User: Model, @unchecked Sendable {
     static let schema = "users"
 
     @ID(key: .id)


### PR DESCRIPTION
Updates the Fluent provider for the 1.48.0 release of FluentKit, which adds mostly-complete `Sendable`-correctness. Also bumps minimum Swift version to 5.8, matching FluentKit.