### PR TITLE
Add FluentEnumSchemaRepresentable protocol for consistent enum field keys

### DIFF
--- a/Sources/Fluent/FluentEnumSchemaRepresentable.swift
+++ b/Sources/Fluent/FluentEnumSchemaRepresentable.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A protocol that allows enums to provide a consistent Fluent field key and database enum name.
+public protocol FluentEnumSchemaRepresentable: RawRepresentable, CaseIterable {
+    /// The name used for the enum in the database (e.g. "day").
+    static var fluentEnumName: String { get }
+}
+
+public extension FluentEnumSchemaRepresentable where RawValue == String {
+    /// A `FieldKey` representing this enum's database field name.
+    static var fieldKey: FieldKey {
+        .init(unicodeScalarLiteral: fluentEnumName)
+    }
+}


### PR DESCRIPTION
### Summary

This PR introduces a new protocol: `FluentEnumSchemaRepresentable`.  
It is designed to help developers using Fluent with enum-based fields in their models.

The protocol provides:

- A static property `fluentEnumName` to serve as the single source of truth for the database enum type name.
- A default implementation of `fieldKey`, derived from that name, for use in `@Enum(key:)` declarations.

### Motivation

Currently, enum field keys and database enum type names are often hardcoded in both model declarations and migrations, which can lead to:

- Potential typos
- Duplicated string values
- Harder refactors

By using `FluentEnumSchemaRepresentable`, developers can define everything in one place and rely on type-safe usage in both models and schema builders.

### Example usage

```swift
enum VideoQuality: String, FluentEnumSchemaRepresentable {
    static let fluentEnumName = "video_quality"
    case sd, hd, uhd
}

// In the model
final class Media: Model {
    @Enum(key: VideoQuality.fieldKey)
    var quality: VideoQuality
}

// In the migration
struct CreateVideoQuality: Migration {
    func prepare(on database: any FluentKit.Database) -> NIOCore.EventLoopFuture<Void> {
        database.enum(VideoQuality.fluentEnumName)
            .case("sd")
            .case("hd")
            .case("uhd")
            .create()
    }
}
```

> Notes:
>This PR intentionally avoids any builder or migration logic (e.g. createEnum(on:)) to keep the proposal minimal and avoid coupling with FluentKit.

That said, this protocol opens the door to an easier and faster way to create and delete enums in schema migrations.

I’d be happy to propose a follow-up PR (in FluentKit) to explore that direction.

---