### PR TITLE
Test Query Operator Descriptions

### DIFF
--- a/Tests/FluentTests/OperatorTests.swift
+++ b/Tests/FluentTests/OperatorTests.swift
@@ -2,6 +2,7 @@ import Fluent
 import Testing
 import Vapor
 import VaporTesting
+import XCTFluent
 
 @Suite
 struct OperatorTests {
@@ -42,50 +43,4 @@ private final class Planet: Model, @unchecked Sendable {
 
     @Field(key: "name")
     var name: String
-}
-
-private struct DummyDatabase: Database {
-    var inTransaction: Bool {
-        false
-    }
-
-    var context: DatabaseContext {
-        .init(configuration: DummyDatabaseConfiguration(), logger: Logger(label: "fluent"), eventLoop: MultiThreadedEventLoopGroup.singleton.any())
-    }
-
-    func execute(query: DatabaseQuery, onOutput: @escaping @Sendable (any DatabaseOutput) -> Void) -> EventLoopFuture<Void> {
-        fatalError()
-    }
-
-    func execute(schema: DatabaseSchema) -> EventLoopFuture<Void> {
-        fatalError()
-    }
-
-    func execute(enum: DatabaseEnum) -> EventLoopFuture<Void> {
-        fatalError()
-    }
-
-    func withConnection<T>(_ closure: @escaping @Sendable (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
-        fatalError()
-    }
-
-    func transaction<T>(_ closure: @escaping @Sendable (any Database) -> EventLoopFuture<T>) -> EventLoopFuture<T> {
-        fatalError()
-    }
-}
-
-private struct DummyDatabaseConfiguration: DatabaseConfiguration {
-    var middleware: [any FluentKit.AnyModelMiddleware] = []
-
-    func makeDriver(for databases: FluentKit.Databases) -> any FluentKit.DatabaseDriver {
-        DummyDatabaseDriver()
-    }
-}
-
-private struct DummyDatabaseDriver: DatabaseDriver {
-    func makeDatabase(with context: FluentKit.DatabaseContext) -> any FluentKit.Database {
-        DummyDatabase()
-    }
-    
-    func shutdown() {}
 }

--- a/Tests/FluentTests/OperatorTests.swift
+++ b/Tests/FluentTests/OperatorTests.swift
@@ -8,30 +8,55 @@ import XCTFluent
 struct OperatorTests {
     @Test
     func customOperators() throws {
-        // TODO: What does this test...?
         let db = DummyDatabase()
 
         // name contains string anywhere, prefix, suffix
-        _ = Planet.query(on: db)
-            .filter(\.$name ~~ "art")
-        _ = Planet.query(on: db)
-            .filter(\.$name =~ "art")
-        _ = Planet.query(on: db)
-            .filter(\.$name ~= "art")
+        #expect(
+            Planet.query(on: db)
+                .filter(\.$name ~~ "art").query.description
+                == #"query read planets filters=[planets[name] contains "art"]"#
+        )
+        #expect(
+            Planet.query(on: db)
+                .filter(\.$name =~ "art").query.description
+                == #"query read planets filters=[planets[name] startswith "art"]"#
+        )
+        #expect(
+            Planet.query(on: db)
+                .filter(\.$name ~= "art").query.description
+                == #"query read planets filters=[planets[name] endswith "art"]"#
+        )
+
         // name doesn't contain string anywhere, prefix, suffix
-        _ = Planet.query(on: db)
-            .filter(\.$name !~ "art")
-        _ = Planet.query(on: db)
-            .filter(\.$name !=~ "art")
-        _ = Planet.query(on: db)
-            .filter(\.$name !~= "art")
+        #expect(
+            Planet.query(on: db)
+                .filter(\.$name !~ "art").query.description
+                == #"query read planets filters=[planets[name] !contains "art"]"#
+        )
+        #expect(
+            Planet.query(on: db)
+                .filter(\.$name !=~ "art").query.description
+                == #"query read planets filters=[planets[name] !startswith "art"]"#
+        )
+        #expect(
+            Planet.query(on: db)
+                .filter(\.$name !~= "art").query.description
+                == #"query read planets filters=[planets[name] !endswith "art"]"#
+        )
 
         // name in array
-        _ = Planet.query(on: db)
-            .filter(\.$name ~~ ["Earth", "Mars"])
+        #expect(
+            Planet.query(on: db)
+                .filter(\.$name ~~ ["Earth", "Mars"]).query.description
+                == #"query read planets filters=[planets[name] ~~ ["Earth", "Mars"]]"#
+        )
+
         // name not in array
-        _ = Planet.query(on: db)
-            .filter(\.$name !~ ["Earth", "Mars"])
+        #expect(
+            Planet.query(on: db)
+                .filter(\.$name !~ ["Earth", "Mars"]).query.description
+                == #"query read planets filters=[planets[name] !~~ ["Earth", "Mars"]]"#
+        )
     }
 }
 


### PR DESCRIPTION
### What?
This PR attempts to resolve the TODO item in `OperatorTests.swift` by comparing the query's description against the query's operator.
It also removes the redundant creation of `DummyDatabase` by using the implementation available in `XCTFluent`

### Why?
Previously the `OperatorTests.customOperators` test wasn't really testing anything more than wether the infix operators compiled or not, now we can be sure that they also are at least described correctly.

### How?
Compare the query's description to a known correct value for each infix operator
```swift
#expect(
    Planet.query(on: db)
         .filter(\.$name ~~ "art").query.description
         == #"query read planets filters=[planets[name] contains "art"]"#
)
```
 
> [!IMPORTANT]
> This still doesn't test whether or not the infix operators actually yield a correct database output, but that is arguably outside the scope of this test anyways.

