### PR TITLE
Concurrency updates and database logging APIs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -9,16 +8,5 @@ updates:
       - dependency-type: all
     groups:
       dependencies:
-        patterns:
-          - "*"
-  - package-ecosystem: "swift"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 6
-    allow:
-      - dependency-type: all
-    groups:
-      all-dependencies:
         patterns:
           - "*"

--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "Fluent", targets: ["Fluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.94.1"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.101.0"),
     ],
     targets: [
         .target(
@@ -40,10 +40,4 @@ let package = Package(
 var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ConciseMagicFile"),
     .enableUpcomingFeature("ForwardTrailingClosures"),
-    .enableUpcomingFeature("ImportObjcForwardDeclarations"),
-    .enableUpcomingFeature("DisableOutwardActorInference"),
-    .enableUpcomingFeature("IsolatedDefaultValues"),
-    .enableUpcomingFeature("GlobalConcurrency"),
-    .enableUpcomingFeature("StrictConcurrency"),
-    .enableExperimentalFeature("StrictConcurrency=complete"),
 ] }

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "Fluent", targets: ["Fluent"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.94.1"),
+        .package(url: "https://github.com/vapor/fluent-kit.git", from: "1.48.4"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.101.0"),
     ],
     targets: [
         .target(
@@ -43,8 +43,5 @@ var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ForwardTrailingClosures"),
     .enableUpcomingFeature("ImportObjcForwardDeclarations"),
     .enableUpcomingFeature("DisableOutwardActorInference"),
-    .enableUpcomingFeature("IsolatedDefaultValues"),
-    .enableUpcomingFeature("GlobalConcurrency"),
-    .enableUpcomingFeature("StrictConcurrency"),
     .enableExperimentalFeature("StrictConcurrency=complete"),
 ] }

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -107,23 +107,33 @@ extension Application {
         }
 
         struct Lifecycle: LifecycleHandler {
+            struct Signature: CommandSignature {
+                @Flag(name: "auto-migrate", help: "If true, Fluent will automatically migrate your database on boot")
+                var autoMigrate: Bool
+
+                @Flag(name: "auto-revert", help: "If true, Fluent will automatically revert your database on boot")
+                var autoRevert: Bool
+            }
+
             func willBoot(_ application: Application) throws {
-                struct Signature: CommandSignature {
-                    @Flag(name: "auto-migrate", help: "If true, Fluent will automatically migrate your database on boot")
-                    var autoMigrate: Bool
-
-                    @Flag(name: "auto-revert", help: "If true, Fluent will automatically revert your database on boot")
-                    var autoRevert: Bool
-
-                    init() {}
-                }
-
                 let signature = try Signature(from: &application.environment.commandInput)
+                
                 if signature.autoRevert {
                     try application.autoRevert().wait()
                 }
                 if signature.autoMigrate {
                     try application.autoMigrate().wait()
+                }
+            }
+            
+            func willBootAsync(_ application: Application) async throws {
+                let signature = try Signature(from: &application.environment.commandInput)
+                
+                if signature.autoRevert {
+                    try await application.autoRevert()
+                }
+                if signature.autoMigrate {
+                    try await application.autoMigrate()
                 }
             }
 

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -12,15 +12,20 @@ extension Request {
     }
 
     public func db(_ id: DatabaseID?) -> any Database {
-        self.application
-            .databases
-            .database(
-                id,
-                logger: self.logger,
-                on: self.eventLoop,
-                history: self.fluent.history.historyEnabled ? self.fluent.history.history : nil,
-                pageSizeLimit: self.fluent.pagination.pageSizeLimit != nil ? self.fluent.pagination.pageSizeLimit?.value : self.application.fluent.pagination.pageSizeLimit
-            )!
+        self.db(id, logger: self.logger)
+    }
+    
+    public func db(_ id: DatabaseID?, logger: Logger) -> any Database {
+        self.application.databases.database(
+            id,
+            logger: logger,
+            on: self.eventLoop,
+            history: self.fluent.history.historyEnabled ? self.fluent.history.history : nil,
+            // Use map() (not flatMap()) so if pageSizeLimit is non-nil but the value is nil
+            // the request's "no limit" setting overrides the app's setting.
+            pageSizeLimit: self.fluent.pagination.pageSizeLimit.map(\.value) ??
+                           self.application.fluent.pagination.pageSizeLimit
+        )!
     }
 
     public var fluent: Fluent {
@@ -34,14 +39,17 @@ extension Application {
     }
 
     public func db(_ id: DatabaseID?) -> any Database {
-        self.databases
-            .database(
-                id,
-                logger: self.logger,
-                on: self.eventLoopGroup.any(),
-                history: self.fluent.history.historyEnabled ? self.fluent.history.history : nil,
-                pageSizeLimit: self.fluent.pagination.pageSizeLimit
-            )!
+        self.db(id, logger: self.logger)
+    }
+    
+    public func db(_ id: DatabaseID?, logger: Logger) -> any Database {
+        self.databases.database(
+            id,
+            logger: logger,
+            on: self.eventLoopGroup.any(),
+            history: self.fluent.history.historyEnabled ? self.fluent.history.history : nil,
+            pageSizeLimit: self.fluent.pagination.pageSizeLimit
+        )!
     }
 
     public var databases: Databases {

--- a/Sources/Fluent/FluentProvider.swift
+++ b/Sources/Fluent/FluentProvider.swift
@@ -61,7 +61,7 @@ extension Application {
     }
 
     public var migrator: Migrator {
-        Migrator(
+        .init(
             databases: self.databases,
             migrations: self.migrations,
             logger: self.logger,
@@ -93,10 +93,7 @@ extension Application {
             let migrationLogLevel: NIOLockedValueBox<Logger.Level>
 
             init(threadPool: NIOThreadPool, on eventLoopGroup: any EventLoopGroup, migrationLogLevel: Logger.Level) {
-                self.databases = Databases(
-                    threadPool: threadPool,
-                    on: eventLoopGroup
-                )
+                self.databases = Databases(threadPool: threadPool, on: eventLoopGroup)
                 self.migrations = .init()
                 self.migrationLogLevel = .init(migrationLogLevel)
             }
@@ -166,21 +163,11 @@ extension Application {
             nonmutating set { self.storage.migrationLogLevel.withLockedValue { $0 = newValue } }
         }
 
-        public var history: History {
-            .init(fluent: self)
-        }
+        public struct History { let fluent: Fluent }
+        public var history: History { .init(fluent: self) }
 
-        public struct History {
-            let fluent: Fluent
-        }
-
-        public var pagination: Pagination {
-            .init(fluent: self)
-        }
-
-        public struct Pagination {
-            let fluent: Fluent
-        }
+        public struct Pagination { let fluent: Fluent }
+        public var pagination: Pagination { .init(fluent: self) }
     }
 
     public var fluent: Fluent {

--- a/Sources/Fluent/MigrateCommand.swift
+++ b/Sources/Fluent/MigrateCommand.swift
@@ -30,16 +30,12 @@ public final class MigrateCommand: AsyncCommand {
 
     private func revert(using context: CommandContext) async throws {
         let migrations = try await context.application.migrator.previewRevertLastBatch().get()
-        guard migrations.count > 0 else {
-            context.console.print("No migrations to revert.")
-            return
+        guard !migrations.isEmpty else {
+            return context.console.print("No migrations to revert.")
         }
         context.console.print("The following migration(s) will be reverted:")
         for (migration, dbid) in migrations {
-            context.console.print("- ", newLine: false)
-            context.console.error(migration.name, newLine: false)
-            context.console.print(" on ", newLine: false)
-            context.console.print(dbid?.string ?? "default")
+            context.console.output("- \(migration.name, color: .red) on \(dbid?.string ?? "<default>", style: .info)")
         }
         if context.console.confirm("Would you like to continue?".consoleText(.warning)) {
             try await context.application.migrator.revertLastBatch().get()
@@ -51,16 +47,12 @@ public final class MigrateCommand: AsyncCommand {
 
     private func prepare(using context: CommandContext) async throws {
         let migrations = try await context.application.migrator.previewPrepareBatch().get()
-        guard migrations.count > 0 else {
-            context.console.print("No new migrations.")
-            return
+        guard !migrations.isEmpty else {
+            return context.console.print("No new migrations.")
         }
         context.console.print("The following migration(s) will be prepared:")
         for (migration, dbid) in migrations {
-            context.console.print("+ ", newLine: false)
-            context.console.success(migration.name, newLine: false)
-            context.console.print(" on ", newLine: false)
-            context.console.print(dbid?.string ?? "default")
+            context.console.output("+ \(migration.name, color: .green) on \(dbid?.string ?? "<default>", style: .info)")
         }
         if context.console.confirm("Would you like to continue?".consoleText(.warning)) {
             try await context.application.migrator.prepareBatch().get()

--- a/Tests/FluentTests/OperatorTests.swift
+++ b/Tests/FluentTests/OperatorTests.swift
@@ -30,6 +30,7 @@ final class OperatorTests: XCTestCase {
             .filter(\.$name !~ ["Earth", "Mars"])
     }
 }
+
 private final class Planet: Model, @unchecked Sendable {
     static let schema = "planets"
 


### PR DESCRIPTION
This update contains the following changes:

- Two new APIs are available: `Application.db(_:logger:)` and `Request.db(_:logger:)`. These work exactly the way the respective `.db(_:)` methods do, except the database's logger will be set to the one provided rather than the default. These APIs will hopefully make it easier to work around the unfortunate fact that `Database.logging(to:)` and its SQLKit counterpart basically don't work at all.
- The `--auto-migrate` and `--auto-revert` commandline flags no longer call `EventLoopFuture.wait()` when the app is booted in `async` mode (no more crash risk).
- The `migrate` command now has nicer console output.
- All tests have been updated to be fully `async`.